### PR TITLE
add autoscaling manifests

### DIFF
--- a/manifests/autoscaling/README.md
+++ b/manifests/autoscaling/README.md
@@ -1,0 +1,205 @@
+# Autoscaling with custom metrics on k8s 1.7
+
+This walkthrough will go over the step-by-step of setting up the prometheus-based custom API server on your cluster and configuring autoscaler (HPA) to use application metrics sourced from prometheus instance.
+
+This walkthrough is done in [kubeadm-dind-cluster v1.7](https://github.com/Mirantis/kubeadm-dind-cluster)
+
+## Cluster configuration
+
+Before getting started, ensure that the main components of your cluster are configured for autoscaling on custom metrics. As of Kubernetes 1.7, this requires enabling the aggregation layer on the API server and configuring the controller manager to use the metrics APIs via their REST clients.
+
+Read more about the aggregation and autoscaling in the Kubernetes documentations:
+- aggregation layer in v1.7: https://kubernetes.io/docs/concepts/api-extension/apiserver-aggregation/
+
+**Start the cluster**
+```
+$ wget https://cdn.rawgit.com/Mirantis/kubeadm-dind-cluster/master/fixed/dind-cluster-v1.7.sh
+$ chmod +x dind-cluster-v1.7.sh
+$ ./dind-cluster-v1.7.sh up
+```
+
+Checking the state of the cluster:
+```
+$ docker ps
+$ kubectl cluster-info
+```
+
+**Configuration**
+
+The manifests of kubernetes components in `kubeadm-dind-cluster` locate at `/etc/kubernetes/manifests`, you can just jump in the master "container" and edit them directly; and kubeadm manages to recreate the components immediately.
+
+These below configurations must be set:
+
+1) enable and configure aggregation layer in v1.7 in `kube-apiserver`: https://kubernetes.io/docs/tasks/access-kubernetes-api/configure-aggregation-layer/
+```
+--requestheader-client-ca-file=<path to aggregator CA cert>
+--requestheader-allowed-names=aggregator
+--requestheader-extra-headers-prefix=X-Remote-Extra-
+--requestheader-group-headers=X-Remote-Group
+--requestheader-username-headers=X-Remote-User
+--proxy-client-cert-file=<path to aggregator proxy cert>
+--proxy-client-key-file=<path to aggregator proxy key>
+```
+
+2) configure controller manager to use the metrics APIs via their REST clients by these settings in `kube-controller-manager`:
+```
+--horizontal-pod-autoscaler-use-rest-clients=true
+--master=<apiserver-address>:<port> //port should be 8080
+```
+
+3) the autoscaling for custom metrics is supported in HPA since v1.7 via `autoscaling/v2alpha1` API. It needs to be enabled by setting the `runtime-config` in `kube-apiserver`:
+```
+--runtime-config=api/all=true
+```
+Once the kube-apiserver is configured and up and running, `kubectl` will auto-discover all API groups. Check it using this below command and you will see the `autoscaling/v2alpha1` is enabled:
+```
+$ kubectl api-versions
+admissionregistration.k8s.io/v1alpha1
+apiextensions.k8s.io/v1beta1
+apiregistration.k8s.io/v1beta1
+apps/v1beta1
+authentication.k8s.io/v1
+authentication.k8s.io/v1beta1
+authorization.k8s.io/v1
+authorization.k8s.io/v1beta1
+autoscaling/v1
+**autoscaling/v2alpha1**
+batch/v1
+batch/v2alpha1
+certificates.k8s.io/v1beta1
+extensions/v1beta1
+networking.k8s.io/v1
+policy/v1beta1
+rbac.authorization.k8s.io/v1alpha1
+rbac.authorization.k8s.io/v1beta1
+settings.k8s.io/v1alpha1
+storage.k8s.io/v1
+storage.k8s.io/v1beta1
+v1
+```
+
+## Deploy Prometheus to monitor services
+The Prometheus setup contains a Prometheus operator and a Prometheus instance
+
+```
+$ kubectl create -f prometheus-operator.yaml
+clusterrole "prometheus-operator" created
+serviceaccount "prometheus-operator" created
+clusterrolebinding "prometheus-operator" created
+deployment "prometheus-operator" created
+
+$ kubectl create -f sample-prometheus-instance.yaml
+clusterrole "prometheus" created
+serviceaccount "prometheus" created
+clusterrolebinding "prometheus" created
+prometheus "sample-metrics-prom" created
+service "sample-metrics-prom" created
+
+$ kubectl get svc
+NAME                  CLUSTER-IP      EXTERNAL-IP   PORT(S)          AGE
+kubernetes            10.96.0.1       <none>        443/TCP          6d
+prometheus-operated   None            <none>        9090/TCP         1h
+```
+
+## Deploy a custom API server
+When the aggregator enabled and configured properly, one can deploy and register a custom API server that provides the `custom-metrics.metrics.k8s.io/v1alpha1` API group/version and let the HPA controller queries custom metrics from that.
+
+The custom API server we are using here is basically [a Prometheus adapter](https://github.com/directxman12/k8s-prometheus-adapter) which can collect metrics from Prometheus and send to HPA controller via REST queries (that's why we must configure HPA controller to use REST client via the `--horizontal-pod-autoscaler-use-rest-clients` flag)
+
+```
+$ kubectl create -f custom-metrics.yaml
+namespace "custom-metrics" created
+serviceaccount "custom-metrics-apiserver" created
+clusterrolebinding "custom-metrics:system:auth-delegator" created
+rolebinding "custom-metrics-auth-reader" created
+clusterrole "custom-metrics-read" created
+clusterrolebinding "custom-metrics-read" created
+deployment "custom-metrics-apiserver" created
+service "api" created
+apiservice "v1alpha1.custom-metrics.metrics.k8s.io" created
+clusterrole "custom-metrics-server-resources" created
+clusterrolebinding "hpa-controller-custom-metrics" created
+```
+
+At this step, the custom API server is deployed and registered to API aggregator, so we can see it:
+
+```
+$ kubectl api-versions
+admissionregistration.k8s.io/v1alpha1
+apiextensions.k8s.io/v1beta1
+apiregistration.k8s.io/v1beta1
+apps/v1beta1
+authentication.k8s.io/v1
+authentication.k8s.io/v1beta1
+authorization.k8s.io/v1
+authorization.k8s.io/v1beta1
+autoscaling/v1
+autoscaling/v2alpha1
+batch/v1
+batch/v2alpha1
+certificates.k8s.io/v1beta1
+**custom-metrics.metrics.k8s.io/v1alpha1**
+extensions/v1beta1
+monitoring.coreos.com/v1alpha1
+networking.k8s.io/v1
+policy/v1beta1
+rbac.authorization.k8s.io/v1alpha1
+rbac.authorization.k8s.io/v1beta1
+settings.k8s.io/v1alpha1
+storage.k8s.io/v1
+storage.k8s.io/v1beta1
+v1
+
+$ kubectl get po -n custom-metrics
+NAME                                        READY     STATUS    RESTARTS   AGE
+custom-metrics-apiserver-2956926076-wcgmw   1/1       Running   0          1h
+
+$ kubectl get --raw /apis/custom-metrics.metrics.k8s.io/v1alpha1
+{"kind":"APIResourceList","apiVersion":"v1","groupVersion":"custom-metrics.metrics.k8s.io/v1alpha1","resources":[]}
+```
+
+## Deploy a sample app
+
+Now we can deploy a sample app and sample HPA rule to do the autoscale with `http_requests` metric collected and exposed via Prometheus.
+
+```
+$ cat sample-metrics-app.yaml
+...
+---
+kind: HorizontalPodAutoscaler
+apiVersion: autoscaling/v2alpha1
+metadata:
+  name: sample-metrics-app-hpa
+spec:
+  scaleTargetRef:
+    kind: Deployment
+    name: sample-metrics-app
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+  - type: Object
+    object:
+      target:
+        kind: Service
+        name: sample-metrics-app
+      metricName: http_requests
+      targetValue: 100
+
+$ kubectl create -f sample-metrics-app.yaml
+deployment "sample-metrics-app" created
+service "sample-metrics-app" created
+servicemonitor "sample-metrics-app" created
+horizontalpodautoscaler "sample-metrics-app-hpa" created
+
+$ kubectl get hpa
+NAME                     REFERENCE                       TARGETS      MINPODS   MAXPODS   REPLICAS   AGE
+sample-metrics-app-hpa   Deployment/sample-metrics-app   866m / 100   2         10        2          1h
+```
+
+Try to increase some loads by hitting the sample app service, then you can see the HPA scales it up.
+
+
+## Further reading
+
+https://github.com/kubernetes/community/blob/master/contributors/design-proposals/custom-metrics-api.md
+https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#support-for-custom-metrics

--- a/manifests/autoscaling/custom-metrics.yaml
+++ b/manifests/autoscaling/custom-metrics.yaml
@@ -1,0 +1,144 @@
+kind: Namespace
+apiVersion: v1
+metadata:
+  name: custom-metrics
+---
+kind: ServiceAccount
+apiVersion: v1
+metadata:
+  name: custom-metrics-apiserver
+  namespace: custom-metrics
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: custom-metrics:system:auth-delegator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: system:auth-delegator
+subjects:
+- kind: ServiceAccount
+  name: custom-metrics-apiserver
+  namespace: custom-metrics
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: custom-metrics-auth-reader
+  namespace: kube-system
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: extension-apiserver-authentication-reader
+subjects:
+- kind: ServiceAccount
+  name: custom-metrics-apiserver
+  namespace: custom-metrics
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: custom-metrics-read
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - namespaces
+  - pods
+  - services
+  verbs:
+  - get
+  - list
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: custom-metrics-read
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: custom-metrics-read
+subjects:
+- kind: ServiceAccount
+  name: custom-metrics-apiserver
+  namespace: custom-metrics
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: custom-metrics-apiserver
+  namespace: custom-metrics
+  labels:
+    app: custom-metrics-apiserver
+spec:
+  replicas: 1
+  template:
+    metadata:
+      name: custom-metrics-apiserver
+      labels:
+        app: custom-metrics-apiserver
+    spec:
+      serviceAccountName: custom-metrics-apiserver
+      containers:
+      - name: custom-metrics-server
+        image: luxas/k8s-prometheus-adapter
+        args:
+        - --prometheus-url=http://sample-metrics-prom.default.svc:9090
+        - --metrics-relist-interval=30s
+        - --rate-interval=60s
+        - --v=10
+        - --logtostderr=true
+        ports:
+        - containerPort: 443
+        securityContext:
+          runAsUser: 0
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  namespace: custom-metrics
+spec:
+  ports:
+  - port: 443
+    targetPort: 443
+  selector:
+    app: custom-metrics-apiserver
+---
+apiVersion: apiregistration.k8s.io/v1beta1
+kind: APIService
+metadata:
+  name: v1alpha1.custom-metrics.metrics.k8s.io
+spec:
+  insecureSkipTLSVerify: true
+  group: custom-metrics.metrics.k8s.io
+  groupPriorityMinimum: 1000
+  versionPriority: 5
+  service:
+    name: api
+    namespace: custom-metrics
+  version: v1alpha1
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: custom-metrics-server-resources
+rules:
+- apiGroups:
+  - custom-metrics.metrics.k8s.io
+  resources: ["*"]
+  verbs: ["*"]
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: hpa-controller-custom-metrics
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: custom-metrics-server-resources
+subjects:
+- kind: ServiceAccount
+  name: horizontal-pod-autoscaler
+  namespace: kube-system

--- a/manifests/autoscaling/prometheus-operator.yaml
+++ b/manifests/autoscaling/prometheus-operator.yaml
@@ -1,0 +1,85 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: prometheus-operator
+rules:
+- apiGroups:
+  - extensions
+  resources:
+  - thirdpartyresources
+  verbs:
+  - create
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - alertmanagers
+  - prometheuses
+  - servicemonitors
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs: ["*"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - secrets
+  verbs: ["*"]
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["list", "delete"]
+- apiGroups: [""]
+  resources:
+  - services
+  - endpoints
+  verbs: ["get", "create", "update"]
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs: ["list", "watch"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus-operator
+subjects:
+- kind: ServiceAccount
+  name: prometheus-operator
+  namespace: default
+---
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  name: prometheus-operator
+  labels:
+    operator: prometheus
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        operator: prometheus
+    spec:
+      serviceAccountName: prometheus-operator
+      containers:
+       - name: prometheus-operator
+         image: luxas/prometheus-operator:v0.10.1
+         resources:
+           requests:
+             cpu: 100m
+             memory: 50Mi
+           limits:
+             cpu: 200m
+             memory: 100Mi

--- a/manifests/autoscaling/sample-metrics-app.yaml
+++ b/manifests/autoscaling/sample-metrics-app.yaml
@@ -49,7 +49,7 @@ kind: ServiceMonitor
 metadata:
   name: sample-metrics-app
   labels:
-    service-monitor: sample-metrics-app
+    service-monitor: function
 spec:
   selector:
     matchLabels:

--- a/manifests/autoscaling/sample-metrics-app.yaml
+++ b/manifests/autoscaling/sample-metrics-app.yaml
@@ -1,0 +1,77 @@
+apiVersion: apps/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    app: sample-metrics-app
+  name: sample-metrics-app
+spec:
+  replicas: 2
+  template:
+    metadata:
+      labels:
+        app: sample-metrics-app
+    spec:
+      containers:
+      - image: luxas/autoscale-demo:v0.1.2
+        name: sample-metrics-app
+        ports:
+        - name: web
+          containerPort: 8080
+        readinessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 5
+        livenessProbe:
+          httpGet:
+            path: /
+            port: 8080
+          initialDelaySeconds: 3
+          periodSeconds: 5
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sample-metrics-app
+  labels:
+    app: sample-metrics-app
+spec:
+  ports:
+  - name: web
+    port: 80
+    targetPort: 8080
+  selector:
+    app: sample-metrics-app
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: ServiceMonitor
+metadata:
+  name: sample-metrics-app
+  labels:
+    service-monitor: sample-metrics-app
+spec:
+  selector:
+    matchLabels:
+      app: sample-metrics-app
+  endpoints:
+  - port: web
+---
+kind: HorizontalPodAutoscaler
+apiVersion: autoscaling/v2alpha1
+metadata:
+  name: sample-metrics-app-hpa
+spec:
+  scaleTargetRef:
+    kind: Deployment
+    name: sample-metrics-app
+  minReplicas: 2
+  maxReplicas: 10
+  metrics:
+  - type: Object
+    object:
+      target:
+        kind: Service
+        name: sample-metrics-app
+      metricName: http_requests
+      targetValue: 100

--- a/manifests/autoscaling/sample-prometheus-instance.yaml
+++ b/manifests/autoscaling/sample-prometheus-instance.yaml
@@ -47,7 +47,7 @@ spec:
   serviceAccountName: prometheus
   serviceMonitorSelector:
     matchLabels:
-      service-monitor: sample-metrics-app
+      service-monitor: function
   resources:
     requests:
       memory: 300Mi

--- a/manifests/autoscaling/sample-prometheus-instance.yaml
+++ b/manifests/autoscaling/sample-prometheus-instance.yaml
@@ -1,0 +1,74 @@
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: prometheus
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - nodes
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: prometheus
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: prometheus
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: prometheus
+subjects:
+- kind: ServiceAccount
+  name: prometheus
+  namespace: default
+---
+apiVersion: monitoring.coreos.com/v1alpha1
+kind: Prometheus
+metadata:
+  name: sample-metrics-prom
+  labels:
+    app: sample-metrics-prom
+    prometheus: sample-metrics-prom
+spec:
+  replicas: 1
+  baseImage: prom/prometheus
+  version: v1.7.1
+  serviceAccountName: prometheus
+  serviceMonitorSelector:
+    matchLabels:
+      service-monitor: sample-metrics-app
+  resources:
+    requests:
+      memory: 300Mi
+  #storage:
+  #  resources:
+  #    requests:
+  #      storage: 3Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sample-metrics-prom
+  labels:
+    app: sample-metrics-prom
+    prometheus: sample-metrics-prom
+spec:
+  type: NodePort
+  ports:
+  - name: web
+    nodePort: 30999
+    port: 9090
+    targetPort: web
+  selector:
+    prometheus: sample-metrics-prom


### PR DESCRIPTION
These manifests worked in kubeadm-dind-cluster. They are also work in other k8s environments if the cluster configuration is set properly (kube-controller-manager and kube-apiserver)

cc/ @arapulido @sebgoa 