### PR TITLE
Add garbage collector to kubeless controller

### DIFF
--- a/cmd/kubeless-controller/kubeless-controller.go
+++ b/cmd/kubeless-controller/kubeless-controller.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
+	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -32,7 +33,10 @@ import (
 	"github.com/kubeless/kubeless/pkg/utils"
 )
 
-const globalUsage = `` //TODO: adding explanation
+const (
+	globalUsage = `` //TODO: adding explanation
+	gcInterval  = 1 * time.Minute
+)
 
 var rootCmd = &cobra.Command{
 	Use:   "kubeless-controller",
@@ -48,7 +52,6 @@ var rootCmd = &cobra.Command{
 			TprClient: tprClient,
 		}
 		c := controller.New(cfg)
-
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 
@@ -58,6 +61,7 @@ var rootCmd = &cobra.Command{
 		signal.Notify(sigterm, syscall.SIGTERM)
 		signal.Notify(sigterm, syscall.SIGINT)
 		<-sigterm
+		go c.RunGC(gcInterval)
 	},
 }
 

--- a/cmd/kubeless-controller/kubeless-controller.go
+++ b/cmd/kubeless-controller/kubeless-controller.go
@@ -24,7 +24,6 @@ import (
 	"os"
 	"os/signal"
 	"syscall"
-	"time"
 
 	"github.com/Sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -35,7 +34,6 @@ import (
 
 const (
 	globalUsage = `` //TODO: adding explanation
-	gcInterval  = 1 * time.Minute
 )
 
 var rootCmd = &cobra.Command{
@@ -56,7 +54,6 @@ var rootCmd = &cobra.Command{
 		defer close(stopCh)
 
 		go c.Run(stopCh)
-		go c.RunGC(gcInterval)
 
 		sigterm := make(chan os.Signal, 1)
 		signal.Notify(sigterm, syscall.SIGTERM)

--- a/cmd/kubeless-controller/kubeless-controller.go
+++ b/cmd/kubeless-controller/kubeless-controller.go
@@ -56,12 +56,12 @@ var rootCmd = &cobra.Command{
 		defer close(stopCh)
 
 		go c.Run(stopCh)
+		go c.RunGC(gcInterval)
 
 		sigterm := make(chan os.Signal, 1)
 		signal.Notify(sigterm, syscall.SIGTERM)
 		signal.Notify(sigterm, syscall.SIGINT)
 		<-sigterm
-		go c.RunGC(gcInterval)
 	},
 }
 

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -4,6 +4,11 @@ import (
 	"testing"
 
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/pkg/api/v1"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	xv1beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	ktesting "k8s.io/client-go/testing"
 )
 
@@ -38,5 +43,53 @@ func TestInitResource(t *testing.T) {
 
 	if !hasAction(client, "update", "thirdpartyresources") {
 		t.Errorf("initResource() failed to update existing thirdpartyresource")
+	}
+}
+
+func TestCollectObjects(t *testing.T) {
+	var (
+		nonExistFunc types.UID = "00000000-0000-0000-0000-000000000000"
+		bt                     = true
+	)
+
+	myNsFoo := metav1.ObjectMeta{
+		Namespace: "myns",
+		Name:      "foo",
+		OwnerReferences: []metav1.OwnerReference{
+			{
+				Kind:               "Function",
+				APIVersion:         "k8s.io",
+				Name:               "funcFoo",
+				UID:                nonExistFunc,
+				BlockOwnerDeletion: &bt,
+			},
+		},
+	}
+
+	deploy := xv1beta1.Deployment{
+		ObjectMeta: myNsFoo,
+	}
+
+	svc := v1.Service{
+		ObjectMeta: myNsFoo,
+	}
+
+	cm := v1.ConfigMap{
+		ObjectMeta: myNsFoo,
+	}
+
+	client := fake.NewSimpleClientset(&deploy, &svc, &cm)
+
+	functionUIDSet := make(map[types.UID]bool)
+	//functionUIDSet[nonExistFunc] = false
+
+	if err := collectServices(client, functionUIDSet); err != nil {
+		t.Errorf("collectService() failed with %v", err)
+	}
+	if err := collectDeployment(client, functionUIDSet); err != nil {
+		t.Errorf("collectDeployment() failed with %v", err)
+	}
+	if err := collectConfigMap(client, functionUIDSet); err != nil {
+		t.Errorf("collectConfigMap() failed with %v", err)
 	}
 }

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,15 +1,9 @@
 package controller
 
 import (
-	"testing"
-
 	"k8s.io/client-go/kubernetes/fake"
-	"k8s.io/client-go/pkg/api/v1"
-
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/types"
-	xv1beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	ktesting "k8s.io/client-go/testing"
+	"testing"
 )
 
 func findAction(fake *fake.Clientset, verb, resource string) ktesting.Action {
@@ -43,53 +37,5 @@ func TestInitResource(t *testing.T) {
 
 	if !hasAction(client, "update", "thirdpartyresources") {
 		t.Errorf("initResource() failed to update existing thirdpartyresource")
-	}
-}
-
-func TestCollectObjects(t *testing.T) {
-	var (
-		nonExistFunc types.UID = "00000000-0000-0000-0000-000000000000"
-		bt                     = true
-	)
-
-	myNsFoo := metav1.ObjectMeta{
-		Namespace: "myns",
-		Name:      "foo",
-		OwnerReferences: []metav1.OwnerReference{
-			{
-				Kind:               "Function",
-				APIVersion:         "k8s.io",
-				Name:               "funcFoo",
-				UID:                nonExistFunc,
-				BlockOwnerDeletion: &bt,
-			},
-		},
-	}
-
-	deploy := xv1beta1.Deployment{
-		ObjectMeta: myNsFoo,
-	}
-
-	svc := v1.Service{
-		ObjectMeta: myNsFoo,
-	}
-
-	cm := v1.ConfigMap{
-		ObjectMeta: myNsFoo,
-	}
-
-	client := fake.NewSimpleClientset(&deploy, &svc, &cm)
-
-	functionUIDSet := make(map[types.UID]bool)
-	//functionUIDSet[nonExistFunc] = false
-
-	if err := collectServices(client, functionUIDSet); err != nil {
-		t.Errorf("collectService() failed with %v", err)
-	}
-	if err := collectDeployment(client, functionUIDSet); err != nil {
-		t.Errorf("collectDeployment() failed with %v", err)
-	}
-	if err := collectConfigMap(client, functionUIDSet); err != nil {
-		t.Errorf("collectConfigMap() failed with %v", err)
 	}
 }

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -1066,3 +1066,19 @@ func addInitContainerAnnotation(dpm *v1beta1.Deployment) error {
 	}
 	return nil
 }
+
+//IsKubernetesResourceNotFoundError returns true if resource is not found
+func IsKubernetesResourceNotFoundError(err error) bool {
+	return k8sErrors.IsNotFound(err)
+}
+
+//CascadeDeleteOptions returns option for cascade deletion
+func CascadeDeleteOptions(gracePeriodSeconds int64) *metav1.DeleteOptions {
+	return &metav1.DeleteOptions{
+		GracePeriodSeconds: func(t int64) *int64 { return &t }(gracePeriodSeconds),
+		PropagationPolicy: func() *metav1.DeletionPropagation {
+			foreground := metav1.DeletePropagationForeground
+			return &foreground
+		}(),
+	}
+}

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -1080,14 +1080,3 @@ func addInitContainerAnnotation(dpm *v1beta1.Deployment) error {
 	}
 	return nil
 }
-
-//CascadeDeleteOptions returns option for cascade deletion
-func CascadeDeleteOptions(gracePeriodSeconds int64) *metav1.DeleteOptions {
-	return &metav1.DeleteOptions{
-		PropagationPolicy: func() *metav1.DeletionPropagation {
-			foreground := metav1.DeletePropagationForeground
-			return &foreground
-		}(),
-		GracePeriodSeconds: &gracePeriodSeconds,
-	}
-}


### PR DESCRIPTION
This PR appends `ownerReferences` field to each deployed svc/cm/deployment which points to their belonged function tpr object. So if the function is deleted, they will become orphaned objects. A garbage collector is added to scan every minutes orphaned deploy/cm/svc then clean them.

cc/ @anguslees 