### PR TITLE
Add "expose deployment" command (minikube only). Clean markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,9 +27,9 @@ Download `kubeless` cli from the [release page](https://github.com/kubeless/kube
 
 There are several kubeless manifests being shipped for multiple k8s environments (non-rbac, rbac and openshift), please consider to pick up the correct one:
 
-- `kubeless-$RELEASE.yaml` is used for non-RBAC Kubernetes cluster.
-- `kubeless-rbac-$RELEASE.yaml` is used for RBAC-enabled Kubernetes cluster.
-- `kubeless-openshift-$RELEASE.yaml` is used to deploy Kubeless to OpenShift (1.5+).
+* `kubeless-$RELEASE.yaml` is used for non-RBAC Kubernetes cluster.
+* `kubeless-rbac-$RELEASE.yaml` is used for RBAC-enabled Kubernetes cluster.
+* `kubeless-openshift-$RELEASE.yaml` is used to deploy Kubeless to OpenShift (1.5+).
 
 For example, this below is a show case of deploying kubeless to a non-RBAC Kubernetes cluster.
 
@@ -60,6 +60,15 @@ function.k8s.io   Kubeless: Serverless framework for Kubernetes   v1
 $ kubectl get functions
 ```
 
+Expose the node port for Kubeless Controller. For example, on minikube:
+
+```console
+$ kubectl expose deployment kubeless-controller --port=8080 \
+                                                --type=NodePort \
+                                                --namespace=kubeless
+service "kubeless-controller" exposed
+```
+
 You are now ready to create functions.
 
 ## Usage
@@ -81,7 +90,7 @@ def foobar(context):
 
 You create it with:
 
-```
+```console
 $ kubeless function deploy get-python --runtime python2.7 \
                                 --handler test.foobar \
                                 --from-file test.py \
@@ -98,7 +107,7 @@ get-python    Function.v1.k8s.io
 
 You can then call the function with:
 
-```
+```console
 $ kubeless function call get-python --data '{"echo": "echo echo"}'
 Connecting to function...
 Forwarding from 127.0.0.1:30000 -> 8080
@@ -109,7 +118,7 @@ Handling connection for 30000
 
 Or you can curl directly, for example (using minikube):
 
-```
+```console
 $ curl --data '{"Another": "Echo"}' $(minikube service get-python --url) --header "Content-Type:application/json"
 {"Another": "Echo"}
 ```
@@ -126,7 +135,7 @@ def foobar(context):
 
 You create it the same way than an _HTTP_ function except that you specify a `--trigger-topic`.
 
-```
+```console
 $ kubeless function deploy test --runtime python2.7 \
                                 --handler test.foobar \
                                 --from-file test.py \
@@ -137,14 +146,14 @@ $ kubeless function deploy test --runtime python2.7 \
 
 You can delete and list functions:
 
-```
+```console
 $ kubeless function delete <function_name>
 $ kubeless function ls
 ```
 
 You can create, list and delete PubSub topics:
 
-```
+```console
 $ kubeless topic create <topic_name>
 $ kubeless topic delete <topic_name>
 $ kubeless topic ls
@@ -160,22 +169,21 @@ Also checkout the [functions repository](https://github.com/kubeless/functions).
 
 ### Building with go
 
-- you need go v1.7+
-- if your working copy is not in your `GOPATH`, you need to set it accordingly.
-- we provided Makefile.
+* you need go v1.7+
+* if your working copy is not in your `GOPATH`, you need to set it accordingly.
+* we provided Makefile.
 
-```
+```console
 $ make binary
 ```
 
 You can build kubeless for multiple platforms with:
 
-```
+```console
 $ make binary-cross
 ```
 
 ## Comparison
-
 
 There are other solutions, like [fission](http://fission.io) and [funktion](https://github.com/fabric8io/funktion). There is also an incubating project at the ASF: [OpenWhisk](https://github.com/openwhisk/openwhisk). We believe however, that Kubeless is the most Kubernetes native of all.
 


### PR DESCRIPTION
Added `kubeless expose deployment` command that is needed before you can run `curl`.

Added `console` to the code sections and changed `-` to `*` for unordered lists to make [markdownlint](https://github.com/markdownlint/markdownlint) complain less.