### PR TITLE
Update labels to use kubeless key instead of app

### DIFF
--- a/kubeless.jsonnet
+++ b/kubeless.jsonnet
@@ -79,7 +79,7 @@ local zookeeperContainer =
 
 local kubelessLabel = {kubeless: "controller"};
 local kafkaLabel = {kubeless: "kafka"};
-local zookeeperLabel = {app: "zookeeper"};
+local zookeeperLabel = {kubeless: "zookeeper"};
 
 local controllerDeployment =
   deployment.default("kubeless-controller", controllerContainer, namespace) +

--- a/kubeless.jsonnet
+++ b/kubeless.jsonnet
@@ -78,7 +78,7 @@ local zookeeperContainer =
   ]);
 
 local kubelessLabel = {kubeless: "controller"};
-local kafkaLabel = {app: "kafka"};
+local kafkaLabel = {kubeless: "kafka"};
 local zookeeperLabel = {app: "zookeeper"};
 
 local controllerDeployment =

--- a/manifests/kafka/kafka-stateful.yaml
+++ b/manifests/kafka/kafka-stateful.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-        app: kafka
+        kubeless: kafka
     spec:
       terminationGracePeriodSeconds: 10
       containers:

--- a/manifests/zookeeper/zk-headless-svc.yaml
+++ b/manifests/zookeeper/zk-headless-svc.yaml
@@ -11,4 +11,4 @@ spec:
     name: leader-election
   clusterIP: None
   selector:
-    app: zookeeper
+    kubeless: zookeeper

--- a/manifests/zookeeper/zk-stateful.yaml
+++ b/manifests/zookeeper/zk-stateful.yaml
@@ -9,7 +9,7 @@ spec:
   template:
     metadata:
       labels:
-        app: zookeeper
+        kubeless: zookeeper
     spec:
       terminationGracePeriodSeconds: 10
       containers:

--- a/manifests/zookeeper/zk-svc.yaml
+++ b/manifests/zookeeper/zk-svc.yaml
@@ -9,4 +9,4 @@ spec:
   - port: 2181
     name: client
   selector:
-    app: zookeeper
+    kubeless: zookeeper


### PR DESCRIPTION
I was getting started checking on out kubeless on my minikube install and noticed that none of the `kubeless topic` commands were working for me. I was able to determine that this is because the topic commands search for a label of `kubeless=kafka` to get the pods it issues commands against. That was [introduced here](https://github.com/kubeless/kubeless/commit/7f74dba0680a9a2698b8a71860ab7d322d104dd5).  

The current manifest for kafka, however, still uses the `app=kafka` label. This PR updates the labels for the kafka stateful set to match the expected `kubeless=kafka`.