### PR TITLE
ruby: adds event trigger support

### DIFF
--- a/docker/runtime/ruby-2.4/event-trigger/Dockerfile
+++ b/docker/runtime/ruby-2.4/event-trigger/Dockerfile
@@ -1,0 +1,11 @@
+FROM bitnami/ruby:2.4
+
+LABEL maintainer "Bitnami <containers@bitnami.com>"
+
+ENV RACK_ENV="production"
+
+RUN gem install sinatra ruby-kafka --no-rdoc --no-ri 
+
+ADD kubeless.rb /
+
+CMD ["ruby", "/kubeless.rb"]

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -65,24 +65,42 @@ post-ruby-verify:
 
 post: post-python post-nodejs post-ruby
 
-pubsub-34:
-	kubeless topic create pubsub
-	kubeless function deploy pubsub --trigger-topic pubsub --runtime python3.4 --handler pubsub.handler --from-file python/pubsub.py
-
-# Generate a random string to inject into pubsub topic,
-# then "tail -f" until it shows (with timeout)
-pubsub-verify-34:
-	$(eval DATA := $(shell mktemp -u -p entry -t XXXXXXXX))
-	kubeless topic publish --topic pubsub --data "$(DATA)"
-	bash -c 'grep -q "$(DATA)" <(timeout 60 kubectl logs -f $$(kubectl get po -oname|grep pubsub))'
-
-pubsub:
-	kubeless topic create s3
-	kubeless function deploy pubsub --trigger-topic s3 --runtime python2.7 --handler pubsub.handler --from-file python/pubsub.py
+pubsub-python:
+	kubeless topic create s3-python
+	kubeless function deploy pubsub-python --trigger-topic s3-python --runtime python2.7 --handler pubsub.handler --from-file python/pubsub.py
 
 # Generate a random string to inject into s3 topic,
 # then "tail -f" until it shows (with timeout)
-pubsub-verify:
+pubsub-python-verify:
 	$(eval DATA := $(shell mktemp -u -p entry -t XXXXXXXX))
-	kubeless topic publish --topic s3 --data "$(DATA)"
-	bash -c 'grep -q "$(DATA)" <(timeout 60 kubectl logs -f $$(kubectl get po -oname|grep pubsub))'
+	kubeless topic publish --topic s3-python --data "$(DATA)"
+	bash -c 'grep -q "$(DATA)" <(timeout 60 kubectl logs -f $$(kubectl get po -oname|grep pubsub-python))'
+
+pubsub-python34:
+	kubeless topic create s3-python34
+	kubeless function deploy pubsub-python34 --trigger-topic s3-python34 --runtime python3.4 --handler pubsub.handler --from-file python/pubsub.py
+
+pubsub-python34-verify:
+	$(eval DATA := $(shell mktemp -u -p entry -t XXXXXXXX))
+	kubeless topic publish --topic s3-python34 --data "$(DATA)"
+	bash -c 'grep -q "$(DATA)" <(timeout 60 kubectl logs -f $$(kubectl get po -oname|grep pubsub-python34))'
+
+pubsub-nodejs:
+	kubeless topic create s3-nodejs
+	kubeless function deploy pubsub-nodejs --trigger-topic s3-nodejs --runtime nodejs6 --handler pubsub.handler --from-file nodejs/helloevent.js
+
+pubsub-nodejs-verify:
+	$(eval DATA := $(shell mktemp -u -p entry -t XXXXXXXX))
+	kubeless topic publish --topic s3-nodejs --data "$(DATA)"
+	bash -c 'grep -q "$(DATA)" <(timeout 60 kubectl logs -f $$(kubectl get po -oname|grep pubsub-nodejs))'
+
+pubsub-ruby:
+	kubeless topic create s3-ruby
+	kubeless function deploy pubsub-ruby --trigger-topic s3-ruby --runtime ruby2.4 --handler pubsub.handler --from-file ruby/helloevent.rb
+
+pubsub-ruby-verify:
+	$(eval DATA := $(shell mktemp -u -p entry -t XXXXXXXX))
+	kubeless topic publish --topic s3-ruby --data "$(DATA)"
+	bash -c 'grep -q "$(DATA)" <(timeout 60 kubectl logs -f $$(kubectl get po -oname|grep pubsub-ruby))'
+
+post: pubsub-python pubsub-nodejs pubsub-ruby

