### PR TITLE
chart: fix missing label template

### DIFF
--- a/helm/kubeless/Chart.yaml
+++ b/helm/kubeless/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: A Helm chart for Kubernetes
 name: kubeless
-version: 0.1.0
+version: 0.1.1

--- a/helm/kubeless/templates/_helpers.tpl
+++ b/helm/kubeless/templates/_helpers.tpl
@@ -25,5 +25,5 @@ The standard labels are frequently used in metadata.
 app: {{ template "name" . }}
 heritage: {{ .Release.Service | quote }}
 release: {{ .Release.Name | quote }}
-chart: {{ template "chartref" . }}
+chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 {{- end -}}

--- a/helm/kubeless/templates/ui-deployment.yaml
+++ b/helm/kubeless/templates/ui-deployment.yaml
@@ -4,7 +4,7 @@ metadata:
   name: {{ template "fullname" . }}-ui
   labels:
 {{ include "labels.standard" . | indent 4 }}
-   controller: {{ template "fullname" . }}-ui
+    controller: {{ template "fullname" . }}-ui
 spec:
   replicas: {{ .Values.controller.deployment.replicaCount }}
   template:


### PR DESCRIPTION
The chart was referencing a `chartref` template that didn't exist,
this PR removes the template.

cc @sameersbn @rimusz