### PR TITLE
finish manifests to start everything

### DIFF
--- a/manifests/README.md
+++ b/manifests/README.md
@@ -1,0 +1,32 @@
+* Install Kubeless
+
+Create `kubeless` namespace and create zookeeper
+
+```
+kubectl create -f zookeeper/namespace.yaml 
+kubectl create -f zookeeper/zk-headless-svc.yaml
+kubectl create -f zookeeper/zk-stateful.yaml 
+kubectl create -f zookeeper/zk-svc.yaml
+```
+
+Create TPR For functions
+
+```
+kubectl create -f tpr/function.yaml
+```
+
+Create Kafka broker
+
+```
+kubectl create -f kafka/kafka-deployment.yaml
+kubectl create -f kafka/kafka-headless-svc.yaml
+kubectl create -f kafka/kafka-svc.yaml
+```
+
+Launch kubeless controller and UI
+
+```
+kubectl create -f controller/controller-deployment.yaml
+kubectl create -f ui/ui-deployment.yaml
+kubectl create -f ui/ui-svc.yaml 
+```

--- a/manifests/controller/controller-deployment.yaml
+++ b/manifests/controller/controller-deployment.yaml
@@ -1,0 +1,22 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+   kubeless: controller
+  namespace: kubeless
+  name: controller
+  namespace: kubeless
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+     kubeless: controller
+  template:
+    metadata:
+      labels:
+        kubeless: controller
+    spec:
+      containers:
+      - name: controller
+        image: bitnami/kubeless-controller:0.0.12
+        imagePullPolicy: IfNotPresent

--- a/manifests/controller/controller-svc.yaml
+++ b/manifests/controller/controller-svc.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    kubeless: controller
+  name: controller
+  namespace: kubeless
+spec:
+  ports:
+  - name: controller-port
+    port: 8000
+    protocol: TCP
+    targetPort: 8000
+  selector:
+    kubeless: controller
+  sessionAffinity: None
+  type: ClusterIP

--- a/manifests/tpr/function.yaml
+++ b/manifests/tpr/function.yaml
@@ -1,0 +1,7 @@
+apiVersion: extensions/v1beta1
+description: 'Kubeless: Serverless framework for Kubernetes'
+kind: ThirdPartyResource
+metadata:
+  name: function.k8s.io
+versions:
+- name: v1

--- a/manifests/ui/ui-deployment.yaml
+++ b/manifests/ui/ui-deployment.yaml
@@ -5,7 +5,6 @@ metadata:
    controller: ui
   namespace: kubeless
   name: ui
-  namespace: kubeless
 spec:
   replicas: 1
   selector:
@@ -18,7 +17,7 @@ spec:
     spec:
       containers:
       - name: ui
-        image: bitnami/kubeless-ui:deployment
+        image: bitnami/kubeless-ui:development
         imagePullPolicy: IfNotPresent
         ports:
         - containerPort: 3000

--- a/manifests/ui/ui-svc.yaml
+++ b/manifests/ui/ui-svc.yaml
@@ -14,4 +14,4 @@ spec:
   selector:
     controller: ui
   sessionAffinity: None
-  type: ClusterIP
+  type: NodePort


### PR DESCRIPTION
This finishes the basic manifests to start kubeless with `kubectl create` instead of `kubeless install`.

There is definitely some polishing to do: Check that we can scale zk , add probes with good timeouts etc...

But this can be the basis for a complete chart and a ksonnet example.

cc/ @ngtuna @anguslees 
