### PR TITLE
[jjo] enable pubsub integration tests

### DIFF
--- a/kubeless.jsonnet
+++ b/kubeless.jsonnet
@@ -68,6 +68,7 @@ local kafkaContainer =
   container.imagePullPolicy("IfNotPresent") +
   container.env(kafkaEnv) +
   container.ports({containerPort: 9092}) +
+  container.livenessProbe({tcpSocket: {port: 9092}, initialDelaySeconds: 30}) +
   container.volumeMounts([
     {
       name: "datadir",

--- a/script/integration-tests
+++ b/script/integration-tests
@@ -61,7 +61,7 @@ exit_code=$?
 # Just showing remaining k8s objects
 kubectl get all --all-namespaces
 
-[[ ${exit_code} == 0 ]] || {
+if [ ${exit_code} -ne 0 -o -n "${TRAVIS_DUMP_LOGS}" ]; then
     echo "INFO: Build ERRORed, dumping logs: ##"
     for ns in kubeless default; do
         echo "### LOGs: namespace: ${ns} ###"
@@ -69,6 +69,8 @@ kubectl get all --all-namespaces
     done
     echo "INFO: LOGs: pod: kube-dns ###"
     kubectl logs -n kube-system -l k8s-app=kube-dns -c kubedns
-}
+    echo "INFO: LOGs: END"
+fi
+[ ${exit_code} -eq 0 ] && echo "INFO: $0: SUCCESS" || echo "ERROR: $0: FAILED"
 exit ${exit_code}
 # vim: sw=4 ts=4 et si

--- a/tests/integration-tests.bats
+++ b/tests/integration-tests.bats
@@ -33,11 +33,10 @@ load ../script/libtest
 @test "Test function: post-nodejs" {
   test_kubeless_function post-nodejs
 }
-@test "Test function: pubsub" {
-  skip "XXX(jjo): flaky kafka->zookeeper under minikube, likely from its kube-dns"
-  test_kubeless_function pubsub
-}
 @test "Test function: get-python-metadata" {
   test_kubeless_function get-python-metadata
+}
+@test "Test function: pubsub" {
+  test_kubeless_function pubsub
 }
 # vim: ts=2 sw=2 si et syntax=sh


### PR DESCRIPTION
* integration-tests.bats: enable `pubsub`

* harden `kafka-0` readiness checks to (more) deterministically run
  `make -C examples pubsub pubsub-verify`
  - add livenessProbe to kafka-0:
    added tcp port 9092 probing, specially needed when testing (i.e. full
    minikube/dind cluster being brought up), kafka startup have been
    observed to fail from e.g. `zookeeper.kubeless` failed resolution
    (kube-dns may have not completely settled), and its containers'
    `/run.sh` does a single shot run w/o retry
  - enhance related functions:
   ` _wait_for_kubeless_kafka_{server,topic}_ready`
  - tail the whole log, to avoid races

* misc:
  - add TRAVIS_DUMP_LOGS for force log dumping even if successful
  - only delete func if not present