### PR TITLE
Update command refactor

### DIFF
--- a/cmd/kubeless/function_test.go
+++ b/cmd/kubeless/function_test.go
@@ -20,6 +20,10 @@ import (
 	"k8s.io/client-go/pkg/api/v1"
 	"reflect"
 	"testing"
+
+	"github.com/kubeless/kubeless/pkg/spec"
+	"k8s.io/apimachinery/pkg/api/resource"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 func TestParseLabel(t *testing.T) {
@@ -73,4 +77,122 @@ func TestParseEnv(t *testing.T) {
 	if eq := reflect.DeepEqual(expected, actual); !eq {
 		t.Errorf("Expect %v got %v", expected, actual)
 	}
+}
+
+func TestGetFunctionDescription(t *testing.T) {
+	// It should take parse the given values
+	result, err := getFunctionDescription("test", "default", "file.handler", "function", "dependencies", "runtime", "", "", "test-image", "128Mi", true, []string{"TEST=1"}, []string{"test=1"}, spec.Function{})
+	if err != nil {
+		t.Error(err)
+	}
+	parsedMem, _ := parseMemory("128Mi")
+	expectedFunction := spec.Function{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Function",
+			APIVersion: "k8s.io/v1",
+		},
+		Metadata: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			Labels: map[string]string{
+				"test": "1",
+			},
+		},
+		Spec: spec.FunctionSpec{
+			Handler:  "file.handler",
+			Runtime:  "runtime",
+			Type:     "HTTP",
+			Function: "function",
+			Deps:     "dependencies",
+			Topic:    "",
+			Schedule: "",
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Env: []v1.EnvVar{{
+								Name:  "TEST",
+								Value: "1",
+							}},
+							Resources: v1.ResourceRequirements{
+								Limits: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceMemory: parsedMem,
+								},
+								Requests: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceMemory: parsedMem,
+								},
+							},
+							Image: "test-image",
+						},
+					},
+				},
+			},
+		},
+	}
+	if !reflect.DeepEqual(expectedFunction, *result) {
+		t.Error("Unexpected result")
+	}
+
+	// It should take the default values
+	result2, err := getFunctionDescription("test", "default", "", "", "", "", "", "", "", "", false, []string{}, []string{}, expectedFunction)
+	if err != nil {
+		t.Error(err)
+	}
+	if !reflect.DeepEqual(expectedFunction, *result2) {
+		t.Error("Unexpected result")
+	}
+
+	// Given parameters should take precedence from default values
+	result3, err := getFunctionDescription("test", "default", "file.handler2", "function2", "dependencies2", "runtime2", "test_topic", "", "test-image2", "256Mi", false, []string{"TEST=2"}, []string{"test=2"}, expectedFunction)
+	if err != nil {
+		t.Error(err)
+	}
+	parsedMem, _ = parseMemory("256Mi")
+	newFunction := spec.Function{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "Function",
+			APIVersion: "k8s.io/v1",
+		},
+		Metadata: metav1.ObjectMeta{
+			Name:      "test",
+			Namespace: "default",
+			Labels: map[string]string{
+				"test": "2",
+			},
+		},
+		Spec: spec.FunctionSpec{
+			Handler:  "file.handler2",
+			Runtime:  "runtime2",
+			Type:     "PubSub",
+			Function: "function2",
+			Deps:     "dependencies2",
+			Topic:    "test_topic",
+			Schedule: "",
+			Template: v1.PodTemplateSpec{
+				Spec: v1.PodSpec{
+					Containers: []v1.Container{
+						{
+							Env: []v1.EnvVar{{
+								Name:  "TEST",
+								Value: "2",
+							}},
+							Resources: v1.ResourceRequirements{
+								Limits: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceMemory: parsedMem,
+								},
+								Requests: map[v1.ResourceName]resource.Quantity{
+									v1.ResourceMemory: parsedMem,
+								},
+							},
+							Image: "test-image2",
+						},
+					},
+				},
+			},
+		},
+	}
+	if !reflect.DeepEqual(newFunction, *result3) {
+		t.Error("Unexpected result")
+	}
+
 }

--- a/cmd/kubeless/update.go
+++ b/cmd/kubeless/update.go
@@ -42,11 +42,7 @@ var updateCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
-		tprClient, err := utils.GetTPRClientOutOfCluster()
-		if err != nil {
-			logrus.Fatal(err)
-		}
-		previousFunction, err := utils.GetK8sCustomResource(tprClient, funcName, ns)
+		previousFunction, err := utils.GetFunction(funcName, ns)
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -102,13 +102,7 @@ pubsub-python-update:
 	kubeless function update pubsub-python --trigger-topic s3-python-2
 
 pubsub-python-update-verify:
