### PR TITLE
Auto generate release notes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,7 @@ before_deploy:
       sed 's/'"$OLD_DIGEST"'/'"@$NEW_DIGEST"'/g' kubeless-rbac.yaml > kubeless-rbac-${TRAVIS_TAG}.yaml
       sed 's/'"$OLD_DIGEST"'/'"@$NEW_DIGEST"'/g' kubeless-openshift.yaml > kubeless-openshift-${TRAVIS_TAG}.yaml
     fi
+  - export RELEASE_NOTES=$(./scripts/release_notes.sh $TRAVIS_TAG)
 
 deploy:
   provider: releases
@@ -85,6 +86,8 @@ deploy:
     - bundles/kubeless_*.zip
   skip_cleanup: true
   overwrite: true
+  body: "${RELEASE_NOTES}"
+  draft: true
   on:
     tags: true
     repo: kubeless/kubeless

--- a/script/release_notes.sh
+++ b/script/release_notes.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+set -e
+
+REPO_NAME=kubeless
+REPO_DOMAIN=kubeless
+
+function check_tag {
+  local tag=$1
+  published_tags=`curl -s https://api.github.com/repos/$REPO_DOMAIN/$REPO_NAME/tags`
+  already_published=`echo $published_tags | jq ".[] | select(.name == \"$tag\")"`
+  echo $already_published
+}
+
+function commit_list {
+  local tag=$1
+  git fetch --tags
+  local last_tag=`curl -s https://api.github.com/repos/$REPO_DOMAIN/$REPO_NAME/tags | jq --raw-output '.[0].name'`
+  local release_notes=`git log $last_tag..HEAD --oneline`
+  local parsed_release_notes=$(echo "$release_notes" | sed -n -e 'H;${x;s/\n/\\n- /g;s/^\\n//;p;}')
+  echo $parsed_release_notes
+}
+
+if [[ -z "$REPO_NAME" || -z "$REPO_DOMAIN" ]]; then
+  echo "Github repository not specified" > /dev/stderr
+  exit 1
+fi
+
+repo_check=`curl -s https://api.github.com/repos/$REPO_DOMAIN/$REPO_NAME`
+if [[ $repo_check == *"Not Found"* ]]; then
+  echo "Not found a Github repository for $REPO_DOMAIN/$REPO_NAME, it is not possible to publish it" > /dev/stderr
+  exit 1
+else
+  tag=$1
+  already_published=`check_tag $tag`
+  if [[ -z $already_published ]]; then
+    commits=`commit_list $tag`
+    notes=$(cat << EOF
+This release includes the following commits and features:\n
+$commits\n
+To install this latest version, use the manifest that is part of the release:
+
+**NO RBAC:**
+
+\`\`\`console
+kubectl create ns kubeless
+curl -sL https://github.com/kubeless/kubeless/releases/download/$tag/kubeless-$tag.yaml | kubectl create -f -
+\`\`\`
+
+**WITH RBAC ENABLED:**
+
+\`\`\`console
+kubectl create ns kubeless
+curl -sL https://github.com/kubeless/kubeless/releases/download/$tag/kubeless-rbac-$tag.yaml | kubectl create -f -
+\`\`\`
+EOF)
+    echo -e "${notes}"
+  else
+    echo "Unable to produce relase notes since $tag was already released"
+    exit 1
+  fi
+fi


### PR DESCRIPTION
This PR changes the release process to:
 - Create a draft instead of directly releasing a new version
 - Auto generate the release notes with the commits/PR included in the release

Eg. For the version 0.2.2 it will generate the message (note that the commit list should be purged to avoid useless info):

---------
This release include the following commits and features:

- ae5437d0 Update command refactor (#340)
- d922f447 Adding contributing documentation (#346)
- abb6223d Add support for custom runtime images in CLI (#323)
- ec6e5385 Merge pull request #332 from andresmgot/deploymentRemoval
- 6c26babf Merge pull request #316 from arjunrao87/pr/multi-env-vars
- 5e1736e0 Merge pull request #338 from andresmgot/quotes
- 8f6a84e0 Fix test
- db8391f9 Allow to use a custom npm scope and registry (#328)
- bb5c78c3 Scape quotes
- 0688218c Avoid the need to scape characters when publishing messages
- 5228eacd Update README.md
- c5caba93 Improve explanation of deploy command (#336)
- e4be8f53 Print parsed dependencies (#335)
- 3098cffb Don't force pod removal to test kubeless behavior
- 46d82573 Improve Minio examples documentation (#331)
- 25d62967 Merging tests back into function_test
- e46a5d64 Updating deploy_test, reverting function_test changes and adding update_test
- 9c8d3875 Merge branch 'pr/multi-env-vars' of https://github.com/arjunrao87/kubeless into pr/multi-env-vars
- 8938530a Adding test cases for PR
- 8bc484b6 Fix deployment recreation
- 5dc47fa9 Merge pull request #329 from kubeless/readme-fix
- 3f2dc7a1 Reverting changes to label flags
- 721be249 Complete PubSub example
- 56bd9056 Fix PubSub example
- c0b3ec32 Updating WIP to include labels change to multival too
- a985ec81 Merge pull request #269 from ngtuna/autoscaling-cm
- 33da0158 WIP : Adding multivalue env variable capability
- 9278c597 edit label
- 5ac4ca12 add autoscaling manifests

To install this latest version, use the manifest that is part of the release:
**NO RBAC:**

```console
kubectl create ns kubeless
curl -sL https://github.com/kubeless/kubeless/releases/download/v0.2.2/kubeless-v0.2.2.yaml | kubectl create -f -
```

**WITH RBAC ENABLED:**

```console
kubectl create ns kubeless
curl -sL https://github.com/kubeless/kubeless/releases/download/v0.2.2/kubeless-rbac-v0.2.2.yaml | kubectl create -f -
```

------