### PR TITLE
Avoid the need to scape characters when publishing messages

### DIFF
--- a/cmd/kubeless/topicPublish.go
+++ b/cmd/kubeless/topicPublish.go
@@ -43,12 +43,8 @@ var topicPublishCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
-		body := fmt.Sprintf(`echo %s > /tmp/msg.txt`, data)
+		body := fmt.Sprintf(`echo '%s' | /opt/bitnami/kafka/bin/kafka-console-producer.sh --broker-list localhost:9092 --topic %s`, data, topic)
 		command := []string{"bash", "-c", body}
-		execCommand(command, ctlNamespace)
-
-		body = fmt.Sprintf(`/opt/bitnami/kafka/bin/kafka-console-producer.sh --broker-list localhost:9092 --topic %s < /tmp/msg.txt`, topic)
-		command = []string{"bash", "-c", body}
 		execCommand(command, ctlNamespace)
 	},
 }

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -111,10 +111,9 @@ pubsub-nodejs:
 	kubeless function deploy pubsub-nodejs --trigger-topic s3-nodejs --runtime nodejs6 --handler pubsub.handler --from-file nodejs/helloevent.js
 
 pubsub-nodejs-verify:
-	$(eval RANDOM := $(shell mktemp -u -p entry -t XXXXXXXX))
-	$(eval DATA := {"test": "$(RANDOM)"})
-	kubeless topic publish --topic s3-nodejs --data '$(DATA)' 
-	bash -c 'grep -q \'$(DATA)\' <(timeout 60 kubectl logs -f $$(kubectl get po -oname|grep pubsub-nodejs))'
+	$(eval DATA := $(shell mktemp -u -p entry -t XXXXXXXX))
+	kubeless topic publish --topic s3-nodejs --data '{"test": "$(DATA)"}' 
+	bash -c 'grep -q "{\"test\": \"$(DATA)\"}" <(timeout 60 kubectl logs -f $$(kubectl get po -oname|grep pubsub-nodejs))'
 
 pubsub-ruby:
 	kubeless topic create s3-ruby

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -111,9 +111,10 @@ pubsub-nodejs:
 	kubeless function deploy pubsub-nodejs --trigger-topic s3-nodejs --runtime nodejs6 --handler pubsub.handler --from-file nodejs/helloevent.js
 
 pubsub-nodejs-verify:
-	$(eval DATA := $(shell mktemp -u -p entry -t XXXXXXXX))
-	kubeless topic publish --topic s3-nodejs --data "$(DATA)"
-	bash -c 'grep -q "$(DATA)" <(timeout 60 kubectl logs -f $$(kubectl get po -oname|grep pubsub-nodejs))'
+	$(eval RANDOM := $(shell mktemp -u -p entry -t XXXXXXXX))
+	$(eval DATA := {"test": "$(RANDOM)"})
+	kubeless topic publish --topic s3-nodejs --data '$(DATA)' 
+	bash -c 'grep -q '$(DATA)' <(timeout 60 kubectl logs -f $$(kubectl get po -oname|grep pubsub-nodejs))'
 
 pubsub-ruby:
 	kubeless topic create s3-ruby

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -114,7 +114,7 @@ pubsub-nodejs-verify:
 	$(eval RANDOM := $(shell mktemp -u -p entry -t XXXXXXXX))
 	$(eval DATA := {"test": "$(RANDOM)"})
 	kubeless topic publish --topic s3-nodejs --data '$(DATA)' 
-	bash -c 'grep -q '$(DATA)' <(timeout 60 kubectl logs -f $$(kubectl get po -oname|grep pubsub-nodejs))'
+	bash -c 'grep -q \'$(DATA)\' <(timeout 60 kubectl logs -f $$(kubectl get po -oname|grep pubsub-nodejs))'
 
 pubsub-ruby:
 	kubeless topic create s3-ruby


### PR DESCRIPTION
It also simplifies the way messages are published. Fixes #333

Ensured with an integration test.