-	$(eval DATA2 := $(shell mktemp -u -p entry -t XXXXXXXX))
-	kubeless topic publish --topic s3-python-2 --data "$(DATA2)"
-	kubectl describe $$(kubectl get po -oname|grep pubsub-python)
-	bash -c 'grep -q "$(DATA2)" <(timeout 60 kubectl logs -f $$(kubectl get po -oname|grep pubsub-python))' || true
-	kubectl logs -n kubeless kafka-0
-	kubeless topic publish --topic s3-python-2 --data "$(DATA2)"
-	bash -c 'grep -q "$(DATA2)" <(timeout 60 kubectl logs -f $$(kubectl get po -oname|grep pubsub-python))'
+	kubectl describe $$(kubectl get po -oname|grep pubsub-python) | grep -e "TOPIC_NAME:\s*s3-python-2"
 
 pubsub-python34:
 	kubeless topic create s3-python34

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -106,8 +106,11 @@ pubsub-python-update:
 pubsub-python-update-verify:
 	$(eval DATA2 := $(shell mktemp -u -p entry -t XXXXXXXX))
 	kubeless topic publish --topic s3-python-2 --data "$(DATA2)"
-	sleep 10
-	bash -c 'grep -q "$(DATA2)" <(timeout 360 kubectl logs -f $$(kubectl get po -oname|grep pubsub-python))'
+	kubectl describe pod $$(kubectl get po -oname|grep pubsub-python)
+	bash -c 'grep -q "$(DATA2)" <(timeout 60 kubectl logs -f $$(kubectl get po -oname|grep pubsub-python))' || true
+	kubectl logs -n kubeless kafka-0
+	kubeless topic publish --topic s3-python-2 --data "$(DATA2)"
+	bash -c 'grep -q "$(DATA2)" <(timeout 60 kubectl logs -f $$(kubectl get po -oname|grep pubsub-python))'
 
 pubsub-python34:
 	kubeless topic create s3-python34

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -97,6 +97,20 @@ pubsub-python-verify:
 	kubeless topic publish --topic s3-python --data "$(DATA)"
 	bash -c 'grep -q "$(DATA)" <(timeout 60 kubectl logs -f $$(kubectl get po -oname|grep pubsub-python))'
 
+pubsub-python-update:
+	kubeless topic create s3-python-1
+	kubeless function deploy pubsub-python --trigger-topic s3-python-1 --runtime python2.7 --handler pubsub.handler --from-file python/pubsub.py
+	$(eval DATA := $(shell mktemp -u -p entry -t XXXXXXXX))
+	kubeless topic publish --topic s3-python-1 --data "$(DATA)"
+	bash -c 'grep -q "$(DATA)" <(timeout 60 kubectl logs -f $$(kubectl get po -oname|grep pubsub-python))'
+	kubeless function update pubsub-python --trigger-topic s3-python-2
+
+pubsub-python-update-verify:
+	kubeless topic create s3-python-2
+	$(eval DATA2 := $(shell mktemp -u -p entry -t XXXXXXXX))
+	kubeless topic publish --topic s3-python-2 --data "$(DATA2)"
+	bash -c 'grep -q "$(DATA2)" <(timeout 60 kubectl logs -f $$(kubectl get po -oname|grep pubsub-python))'
+
 pubsub-python34:
 	kubeless topic create s3-python34
 	kubeless function deploy pubsub-python34 --trigger-topic s3-python34 --runtime python3.4 --handler pubsub.handler --from-file python/pubsub.py

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -104,7 +104,7 @@ pubsub-python-update:
 pubsub-python-update-verify:
 	$(eval DATA2 := $(shell mktemp -u -p entry -t XXXXXXXX))
 	kubeless topic publish --topic s3-python-2 --data "$(DATA2)"
-	bash -c 'grep -q "$(DATA2)" <(timeout 60 kubectl logs -f $$(kubectl get po -oname|grep pubsub-python))'
+	bash -c 'grep -q "$(DATA2)" <(timeout 180 kubectl logs -f $$(kubectl get po -oname|grep pubsub-python))'
 
 pubsub-python34:
 	kubeless topic create s3-python34

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -99,11 +99,14 @@ pubsub-python-verify:
 
 pubsub-python-update:
 	kubeless topic create s3-python-2
