### PR TITLE
support scheduled function

### DIFF
--- a/cmd/kubeless/deploy.go
+++ b/cmd/kubeless/deploy.go
@@ -42,6 +42,11 @@ var deployCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
+		schedule, err := cmd.Flags().GetString("schedule")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
 		topic, err := cmd.Flags().GetString("trigger-topic")
 		if err != nil {
 			logrus.Fatal(err)
@@ -98,8 +103,12 @@ var deployCmd = &cobra.Command{
 		}
 
 		funcType := "PubSub"
-		if triggerHTTP {
+		switch {
+		case triggerHTTP:
 			funcType = "HTTP"
+			topic = ""
+		case schedule != "":
+			funcType = "Scheduled"
 			topic = ""
 		}
 
@@ -124,6 +133,7 @@ var deployCmd = &cobra.Command{
 				Type:     funcType,
 				Function: funcContent,
 				Topic:    topic,
+				Schedule: schedule,
 				Template: v1.PodTemplateSpec{
 					Spec: v1.PodSpec{
 						Containers: []v1.Container{{}},
@@ -172,6 +182,7 @@ func init() {
 	deployCmd.Flags().StringP("namespace", "", api.NamespaceDefault, "Specify namespace for the function")
 	deployCmd.Flags().StringP("dependencies", "", "", "Specify a file containing list of dependencies for the function")
 	deployCmd.Flags().StringP("trigger-topic", "", "kubeless", "Deploy a pubsub function to Kubeless")
+	deployCmd.Flags().StringP("schedule", "", "", "Specify schedule in cron format for scheduled function")
 	deployCmd.Flags().StringP("memory", "", "", "Request amount of memory, which is measured in bytes, for the function. It is expressed as a plain integer or a fixed-point interger with one of these suffies: E, P, T, G, M, K, Ei, Pi, Ti, Gi, Mi, Ki")
 	deployCmd.Flags().Bool("trigger-http", false, "Deploy a http-based function to Kubeless")
 }

--- a/cmd/kubeless/ingressList.go
+++ b/cmd/kubeless/ingressList.go
@@ -83,10 +83,16 @@ func printIngress(w io.Writer, ings []v1beta1.Ingress, output string) error {
 		for _, i := range ings {
 			switch output {
 			case "json":
-				b, _ := json.MarshalIndent(i.Spec, "", "  ")
+				b, err := json.MarshalIndent(i.Spec, "", "  ")
+				if err != nil {
+					return err
+				}
 				fmt.Fprintln(w, string(b))
 			case "yaml":
-				b, _ := yaml.Marshal(i.Spec)
+				b, err := yaml.Marshal(i.Spec)
+				if err != nil {
+					return err
+				}
 				fmt.Fprintln(w, string(b))
 			default:
 				return fmt.Errorf("Wrong output format. Please use only json|yaml")

--- a/cmd/kubeless/list.go
+++ b/cmd/kubeless/list.go
@@ -154,10 +154,16 @@ func printFunctions(w io.Writer, functions []*spec.Function, output string) erro
 		for _, f := range functions {
 			switch output {
 			case "json":
-				b, _ := json.MarshalIndent(f, "", "  ")
+				b, err := json.MarshalIndent(f, "", "  ")
+				if err != nil {
+					return err
+				}
 				fmt.Fprintln(w, string(b))
 			case "yaml":
-				b, _ := yaml.Marshal(f)
+				b, err := yaml.Marshal(f)
+				if err != nil {
+					return err
+				}
 				fmt.Fprintln(w, string(b))
 			default:
 				return fmt.Errorf("Wrong output format. Please use only json|yaml")

--- a/cmd/kubeless/list.go
+++ b/cmd/kubeless/list.go
@@ -118,13 +118,14 @@ func printFunctions(w io.Writer, functions []*spec.Function, output string) erro
 		table := uitable.New()
 		table.MaxColWidth = 50
 		table.Wrap = true
-		table.AddRow("NAME", "NAMESPACE", "HANDLER", "RUNTIME", "TYPE", "TOPIC", "MEMORY", "ENV", "LABEL")
+		table.AddRow("NAME", "NAMESPACE", "HANDLER", "RUNTIME", "TYPE", "TOPIC", "MEMORY", "ENV", "LABEL", "SCHEDULE")
 		for _, f := range functions {
 			n := f.Metadata.Name
 			h := f.Spec.Handler
 			r := f.Spec.Runtime
 			t := f.Spec.Type
 			tp := f.Spec.Topic
+			s := f.Spec.Schedule
 			ns := f.Metadata.Namespace
 			mem := ""
 			env := ""
@@ -146,7 +147,7 @@ func printFunctions(w io.Writer, functions []*spec.Function, output string) erro
 				}
 				label = buffer.String()
 			}
-			table.AddRow(n, ns, h, r, t, tp, mem, env, label)
+			table.AddRow(n, ns, h, r, t, tp, mem, env, label, s)
 		}
 		fmt.Fprintln(w, table)
 	} else {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -194,7 +194,7 @@ func (c *Controller) processItem(key string) error {
 
 	funcObj := obj.(*spec.Function)
 
-	err = utils.EnsureK8sResources(ns, name, funcObj, c.clientset)
+	err = utils.EnsureK8sResources(funcObj, c.clientset)
 	if err != nil {
 		c.logger.Errorf("Function can not be created/updated: %v", err)
 		return err

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -36,6 +36,7 @@ type FunctionSpec struct {
 	Runtime  string             `json:"runtime"`
 	Type     string             `json:"type"`
 	Topic    string             `json:"topic"`
+	Schedule string             `json:"schedule"`
 	Deps     string             `json:"deps"`
 	Template v1.PodTemplateSpec `json:"template" protobuf:"bytes,3,opt,name=template"`
 }

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -59,7 +59,7 @@ const (
 	node8Http      = "bitnami/kubeless-nodejs@sha256:1eff2beae6fcc40577ada75624c3e4d3840a854588526cd8616d66f4e889dfe6"
 	node8Pubsub    = "bitnami/kubeless-nodejs-event-consumer@sha256:4d005c9c0b462750d9ab7f1305897e7a01143fe869d3b722ed3330560f9c7fb5"
 	ruby24Http     = "bitnami/kubeless-ruby@sha256:98e95c41652a7a0149421157c2dfb64b31e0d406b8c46c8bc89bd54e50f9898d"
-	busybox        = "tuna/busybox@sha256:3651f7ee3b1e779471e338dcc43e6a5e69e0a8c7a4d08fd5702531cbbacc3269"
+	busybox        = "busybox@sha256:be3c11fdba7cfe299214e46edc642e09514dbb9bbefcd0d3836c05a1e0cd0642"
 	pubsubFunc     = "PubSub"
 	schedFunc      = "Scheduled"
 )
@@ -269,6 +269,9 @@ func GetFunctionData(runtime, ftype, modName string) (imageName, depName, fileNa
 
 // EnsureK8sResources creates/updates k8s objects (deploy, svc, configmap) for the function
 func EnsureK8sResources(funcObj *spec.Function, client kubernetes.Interface) error {
+	if len(funcObj.Metadata.Labels) == 0 {
+		funcObj.Metadata.Labels = make(map[string]string)
+	}
 	funcObj.Metadata.Labels["function"] = funcObj.Metadata.Name
 
 	t := true
@@ -917,7 +920,7 @@ func ensureFuncJob(client kubernetes.Interface, funcObj *spec.Function, or []met
 								{
 									Image: busybox,
 									Name:  "trigger",
-									Args:  []string{"curl", fmt.Sprintf("http://%s.%s.svc:8080", funcObj.Metadata.Name, funcObj.Metadata.Namespace)},
+									Args:  []string{"wget", "-qO-", fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", funcObj.Metadata.Name, funcObj.Metadata.Namespace)},
 								},
 							},
 							RestartPolicy: v1.RestartPolicyOnFailure,

--- a/pkg/utils/k8sutil_test.go
+++ b/pkg/utils/k8sutil_test.go
@@ -234,7 +234,7 @@ func TestEnsureK8sResources(t *testing.T) {
 		},
 	}
 
-	if err := EnsureK8sResources(ns, func1, f1, clientset); err != nil {
+	if err := EnsureK8sResources(f1, clientset); err != nil {
 		t.Fatalf("Creating resources returned err: %v", err)
 	}
 
@@ -262,7 +262,7 @@ func TestEnsureK8sResources(t *testing.T) {
 		t.Errorf("Create wrong deployment object. Expect deployment labels foo=bar but got %s", dpm.Spec.Template.Labels["foo"])
 	}
 
-	if err := EnsureK8sResources(ns, func2, f2, clientset); err != nil {
+	if err := EnsureK8sResources(f2, clientset); err != nil {
 		t.Fatalf("Creating resources returned err: %v", err)
 	}
 	svc, err = clientset.CoreV1().Services(ns).Get(func2, metav1.GetOptions{})


### PR DESCRIPTION
$ kubeless function deploy --schedule "*/1 * * * *" --runtime python2.7 --handler helloget.foo --from-file python/helloget.py

- create cronjob object instead of deploy and svc
- inject configmap to cronjob
- keep initContiner for cronjob to support loading function dependency (I am not really sure about this case)
- keep livenessProbe, prometheus annotations
- refactor EnsureK8sResources()