### PR TITLE
ingress controller http only

### DIFF
--- a/manifests/README.md
+++ b/manifests/README.md
@@ -6,9 +6,9 @@
 Create `kubeless` namespace and create zookeeper
 
 ```
-kubectl create -f zookeeper/namespace.yaml 
+kubectl create -f zookeeper/namespace.yaml
 kubectl create -f zookeeper/zk-headless-svc.yaml
-kubectl create -f zookeeper/zk-stateful.yaml 
+kubectl create -f zookeeper/zk-stateful.yaml
 kubectl create -f zookeeper/zk-svc.yaml
 ```
 
@@ -31,5 +31,13 @@ Launch kubeless controller and UI
 ```
 kubectl create -f controller/controller-deployment.yaml
 kubectl create -f ui/ui-deployment.yaml
-kubectl create -f ui/ui-svc.yaml 
+kubectl create -f ui/ui-svc.yaml
+```
+
+Create Ingress controller and sample ingress route
+
+```
+kubectl create -f ingress/ingress-controller-http-only.yaml
+kubectl create -f ingress/demo-svc.yaml
+kubectl create -f ingress/demo-ingress.yaml
 ```

--- a/manifests/ingress/ingress-controller-http-only.yaml
+++ b/manifests/ingress/ingress-controller-http-only.yaml
@@ -12,7 +12,7 @@ spec:
       labels:
         app: default-http-backend
     spec:
-      terminationGracePeriodSeconds: 60      
+      terminationGracePeriodSeconds: 60
       containers:
       - name: default-http-backend
         # Any image is permissable as long as:
@@ -70,7 +70,7 @@ spec:
         k8s-app: nginx-ingress-lb
         name: nginx-ingress-lb
     spec:
-      terminationGracePeriodSeconds: 60      
+      terminationGracePeriodSeconds: 60
       containers:
       - image: gcr.io/google_containers/nginx-ingress-controller:0.8.2
         name: nginx-ingress-lb
@@ -95,8 +95,6 @@ spec:
         ports:
         - containerPort: 80
           hostPort: 80
-        - containerPort: 443
-          hostPort: 443
         args:
         - /nginx-ingress-controller
         - --default-backend-service=default/default-http-backend


### PR DESCRIPTION
Minor change to the ingress-controller manifest to support http only. For https setup, Adnan and I are going to submit documentation.