### PR TITLE
Allow to use a custom npm scope and registry

### DIFF
--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -11,8 +11,19 @@ Each runtime is encapsulated in a container image. The reference to these images
 ## HTTP Trigger
 This variant is used when the function is meant to be triggered through HTTP. For doing so we use a web framework that is in charge of receiving request and redirect them to the function. This kind of trigger is supported for all the runtimes.
 
-### NodeJS HTTP Trigger
-For the NodeJS runtime we start an [Express](http://expressjs.com) server and we include the routes for serving the health check and exposing the monitoring metrics. Apart from that we enable [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS) requests and [Morgan](https://github.com/expressjs/morgan) for handling the logging in the server. Monitoring is supported if the function is synchronous or if it uses promises.
+### Node.js HTTP Trigger
+For the Node.js runtime we start an [Express](http://expressjs.com) server and we include the routes for serving the health check and exposing the monitoring metrics. Apart from that we enable [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS) requests and [Morgan](https://github.com/expressjs/morgan) for handling the logging in the server. Monitoring is supported if the function is synchronous or if it uses promises.
+
+When using the Node.js runtime, it is possible to configure a [custom registry or scope](https://docs.npmjs.com/misc/scope#associating-a-scope-with-a-registry) in case a function needs to install modules from a different source. For doing so it is necessary to set up the environment variables *NPM_REGISTRY* and *NPM_SCOPE* when deploying the function:
+```console
+$ kubeless function deploy myFunction --runtime nodejs6 \
+                                --env NPM_REGISTRY=http://my-registry.com \
+                                --env NPM_SCOPE=@myorg \
+                                --dependencies package.json \
+                                --handler test.foobar \
+                                --from-file test.js \
+                                --trigger-http
+```
 
 ### Python HTTP Trigger
 For python we use [Bottle](https://bottlepy.org) and we also add routes for health check and monitoring metrics.

--- a/pkg/utils/k8sutil_test.go
+++ b/pkg/utils/k8sutil_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/kubeless/kubeless/pkg/spec"
@@ -179,6 +180,7 @@ func TestEnsureK8sResources(t *testing.T) {
 	ns := "myns"
 	func1 := "foo1"
 	func2 := "foo2"
+	func3 := "foo3"
 
 	funcLabels := map[string]string{
 		"foo": "bar",
@@ -227,6 +229,42 @@ func TestEnsureK8sResources(t *testing.T) {
 								{
 									Name:  "foo",
 									Value: "bar",
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	f3 := &spec.Function{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Function",
+			APIVersion: "k8s.io/v1",
+		},
+		Metadata: metav1.ObjectMeta{
+			Name:      func3,
+			Namespace: ns,
+			Labels:    funcLabels,
+		},
+		Spec: spec.FunctionSpec{
+			Handler: "foo.bar",
+			Runtime: "nodejs6",
+			Deps:    "sample",
+			Template: v1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{},
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Env: []v1.EnvVar{
+								{
+									Name:  "NPM_REGISTRY",
+									Value: "http://my-registry.com",
+								},
+								{
+									Name:  "NPM_SCOPE",
+									Value: "@kubeless",
 								},
 							},
 						},
@@ -299,6 +337,17 @@ func TestEnsureK8sResources(t *testing.T) {
 		}
 	} else {
 		t.Errorf("Deployment annotation doesn't contain key bar")
+	}
+
+	if err := EnsureK8sResources(f3, clientset); err != nil {
+		t.Fatalf("Creating resources returned err: %v", err)
+	}
+	dpm, err = clientset.ExtensionsV1beta1().Deployments(ns).Get(func3, metav1.GetOptions{})
+	if len(dpm.Spec.Template.Spec.InitContainers) == 0 {
+		t.Errorf("Init container should be defined when dependencies are specified")
+	}
+	if match, _ := regexp.MatchString("npm config set @kubeless:registry http://my-registry.com", strings.Join(dpm.Spec.Template.Spec.InitContainers[0].Command, " ")); !match {
+		t.Errorf("Unable to set the NPM registry")
 	}
 }
 


### PR DESCRIPTION
This PR allows users to specify `--env NPM_SCOPE=@myorg` and `--env NPM_REGISTRY=http://myregistry.com` to specify custom scopes and registries when installing NPM modules.

Fixes #306