### PR TITLE
Update ingress controller image version

### DIFF
--- a/manifests/ingress/ingress-controller.yaml
+++ b/manifests/ingress/ingress-controller.yaml
@@ -72,7 +72,7 @@ spec:
     spec:
       terminationGracePeriodSeconds: 60      
       containers:
-      - image: gcr.io/google_containers/nginx-ingress-controller:0.8.2
+      - image: gcr.io/google_containers/nginx-ingress-controller:0.9.0-beta.11
         name: nginx-ingress-lb
         imagePullPolicy: Always
         livenessProbe:


### PR DESCRIPTION
The image 0.8.2 fails to show the ingress IP with the latest kubernetes version (1.7.0):
```
$ kubectl get ingress
NAME            HOSTS     ADDRESS   PORTS     AGE
ingress-hello   *                   80        5m
```
I tested it with the latest version available (used in https://github.com/kubernetes/ingress/blob/master/examples/tcp/nginx/nginx-tcp-ingress-controller.yaml#L20) and it works properly.