### PR TITLE
Added kube-lego support for ingress creation

### DIFF
--- a/cmd/kubeless/ingressCreate.go
+++ b/cmd/kubeless/ingressCreate.go
@@ -56,7 +56,7 @@ var ingressCreateCmd = &cobra.Command{
 			}
 		}
 
-		enableTlsAcme, err := cmd.Flags().GetBool("enableTlsAcme")
+		enableTLSAcme, err := cmd.Flags().GetBool("enableTLSAcme")
 		if err != nil {
 			logrus.Fatal(err)
 		}
@@ -76,7 +76,7 @@ var ingressCreateCmd = &cobra.Command{
 
 		client := utils.GetClientOutOfCluster()
 
-		err = utils.CreateIngress(client, ingressName, funcName, hostName, ns, enableTlsAcme)
+		err = utils.CreateIngress(client, ingressName, funcName, hostName, ns, enableTLSAcme)
 		if err != nil {
 			logrus.Fatalf("Can't create ingress route: %v", err)
 		}
@@ -97,5 +97,5 @@ func functionExists(tprClient rest.Interface, function, ns string) error {
 func init() {
 	ingressCreateCmd.Flags().StringP("hostname", "", "", "Specify a valid hostname for the function")
 	ingressCreateCmd.Flags().StringP("function", "", "", "Name of the function")
-	ingressCreateCmd.Flags().BoolP("enableTlsAcme", "", false, "If true, Ingress will be configured for use with kube-lego")
+	ingressCreateCmd.Flags().BoolP("enableTLSAcme", "", false, "If true, Ingress will be configured for use with kube-lego")
 }

--- a/cmd/kubeless/ingressCreate.go
+++ b/cmd/kubeless/ingressCreate.go
@@ -56,6 +56,11 @@ var ingressCreateCmd = &cobra.Command{
 			}
 		}
 
+		enableTlsAcme, err := cmd.Flags().GetBool("enableTlsAcme")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
 		tprClient, err := utils.GetTPRClientOutOfCluster()
 		if err != nil {
 			logrus.Fatal(err)
@@ -71,7 +76,7 @@ var ingressCreateCmd = &cobra.Command{
 
 		client := utils.GetClientOutOfCluster()
 
-		err = utils.CreateIngress(client, ingressName, funcName, hostName, ns)
+		err = utils.CreateIngress(client, ingressName, funcName, hostName, ns, enableTlsAcme)
 		if err != nil {
 			logrus.Fatalf("Can't create ingress route: %v", err)
 		}
@@ -92,4 +97,5 @@ func functionExists(tprClient rest.Interface, function, ns string) error {
 func init() {
 	ingressCreateCmd.Flags().StringP("hostname", "", "", "Specify a valid hostname for the function")
 	ingressCreateCmd.Flags().StringP("function", "", "", "Name of the function")
+	ingressCreateCmd.Flags().BoolP("enableTlsAcme", "", false, "If true, Ingress will be configured for use with kube-lego")
 }

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -775,7 +775,7 @@ func addInitContainerAnnotation(dpm *v1beta1.Deployment) error {
 }
 
 // CreateIngress creates ingress rule for a specific function
-func CreateIngress(client kubernetes.Interface, ingressName, funcName, hostname, ns string, enableTlsAcme bool) error {
+func CreateIngress(client kubernetes.Interface, ingressName, funcName, hostname, ns string, enableTLSAcme bool) error {
 
 	ingress := &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
@@ -804,7 +804,7 @@ func CreateIngress(client kubernetes.Interface, ingressName, funcName, hostname,
 		},
 	}
 
-	if enableTlsAcme {
+	if enableTLSAcme {
 		// add annotations and TLS configuration for kube-lego
 		ingressAnnotations := map[string]string{
 			"kubernetes.io/tls-acme":             "true",

--- a/pkg/utils/k8sutil_test.go
+++ b/pkg/utils/k8sutil_test.go
@@ -285,10 +285,10 @@ func doesNotContain(envs []v1.EnvVar, env v1.EnvVar) bool {
 
 func TestCreateIngressResource(t *testing.T) {
 	clientset := fake.NewSimpleClientset()
-	if err := CreateIngress(clientset, "foo", "bar", "foo.bar", "myns"); err != nil {
+	if err := CreateIngress(clientset, "foo", "bar", "foo.bar", "myns", false); err != nil {
 		t.Fatalf("Creating ingress returned err: %v", err)
 	}
-	if err := CreateIngress(clientset, "foo", "bar", "foo.bar", "myns"); err != nil {
+	if err := CreateIngress(clientset, "foo", "bar", "foo.bar", "myns", false); err != nil {
 		if !k8sErrors.IsAlreadyExists(err) {
 			t.Fatalf("Expect object is already exists, got %v", err)
 		}


### PR DESCRIPTION
Hi,

I'm playing around with `kubeless` on Google Container Engine. I came across the `kubeless ingress` subcommands, but the created Ingress misses configuration for `kube-lego`, which uses LetsEncrypt for adding certificates to Ingresses automatically. With this PR I'm adding a flag which triggers the needed configuration of the Ingress: `kubeless ingress create ... --enableTLSAcme`

Greetings,
Marc