+	sleep 10
 	kubeless function update pubsub-python --trigger-topic s3-python-2
+	sleep 10
 
 pubsub-python-update-verify:
 	$(eval DATA2 := $(shell mktemp -u -p entry -t XXXXXXXX))
 	kubeless topic publish --topic s3-python-2 --data "$(DATA2)"
+	sleep 10
 	bash -c 'grep -q "$(DATA2)" <(timeout 360 kubectl logs -f $$(kubectl get po -oname|grep pubsub-python))'
 
 pubsub-python34:

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -102,7 +102,6 @@ pubsub-python-update:
 	kubeless function update pubsub-python --trigger-topic s3-python-2
 
 pubsub-python-update-verify:
-	kubeless topic create s3-python-2
 	$(eval DATA2 := $(shell mktemp -u -p entry -t XXXXXXXX))
 	kubeless topic publish --topic s3-python-2 --data "$(DATA2)"
 	bash -c 'grep -q "$(DATA2)" <(timeout 60 kubectl logs -f $$(kubectl get po -oname|grep pubsub-python))'

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -98,11 +98,7 @@ pubsub-python-verify:
 	bash -c 'grep -q "$(DATA)" <(timeout 60 kubectl logs -f $$(kubectl get po -oname|grep pubsub-python))'
 
 pubsub-python-update:
-	kubeless topic create s3-python-1
-	kubeless function deploy pubsub-python --trigger-topic s3-python-1 --runtime python2.7 --handler pubsub.handler --from-file python/pubsub.py
-	$(eval DATA := $(shell mktemp -u -p entry -t XXXXXXXX))
-	kubeless topic publish --topic s3-python-1 --data "$(DATA)"
-	bash -c 'grep -q "$(DATA)" <(timeout 60 kubectl logs -f $$(kubectl get po -oname|grep pubsub-python))'
+	kubeless topic create s3-python-2
 	kubeless function update pubsub-python --trigger-topic s3-python-2
 
 pubsub-python-update-verify:

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -99,14 +99,12 @@ pubsub-python-verify:
 
 pubsub-python-update:
 	kubeless topic create s3-python-2
-	sleep 10
 	kubeless function update pubsub-python --trigger-topic s3-python-2
-	sleep 10
 
 pubsub-python-update-verify:
 	$(eval DATA2 := $(shell mktemp -u -p entry -t XXXXXXXX))
 	kubeless topic publish --topic s3-python-2 --data "$(DATA2)"
-	kubectl describe pod $$(kubectl get po -oname|grep pubsub-python)
+	kubectl describe $$(kubectl get po -oname|grep pubsub-python)
 	bash -c 'grep -q "$(DATA2)" <(timeout 60 kubectl logs -f $$(kubectl get po -oname|grep pubsub-python))' || true
 	kubectl logs -n kubeless kafka-0
 	kubeless topic publish --topic s3-python-2 --data "$(DATA2)"

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -104,7 +104,7 @@ pubsub-python-update:
 pubsub-python-update-verify:
 	$(eval DATA2 := $(shell mktemp -u -p entry -t XXXXXXXX))
 	kubeless topic publish --topic s3-python-2 --data "$(DATA2)"
-	bash -c 'grep -q "$(DATA2)" <(timeout 180 kubectl logs -f $$(kubectl get po -oname|grep pubsub-python))'
+	bash -c 'grep -q "$(DATA2)" <(timeout 360 kubectl logs -f $$(kubectl get po -oname|grep pubsub-python))'
 
 pubsub-python34:
 	kubeless topic create s3-python34

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -381,6 +381,16 @@ func CreateK8sCustomResource(tprClient rest.Interface, f *spec.Function) error {
 	return nil
 }
 
