### PR TITLE
Fix deployment recreation

### DIFF
--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -334,7 +334,7 @@ func DeleteK8sResources(ns, name string, client kubernetes.Interface) error {
 	}
 
 	// delete deployment
-	deletePolicy := metav1.DeletePropagationForeground
+	deletePolicy := metav1.DeletePropagationBackground
 	err = client.Extensions().Deployments(ns).Delete(name, &metav1.DeleteOptions{PropagationPolicy: &deletePolicy})
 	if err != nil && !k8sErrors.IsNotFound(err) {
 		return err

--- a/script/libtest.bash
+++ b/script/libtest.bash
@@ -137,7 +137,6 @@ kubeless_function_delete() {
     local func=${1:?}; shift
     echo_info "Deleting function "${func}" in case still present ... "
     kubeless function ls |grep -w "${func}" && kubeless function delete "${func}" >& /dev/null || true
-    kubectl delete all -l function="${func}" > /dev/null || true
     k8s_wait_for_pod_gone -l function="${func}"
 }
 kubeless_function_deploy() {


### PR DESCRIPTION
Use `DeletePropagationBackground` instead of `DeletePropagationForeground`.

This fixes #324 since the `Foreground` policy causes that after trying to recreate (delete + deploy), the controller tries to patch the deployment that is being terminated instead of creating a new one.

I checked that after deleting the function everything is cleaned up with the `Background` policy so this PR should not cause a regression regarding https://github.com/kubeless/kubeless/pull/279