### PR TITLE
Fix error message about the list of available runtimes.

### DIFF
--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -75,8 +75,8 @@ func init() {
 	python27 := runtimeVersion{runtimeID: "python", version: "2.7", httpImage: python27Http, pubsubImage: python27Pubsub}
 	python = []runtimeVersion{python27}
 
-	node6 := runtimeVersion{runtimeID: "node", version: "6", httpImage: node6Http, pubsubImage: node6Pubsub}
-	node8 := runtimeVersion{runtimeID: "node", version: "8", httpImage: node8Http, pubsubImage: node8Pubsub}
+	node6 := runtimeVersion{runtimeID: "nodejs", version: "6", httpImage: node6Http, pubsubImage: node6Pubsub}
+	node8 := runtimeVersion{runtimeID: "nodejs", version: "8", httpImage: node8Http, pubsubImage: node8Pubsub}
 	node = []runtimeVersion{node6, node8}
 
 	ruby24 := runtimeVersion{runtimeID: "ruby", version: "2.4", httpImage: ruby24Http, pubsubImage: ""}

--- a/pkg/utils/k8sutil_test.go
+++ b/pkg/utils/k8sutil_test.go
@@ -118,7 +118,7 @@ func TestGetFunctionData(t *testing.T) {
 
 	// Throws an error if the runtime version doesn't exist
 	_, _, _, err = GetFunctionData("nodejs3", "HTTP", "test")
-	expectedErrMsg := regexp.MustCompile("The given runtime and version 'nodejs3' does not have a valid image for HTTP based functions. Available runtimes are: python2.7, node6, node8, ruby2.4")
+	expectedErrMsg := regexp.MustCompile("The given runtime and version 'nodejs3' does not have a valid image for HTTP based functions. Available runtimes are: python2.7, nodejs6, nodejs8, ruby2.4")
 	if expectedErrMsg.FindString(err.Error()) == "" {
 		t.Fatalf("Retrieving data for 'nodejs3' should return an error")
 	}


### PR DESCRIPTION
The nodejs runtimes are called nodejs6 and nodejs8, but the error messages if you used a wrong runtime name were wrong, specifying "node6" and "node8" instead. 

This pull request fixes that error message to the correct runtime name.