### PR TITLE
Improve explanation of deploy command

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,7 @@ $ kubeless function deploy get-python --runtime python2.7 \
 
 Let's dissect the command:
  - `get-python`: This is the name of the function we want to deploy.
- - `--runtime python2.7`: This is the runtime we want to use to run our function.
+ - `--runtime python2.7`: This is the runtime we want to use to run our function. Available runtimes are shown in the help information.
  - `--from-file test.py`: This is the file containing the function code.
  - `--handler test.foobar`: This specifies the file and the exposed function that will be used when receiving requests. In this example we are using the function `foobar` from the file `test.py`.
  - `--trigger-http`: This sets the function trigger. The available options are:

--- a/README.md
+++ b/README.md
@@ -86,10 +86,22 @@ You create it with:
 
 ```console
 $ kubeless function deploy get-python --runtime python2.7 \
-                                --handler test.foobar \
                                 --from-file test.py \
+                                --handler test.foobar \
                                 --trigger-http
 ```
+
+Let's dissect the command:
+ - `get-python`: This is the name of the function we want to deploy.
+ - `--runtime python2.7`: This is the runtime we want to use to run our function.
+ - `--from-file test.py`: This is the file containing the function code.
+ - `--handler test.foobar`: This specifies the file and the exposed function that will be used when receiving requests. In this example we are using the function `foobar` from the file `test.py`.
+ - `--trigger-http`: This sets the function trigger. The available options are:
+   - `--trigger-http` to trigger the function using HTTP requests.
+   - `--trigger-topic` to trigger the function with a certain Kafka topic. See the [next example](#pubsub-function).
+   - `--schedule` to trigger the function following a certain schedule using Cron notation. F.e. `--schedule "*/10 * * * *"` would trigger the function every 10 minutes.
+
+You can find the rest of options available when deploying a function executing `kubeless function deploy --help`
 
 You will see the function custom resource created:
 

--- a/cmd/kubeless/deploy.go
+++ b/cmd/kubeless/deploy.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"strings"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/kubeless/kubeless/pkg/spec"
 	"github.com/kubeless/kubeless/pkg/utils"
@@ -174,7 +176,7 @@ var deployCmd = &cobra.Command{
 }
 
 func init() {
-	deployCmd.Flags().StringP("runtime", "", "", "Specify runtime")
+	deployCmd.Flags().StringP("runtime", "", "", "Specify runtime. Available runtimes are: "+strings.Join(utils.GetRuntimes(), ", "))
 	deployCmd.Flags().StringP("handler", "", "", "Specify handler")
 	deployCmd.Flags().StringP("from-file", "", "", "Specify code file")
 	deployCmd.Flags().StringSliceP("label", "", []string{}, "Specify labels of the function. Both separator ':' and '=' are allowed. For example: --label foo1=bar1,foo2:bar2")

--- a/cmd/kubeless/update.go
+++ b/cmd/kubeless/update.go
@@ -17,6 +17,8 @@ limitations under the License.
 package main
 
 import (
+	"strings"
+
 	"github.com/Sirupsen/logrus"
 	"github.com/kubeless/kubeless/pkg/spec"
 	"github.com/kubeless/kubeless/pkg/utils"
@@ -131,7 +133,7 @@ var updateCmd = &cobra.Command{
 }
 
 func init() {
-	updateCmd.Flags().StringP("runtime", "", "", "Specify runtime")
+	updateCmd.Flags().StringP("runtime", "", "", "Specify runtime. Available runtimes are: "+strings.Join(utils.GetRuntimes(), ", "))
 	updateCmd.Flags().StringP("handler", "", "", "Specify handler")
 	updateCmd.Flags().StringP("from-file", "", "", "Specify code file")
 	updateCmd.Flags().StringP("memory", "", "", "Request amount of memory for the function")

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -76,6 +76,7 @@ type runtimeVersion struct {
 }
 
 var python, node, ruby, dotnetcore []runtimeVersion
+var availableRuntimes [][]runtimeVersion
 
 func init() {
 	python27 := runtimeVersion{runtimeID: "python", version: "2.7", httpImage: python27Http, pubsubImage: python27Pubsub}
@@ -91,6 +92,19 @@ func init() {
 
 	dotnetcore2 := runtimeVersion{runtimeID: "dotnetcore", version: "2.0", httpImage: dotnetcore2Http, pubsubImage: ""}
 	dotnetcore = []runtimeVersion{dotnetcore2}
+
+	availableRuntimes = [][]runtimeVersion{python, node, ruby, dotnetcore}
+}
+
+// GetRuntimes returns the list of available runtimes as strings
+func GetRuntimes() []string {
+	result := []string{}
+	for _, languages := range availableRuntimes {
+		for _, runtime := range languages {
+			result = append(result, runtime.runtimeID+runtime.version)
+		}
+	}
+	return result
 }
 
 // GetClient returns a k8s clientset to the request from inside of cluster

--- a/pkg/utils/k8sutil_test.go
+++ b/pkg/utils/k8sutil_test.go
@@ -3,6 +3,7 @@ package utils
 import (
 	"os"
 	"regexp"
+	"strings"
 	"testing"
 
 	"github.com/kubeless/kubeless/pkg/spec"
@@ -392,5 +393,13 @@ func TestGetLocalHostname(t *testing.T) {
 
 	if expectedHostName != actualHostName {
 		t.Errorf("Expected %s but got %s", expectedHostName, actualHostName)
+	}
+}
+
+func TestGetRuntimes(t *testing.T) {
+	runtimes := strings.Join(GetRuntimes(), ", ")
+	expectedRuntimes := "python2.7, python3.4, nodejs6, nodejs8, ruby2.4, dotnetcore2.0"
+	if runtimes != expectedRuntimes {
+		t.Errorf("Expected %s but got %s", expectedRuntimes, runtimes)
 	}
 }


### PR DESCRIPTION
This PR elaborates the explanation of the command `function deploy` in the main README. Apart from that it shows the available runtimes when executing `function deploy|update --help`.

Fixes #281 