### PR TITLE
leading YAML seperator in templates cause "object not found" error

### DIFF
--- a/chart/kubeless/templates/kafka-headless-svc.yaml
+++ b/chart/kubeless/templates/kafka-headless-svc.yaml
@@ -1,5 +1,4 @@
 # A headless service to create DNS records
----
 apiVersion: v1
 kind: Service
 metadata:


### PR DESCRIPTION
A bug in helm causes "object not found" error to be thrown while
deleting a release if any template contains a leading YAML seperator.

Fixes #239