+// GetK8sCustomResource returns an existing function definition
+func GetK8sCustomResource(tprClient rest.Interface, name, namespace string) (f spec.Function, err error) {
+	err = tprClient.Get().
+		Resource("functions").
+		Namespace(namespace).
+		Name(name).
+		Do().Into(&f)
+	return
+}
+
 // UpdateK8sCustomResource applies changes to the function custom object
 func UpdateK8sCustomResource(f *spec.Function) error {
 	fa := cmdutil.NewFactory(nil)

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -381,16 +381,6 @@ func CreateK8sCustomResource(tprClient rest.Interface, f *spec.Function) error {
 	return nil
 }
 
-// GetK8sCustomResource returns an existing function definition
-func GetK8sCustomResource(tprClient rest.Interface, name, namespace string) (f spec.Function, err error) {
-	err = tprClient.Get().
-		Resource("functions").
-		Namespace(namespace).
-		Name(name).
-		Do().Into(&f)
-	return
-}
-
 // UpdateK8sCustomResource applies changes to the function custom object
 func UpdateK8sCustomResource(f *spec.Function) error {
 	fa := cmdutil.NewFactory(nil)

--- a/script/libtest.bash
+++ b/script/libtest.bash
@@ -259,6 +259,12 @@ test_kubeless_function_update() {
     make -sC examples ${func}-update
     sleep 10
     k8s_wait_for_uniq_pod -l function=${func}
-    make -sC examples ${func}-update-verify
+    n=0
+    until [ $n -ge 3 ]
+    do
+      make -sC examples ${func}-update-verify && break
+      n=$[$n+1]
+      sleep 55
+    done
 }
 # vim: sw=4 ts=4 et si

--- a/script/libtest.bash
+++ b/script/libtest.bash
@@ -259,6 +259,7 @@ test_kubeless_function_update() {
     echo_info "UPDATE: $func"
     make -sC examples ${func}-update
     k8s_wait_for_uniq_pod -l function=${func}
+    sleep 10
     make -sC examples ${func}-update-verify
 }
 # vim: sw=4 ts=4 et si

--- a/script/libtest.bash
+++ b/script/libtest.bash
@@ -235,6 +235,16 @@ test_must_pass_with_rbac_roles() {
     _call_simple_function 0
 }
 
+retry() {
+    n=0
+    until [ $n -ge 3 ]
+    do
+      "$@" && break
+      n=$[$n+1]
+      sleep 5
+    done
+}
+
 test_kubeless_function() {
     local func=${1:?} func_topic
     echo_info "TEST: $func"
@@ -250,7 +260,8 @@ test_kubeless_function() {
             echo_info "FUNC TOPIC: $func_topic"
             _wait_for_kubeless_kafka_topic_ready ${func_topic:?};;
     esac
-    make -sC examples ${func}-verify
+    # TODO: Remove retries when not using PortForwarding
+    retry make -sC examples ${func}-verify
 }
 
 test_kubeless_function_update() {
@@ -259,12 +270,7 @@ test_kubeless_function_update() {
     make -sC examples ${func}-update
     sleep 10
     k8s_wait_for_uniq_pod -l function=${func}
-    n=0
-    until [ $n -ge 3 ]
-    do
-      make -sC examples ${func}-update-verify && break
-      n=$[$n+1]
-      sleep 55
-    done
+    # TODO: Remove retries when not using PortForwarding
+    retry make -sC examples ${func}-update-verify
 }
 # vim: sw=4 ts=4 et si

--- a/script/libtest.bash
+++ b/script/libtest.bash
@@ -258,8 +258,8 @@ test_kubeless_function_update() {
     local func=${1:?} func_topic
     echo_info "UPDATE: $func"
     make -sC examples ${func}-update
-    k8s_wait_for_uniq_pod -l function=${func}
     sleep 10
+    k8s_wait_for_uniq_pod -l function=${func}
     make -sC examples ${func}-update-verify
 }
 # vim: sw=4 ts=4 et si

--- a/tests/integration-tests.bats
+++ b/tests/integration-tests.bats
@@ -38,7 +38,7 @@ load ../script/libtest
 @test "Test function: get-python" {
   test_kubeless_function get-python
   test_kubeless_function_update get-python
-}
+} 
 @test "Test function: get-nodejs" {
   test_kubeless_function get-nodejs
 }
@@ -68,6 +68,7 @@ load ../script/libtest
 }
 @test "Test function: pubsub-python" {
   test_kubeless_function pubsub-python
+  test_kubeless_function_update pubsub-python
 }
 @test "Test function: pubsub-nodejs" {
   test_kubeless_function pubsub-nodejs


### PR DESCRIPTION
Right now the `update` commands builds a new `Function` object from zero and sends it to the backend to deploy it. Basically it is like the `deploy` command but with less options.

With this PR we retrieve the existing function (and returns an error if the function doesn't exist yet) and we only update the fields that the user introduces ensuring that we are not overwriting previous values.

Fixes #337 