### PR TITLE
Improve NodeJS runtime support

### DIFF
--- a/docker/runtime/nodejs-6.10/http-trigger/.eslintrc.js
+++ b/docker/runtime/nodejs-6.10/http-trigger/.eslintrc.js
@@ -1,0 +1,16 @@
+module.exports = {
+  "extends": "airbnb",
+  "plugins": [],
+  "rules": {
+    "func-names": "off",
+    "strict": "off",
+    "prefer-rest-params": "off",
+    "react/require-extension" : "off",
+    "import/no-extraneous-dependencies" : "off",
+    "no-console": "off"
+  },
+  "env": {
+       "mocha": true,
+       "jest": true
+   }
+};

--- a/docker/runtime/nodejs-6.10/http-trigger/.gitignore
+++ b/docker/runtime/nodejs-6.10/http-trigger/.gitignore
@@ -1,0 +1,2 @@
+node_modules
+npm-debug.log

--- a/docker/runtime/nodejs-6.10/http-trigger/Dockerfile
+++ b/docker/runtime/nodejs-6.10/http-trigger/Dockerfile
@@ -4,4 +4,8 @@ RUN apk add --no-cache git
 
 ADD kubeless.js /
 
+ADD package.json /
+
+RUN npm install
+
 CMD ["node", "/kubeless.js"]

--- a/docker/runtime/nodejs-6.10/http-trigger/kubeless.js
+++ b/docker/runtime/nodejs-6.10/http-trigger/kubeless.js
@@ -1,24 +1,65 @@
-#!/usr/bin/env node
+'use strict';
 
-const http = require('http')
-const path = require('path')
+const client = require('prom-client');
+const express = require('express');
+const path = require('path');
 
-const modName = process.env.MOD_NAME
-const funcHandler = process.env.FUNC_HANDLER
+const app = express();
 
-const modRootPath = process.env.MOD_ROOT_PATH ? process.env.MOD_ROOT_PATH : '/kubeless/'
-const modPath = path.join(modRootPath, modName + '.js')
-console.log('Loading', modPath)
+const modName = process.env.MOD_NAME;
+const funcHandler = process.env.FUNC_HANDLER;
+
+const timeHistogram = new client.Histogram({
+  name: 'function_duration_seconds',
+  help: 'Duration of user function in seconds',
+});
+const callsCounter = new client.Counter({
+  name: 'function_calls_total',
+  help: 'Number of calls to user function',
+  labelNames: ['method'],
+});
+const errorsCounter = new client.Counter({
+  name: 'function_failures_total',
+  help: 'Number of exceptions in user function',
+  labelNames: ['method'],
+});
+
+const modRootPath = process.env.MOD_ROOT_PATH ? process.env.MOD_ROOT_PATH : '/kubeless/';
+const modPath = path.join(modRootPath, `${modName}.js`);
+console.log('Loading', modPath);
+let mod = null;
 try {
-  var mod = require(modPath)
+  mod = require(modPath); // eslint-disable-line global-require
 } catch (e) {
-  console.error('No valid module found for the name: function, Failed to import module')
-  process.exit(1)
+  console.error(
+    'No valid module found for the name: function, Failed to import module:\n' +
+    `${e.message}`
+  );
+  process.exit(1);
 }
 
-console.log('mod[funcHandler]', funcHandler, mod[funcHandler])
-const server = http.createServer((req, res) => {
-  return mod[funcHandler](req, res)
-})
+console.log('mod[funcHandler]', funcHandler, mod[funcHandler]);
 
-server.listen(8080, '0.0.0.0')
+app.get('/healthz', (req, res) => {
+  res.status(200).send('OK');
+});
+
+app.get('/metrics', (req, res) => {
+  res.status(200);
+  res.type(client.register.contentType);
+  res.send(client.register.metrics());
+});
+
+app.all('/', (req, res) => {
+  const end = timeHistogram.startTimer();
+  callsCounter.labels(req.method).inc();
+  Promise.resolve(mod[funcHandler](req, res)).then(() => {
+    end();
+  }).catch((err) => {
+    errorsCounter.labels(req.method).inc();
+    res.status(500).send('Internal Server Error');
+    console.error(`Function failed to execute: ${err.stack}`);
+  });
+});
+
+app.listen(8080);

--- a/docker/runtime/nodejs-6.10/http-trigger/package.json
+++ b/docker/runtime/nodejs-6.10/http-trigger/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "nodejs-http-trigger",
+  "version": "0.0.1",
+  "description": "Express server for serving http-based functions for Kubeless",
+  "author": "containers@bitnami.com",
+  "license": "Apache-2.0",
+  "bugs": {
+    "url": "https://github.com/serverless/serverless-kubeless/issues"
+  },
+  "homepage": "https://github.com/serverless/serverless-kubeless#readme",
+  "dependencies": {
+    "express": "^4.15.3",
+    "prom-client": "^10.0.2"
+  }
+}

--- a/examples/nodejs/hellowithdata.js
+++ b/examples/nodejs/hellowithdata.js
@@ -1,14 +1,17 @@
 module.exports = {
-  handler: function (req, res) {
-    var body = []
-    req.on('error', function (err) {
-      console.error(err)
-    }).on('data', function (chunk) {
-      body.push(chunk)
-    }).on('end', function () {
-      body = Buffer.concat(body).toString()
-      console.log(body)
-      res.end(body)
-    })
-  }
-}
+  handler: (req, res) => {
+    let body = [];
+    return new Promise((resolve, reject) => {
+      req.on('error', (err) => {
+        reject(new Error(err));
+      }).on('data', (chunk) => {
+        body.push(chunk);
+      }).on('end', () => {
+        body = Buffer.concat(body).toString();
+        console.log(body);
+        res.end(body);
+        resolve();
+      });
+    });
+  },
+};

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -52,7 +52,7 @@ import (
 const (
 	pythonRuntime = "bitnami/kubeless-python@sha256:3be6b50133380ab0fb2bd3fd4c91c300e031eff9a357e464466ba6dafa0cb32b"
 	pubsubRuntime = "bitnami/kubeless-event-consumer@sha256:985644359c6c6fd8ea74740d341b7e9bc68390e4601cd04de767849e1b9c79b1"
-	nodejsRuntime = "rosskukulinski/kubeless-nodejs@sha256:8538660749e40847ac637d61caec5a609682b65727f8331ad5ef67e910b729cb"
+	nodejsRuntime = "bitnami/kubeless-nodejs@sha256:9304c50a408563d9f7782568d536ed198bdc830dc143be38472f57b2f61de104"
 	rubyRuntime   = "jbianquettibitnami/kubeless-ruby@sha256:9ea43e4e1570b46ae272e9f81a0ea4736e4956ee2ee67d8def29287a1d7153fe"
 	pubsubFunc    = "PubSub"
 )


### PR DESCRIPTION
This PR rewrites the NodeJS support for Kubeless. These are the major changes: 
 - Now the functions are served using [Express](https://expressjs.com/)
 - Support for liveness probe in the URL `/healthz`
 - Support for prometheus metrics in the URL `/metrics`. The exposed metrics are:
   - Access counter per method (GET/POST)
   - Error counter per method
   - Histogram about function duration.

It also adapt the existing Dockerfile and the NodeJS example.
Note that for retrieving metrics, if the user function is asynchronous, it should return a `Promise`.