### PR TITLE
Remove unused platforms

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,10 +2,8 @@ language: go
 
 os:
   - linux
-  - osx
 
 go:
-  - 1.7
   - 1.8.3
 
 go_import_path: github.com/kubeless/kubeless
@@ -50,10 +48,8 @@ script:
 
 after_success:
   - |
-    if [[ "$TRAVIS_OS_NAME" == linux && \
-          "$TRAVIS_BRANCH" == master && \
-          "$TRAVIS_PULL_REQUEST" == false && \
-          "$TRAVIS_GO_VERSION" == 1.8.3 ]]; then
+    if [[ "$TRAVIS_BRANCH" == master && \
+          "$TRAVIS_PULL_REQUEST" == false ]]; then
       docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
       docker tag $CONTROLLER_IMAGE ${CONTROLLER_IMAGE_NAME}:latest
       docker push ${CONTROLLER_IMAGE_NAME}:latest
@@ -88,6 +84,4 @@ deploy:
   on:
     tags: true
     repo: kubeless/kubeless
-    go: 1.8.3
-    os: linux
     condition: $CGO_ENABLED = 0

--- a/script/binary-cli
+++ b/script/binary-cli
@@ -16,7 +16,7 @@
 
 set -e
 
-OS_PLATFORM_ARG=(-os="linux")
+OS_PLATFORM_ARG=(-os="darwin linux windows")
 OS_ARCH_ARG=(-arch="amd64")
 
 if [ -z "$1" ]; then

--- a/script/binary-cli
+++ b/script/binary-cli
@@ -16,8 +16,8 @@
 
 set -e
 
-OS_PLATFORM_ARG=(-os="darwin linux windows")
-OS_ARCH_ARG=(-arch="386 amd64")
+OS_PLATFORM_ARG=(-os="linux")
+OS_ARCH_ARG=(-arch="amd64")
 
 if [ -z "$1" ]; then
     VERSION=dev-$(shell date +%FT%T%z)

--- a/script/binary-cli
+++ b/script/binary-cli
@@ -17,7 +17,7 @@
 set -e
 
 OS_PLATFORM_ARG=(-os="darwin linux windows")
-OS_ARCH_ARG=(-arch="amd64")
+OS_ARCH_ARG=(-arch="386 amd64")
 
 if [ -z "$1" ]; then
     VERSION=dev-$(shell date +%FT%T%z)

--- a/script/binary-controller
+++ b/script/binary-controller
@@ -18,13 +18,13 @@ set -e
 
 if [ -z "$1" ]; then
 #    TODO: Skip windows at this moment
-    OS_PLATFORM_ARG=(-os="darwin linux")
+    OS_PLATFORM_ARG=(-os="linux")
 else
     OS_PLATFORM_ARG=($1)
 fi
 
 if [ -z "$2" ]; then
-    OS_ARCH_ARG=(-arch="386 amd64")
+    OS_ARCH_ARG=(-arch="amd64")
 else
     OS_ARCH_ARG=($2)
 fi


### PR DESCRIPTION
Remove the builds for OS X, Go 1.7 and 386 binaries since they are not being used.

Fixes #343 