### PR TITLE
[jjo] narrow clusterRoleBinding fields,

### DIFF
--- a/kubeless-rbac.jsonnet
+++ b/kubeless-rbac.jsonnet
@@ -24,8 +24,8 @@ local clusterRoleBinding(name, role, subjects) = {
     apiVersion: "rbac.authorization.k8s.io/v1beta1",
     kind: "ClusterRoleBinding",
     metadata: objectMeta.name(name),
-    subjects: [s + {namespace: s.metadata.namespace, name: s.metadata.name} for s in subjects],
-    roleRef: role + {name: role.metadata.name},
+    subjects: [{kind: s.kind, namespace: s.metadata.namespace, name: s.metadata.name} for s in subjects],
+    roleRef: {kind: role.kind, name: role.metadata.name},
 };
 
 local controllerClusterRole = clusterRole(


### PR DESCRIPTION
#OCD~ish: get kubecfg diff --diff-strategy subset to be zero:

* before: https://gist.github.com/jjo/e95c105b1039456735ecf9b6c3eb6b3a
* after: https://gist.github.com/jjo/a8c68931fdfc6fb7346d25d3f61ba0fc
