### PR TITLE
correct pwd in before_deploy section

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -51,7 +51,7 @@ after_success:
 
 before_deploy:
   - make binary-cross
-  - cd bundles && for d in kubeless_*; do zip -r9 $d.zip $d/; done
+  - for d in bundles/kubeless_*; do zip -r9 $d.zip $d/; done
   - |
     if [ "$TRAVIS_OS_NAME" = linux ]; then
       docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"


### PR DESCRIPTION
`cd bundles` in before_deploy section makes the current directory changes to bundles that causes `No such file or directory` error in later commands