### PR TITLE
[jjo] add minikube-rbac-test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,5 +58,8 @@ validation:
 	./script/validate-gofmt
 	./script/validate-git-marks
 
+minikube-rbac-test:
+	./script/minikube-rbac-test
+
 fmt:
 	$(GOFMT) -s -w $(GO_FILES)

--- a/script/minikube-rbac-test
+++ b/script/minikube-rbac-test
@@ -140,10 +140,8 @@ test_kubeless_rbac() {
     [[ $current_context != "" ]] && \
         info "Saved context: '${current_context}'" && \
         ${KUBECTL_BIN} config use-context ${MINIKUBE_CONTEXT}
-    (
-        _test_must_fail_without_rbac_roles
-        _test_must_pass_with_rbac_roles
-    )
+    _test_must_fail_without_rbac_roles
+    _test_must_pass_with_rbac_roles
     # Restore current_context
     [[ $current_context != "" ]] && \
         info "Restoring context: '${current_context}'" && \

--- a/script/minikube-rbac-test
+++ b/script/minikube-rbac-test
@@ -1,0 +1,160 @@
+#!/bin/bash
+# Instrument basic smoke RBAC test against minikube:
+# - _test_must_fail_without_rbac_roles for failure
+# - _test_must_pass_with_rbac_roles    for success
+#
+# Assumes already setup minikube RBAC'd environment
+set -u
+
+KUBECTL_BIN=$(which kubectl)
+KUBECFG_BIN=$(which kubecfg)
+MINIKUBE_CONTEXT="minikube"
+
+T_BOLD=$(test -t 0 && tput bold)
+T_SGR0=$(test -t 0 && tput sgr0)
+
+typeset -i TOTAL_PASS=0
+typeset -i TOTAL_FAIL=0
+
+# Wrapup kubectl, kubecfg for --context
+kubectl() {
+    ${KUBECTL_BIN} --context=${MINIKUBE_CONTEXT} "$@"
+}
+kubecfg() {
+    ${KUBECFG_BIN} --context=${MINIKUBE_CONTEXT} "$@"
+}
+
+## Generic helper functions
+info () {
+    echo "INFO: $@"
+}
+spin() {
+    echo -n .; sleep $1; echo -ne "\r"; sleep $1
+}
+
+_pass_or_fail() {
+    local rc=${1:?} exp_rc=${2:?} msg="${3:?}" status
+    [[ ${rc} == ${exp_rc} ]] \
+        && { status=PASS; TOTAL_PASS=TOTAL_PASS+1; } \
+        || { status=FAIL; TOTAL_FAIL=TOTAL_FAIL+1; }
+    echo "${T_BOLD}${status}${T_SGR0}: ${msg}"
+    [[ ${status} = PASS ]]
+}
+
+## Pre-run verifications
+verify_k8s_tools() {
+    local tools="minikube kubectl kubecfg kubeless"
+    info "VERIFY: k8s tools installed: $tools"
+    for exe in minikube kubectl kubecfg kubeless; do
+        which ${exe} >/dev/null && continue
+        echo "ERROR: '${exe}' needs to be installed"
+        return 1
+    done
+}
+
+verify_minikube_running () {
+    info "VERIFY: minikube running ..."
+    minikube status | grep -q "minikube: Running"
+}
+verify_minikube_rbac_mode() {
+    info "VERIFY: minikube running with RBAC ... "
+    kubectl api-versions |&grep -q rbac && return 0
+    echo "ERROR: Please run minikube as: minikube start --extra-config=apiserver.Authorization.Mode=RBAC"
+    return 1
+}
+
+## k8s specific Helper functions
+_wait_for_kubeless_controller_ready() {
+    info "Waiting for kubeless controller to be ready ... "
+    until kubectl get pod --namespace=kubeless --selector=kubeless=controller|&egrep -q Running; do
+        spin 0.5
+    done
+    sleep 10
+}
+_recreate_kubeless() {
+    local jsonnet_del=${1:?missing jsonnet delete manifest} jsonnet_upd=${2:?missing jsonnet update manifest}
+    info "Delete kubeless namespace, wait to be gone ... "
+    kubecfg delete ${jsonnet_del}
+    kubectl delete namespace kubeless >& /dev/null || true
+    while kubectl get namespace kubeless >& /dev/null; do
+        spin 0.5
+    done
+    kubectl create namespace kubeless
+    kubecfg update ${jsonnet_upd}
+}
+_wait_for_function_pod_ready() {
+    info "Waiting for function pod to be ready ... "
+    until kubectl get pod --selector=function=get-python |&grep -q Running; do
+        spin 0.5
+    done
+}
+_wait_for_controller_logline() {
+    local string="${1:?}"
+    info "Waiting for controller to show logline '${1}' ..."
+    until kubectl --context=minikube logs --tail=10 --namespace=kubeless --selector=kubeless=controller|&grep -q "${string}"; do
+        spin 0.5
+    done
+    _pass_or_fail $? 0 "Found logline: '$string'"
+}
+_delete_function() {
+    info "Deleting function in case still present ... "
+    kubeless function delete get-python >& /dev/null || true
+    kubectl delete all --selector=function=get-python >& /dev/null || true
+}
+_deploy_function() {
+    info "Deploying function ..."
+    kubeless function deploy get-python --runtime python27 --handler hellowithdata.handler --from-file examples/python/hellowithdata.py --trigger-http 
+}
+_call_function() {
+    local exp_rc=${1:-0}
+    info "Calling function, expecting rc=${exp_rc} "
+    kubeless function call get-python --data '{"it-s": "alive"}' |&egrep it.*alive
+    _pass_or_fail $? ${exp_rc} "called function, got rc=$?"
+}
+_test_must_fail_without_rbac_roles() {
+    info "RBAC TEST: function deploy/call must fail without RBAC roles"
+    _delete_function
+    _recreate_kubeless kubeless-rbac.jsonnet kubeless.jsonnet
+    _wait_for_kubeless_controller_ready
+    _deploy_function
+    _wait_for_controller_logline "User.*cannot"
+    _call_function 1
+}
+_test_must_pass_with_rbac_roles() {
+    info "RBAC TEST: function deploy/call must succeed with RBAC roles"
+    _delete_function
+    _recreate_kubeless kubeless-rbac.jsonnet kubeless-rbac.jsonnet
+    _wait_for_kubeless_controller_ready
+    _deploy_function
+    _wait_for_controller_logline "controller synced and ready"
+    _wait_for_function_pod_ready
+    _call_function 0
+}
+test_kubeless_rbac() {
+    local current_context=$(${KUBECTL_BIN} config current-context)
+    # Kubeless doesn't support contexts yet, save+restore it
+    # Don't save current_context if it's "minikube" already
+    [[ $current_context == $MINIKUBE_CONTEXT ]] && current_context=""
+
+    # Save current_context
+    [[ $current_context != "" ]] && \
+        info "Saved context: '${current_context}'" && \
+        ${KUBECTL_BIN} config use-context ${MINIKUBE_CONTEXT}
+    (
+        _test_must_fail_without_rbac_roles
+        _test_must_pass_with_rbac_roles
+    )
+    # Restore current_context
+    [[ $current_context != "" ]] && \
+        info "Restoring context: '${current_context}'" && \
+        ${KUBECTL_BIN} config use-context ${current_context}
+}
+
+verify_k8s_tools || exit 255
+verify_minikube_running || exit 255
+verify_minikube_rbac_mode || exit 255
+test_kubeless_rbac
+info "exit ${T_BOLD}PASS=$TOTAL_PASS FAIL=$TOTAL_FAIL${T_SGR0}"
+exit $TOTAL_FAIL
+
+# vim: sw=4 ts=4 et si


### PR DESCRIPTION
Add basic smoke testing for success/failure with/out RBAC role,
example run:

```
$ make minikube-rbac-test 
./script/minikube-rbac-test
INFO: VERIFY: k8s tools installed: minikube kubectl kubecfg kubeless
INFO: VERIFY: minikube running ...
INFO: VERIFY: minikube running with RBAC ... 
INFO: RBAC TEST: function deploy/call must fail without RBAC roles
INFO: Deleting function in case still present ... 
INFO: Delete kubeless namespace, wait to be gone ... 
namespace "kubeless" created
INFO: Waiting for kubeless controller to be ready ... 
INFO: Deploying function ...
INFO: Waiting for controller to show logline 'User.*cannot' ...
PASS: Found logline: 'User.*cannot'
INFO: Calling function, expecting rc=1 
PASS: called function, got rc=1
INFO: RBAC TEST: function deploy/call must succeed with RBAC roles
INFO: Deleting function in case still present ... 
INFO: Delete kubeless namespace, wait to be gone ... 
namespace "kubeless" created
INFO: Waiting for kubeless controller to be ready ... 
INFO: Deploying function ...
INFO: Waiting for controller to show logline 'controller synced and ready' ...
PASS: Found logline: 'controller synced and ready'
INFO: Waiting for function pod to be ready ... 
INFO: Calling function, expecting rc=0 
{"it-s": "alive"}
PASS: called function, got rc=0
INFO: exit PASS=4 FAIL=0

```