### PR TITLE
Fix PubSub example

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ Kubeless also supports [ingress](https://kubernetes.io/docs/concepts/services-ne
 
 ### PubSub function
 
-Messages need to be JSON messages. A function can be as simple as:
+A function can be as simple as:
 
 ```python
 def foobar(context):
@@ -142,6 +142,17 @@ $ kubeless function deploy test --runtime python2.7 \
                                 --handler test.foobar \
                                 --from-file test.py \
                                 --trigger-topic test-topic
+```
+
+After that you can invoke them publishing messages in that topic:
+```console
+$ kubeless topic publish --topic test-topic --data "Hello World!"
+```
+
+You can check the result in the pod logs:
+```console
+$ kubectl logs test-695251588-cxwmc
+Hello World!
 ```
 
 ### Other commands

--- a/README.md
+++ b/README.md
@@ -131,8 +131,8 @@ Messages need to be JSON messages. A function can be as simple as:
 
 ```python
 def foobar(context):
-    print context.json
-    return context.json
+    print context
+    return context
 ```
 
 You create it the same way than an _HTTP_ function except that you specify a `--trigger-topic`.


### PR DESCRIPTION
When publishing a message under a topic the function should read it as `context` not `context.json` since it is a string