--- a/examples/ruby/helloevent.rb
+++ b/examples/ruby/helloevent.rb
@@ -1,0 +1,3 @@
+def handler(request)
+  puts request
+end

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -60,7 +60,8 @@ const (
 	node6Pubsub    = "bitnami/kubeless-nodejs-event-consumer@sha256:b027bfef5f99c3be68772155a1feaf1f771ab9a3c7bb49bef2e939d6b766abec"
 	node8Http      = "bitnami/kubeless-nodejs@sha256:1eff2beae6fcc40577ada75624c3e4d3840a854588526cd8616d66f4e889dfe6"
 	node8Pubsub    = "bitnami/kubeless-nodejs-event-consumer@sha256:4d005c9c0b462750d9ab7f1305897e7a01143fe869d3b722ed3330560f9c7fb5"
-	ruby24Http     = "bitnami/kubeless-ruby@sha256:98e95c41652a7a0149421157c2dfb64b31e0d406b8c46c8bc89bd54e50f9898d"
+	ruby24Http     = "bitnami/kubeless-ruby@sha256:97b18ac36bb3aa9529231ea565b339ec00d2a5225cf7eb010cd5a6188cf72ab5"
+	ruby24Pubsub   = "bitnami/kubeless-ruby-event-consumer@sha256:938a860dbd9b7fb6b4338248a02c92279315c6e42eed0700128b925d3696b606"
 	busybox        = "busybox@sha256:be3c11fdba7cfe299214e46edc642e09514dbb9bbefcd0d3836c05a1e0cd0642"
 	pubsubFunc     = "PubSub"
 	schedFunc      = "Scheduled"
@@ -84,7 +85,7 @@ func init() {
 	node8 := runtimeVersion{runtimeID: "nodejs", version: "8", httpImage: node8Http, pubsubImage: node8Pubsub}
 	node = []runtimeVersion{node6, node8}
 
-	ruby24 := runtimeVersion{runtimeID: "ruby", version: "2.4", httpImage: ruby24Http, pubsubImage: ""}
+	ruby24 := runtimeVersion{runtimeID: "ruby", version: "2.4", httpImage: ruby24Http, pubsubImage: ruby24Pubsub}
 	ruby = []runtimeVersion{ruby24}
 }
 

--- a/script/libtest.bash
+++ b/script/libtest.bash
@@ -149,7 +149,7 @@ _wait_for_kubeless_kafka_server_ready() {
     echo_info "Waiting for kafka-0 to be ready ..."
     k8s_wait_for_pod_logline "Kafka.*Server.*started" -n kubeless kafka-0
     sleep 10
-    kubeless topic create "${test_topic}"
+    kubeless topic create "${test_topic}" || true
     _wait_for_kubeless_kafka_topic_ready "${test_topic}"
 }
 _wait_for_kubeless_kafka_topic_ready() {

--- a/tests/integration-tests.bats
+++ b/tests/integration-tests.bats
@@ -59,7 +59,13 @@ load ../script/libtest
 @test "Test function: get-python-metadata" {
   test_kubeless_function get-python-metadata
 }
-@test "Test function: pubsub" {
-  test_kubeless_function pubsub
+@test "Test function: pubsub-python" {
+  test_kubeless_function pubsub-python
+}
+@test "Test function: pubsub-nodejs" {
+  test_kubeless_function pubsub-nodejs
+}
+@test "Test function: pubsub-ruby" {
+  test_kubeless_function pubsub-ruby
 }
 # vim: ts=2 sw=2 si et syntax=sh


### PR DESCRIPTION
Adds the event-trigger implementation for the ruby 2.4 runtime. I've
modified the way the function is called, it now gets the Ruby class
name from the FUNC_NAME and loads that as a constant. If we want to
keep this as-is, I can undo that change.

I've also intentionally left out prometheus metrics, I think that can
be added from someone with more prometheus knowledge in a later PR.