### PR TITLE
Update fix

### DIFF
--- a/cmd/kubeless/update.go
+++ b/cmd/kubeless/update.go
@@ -121,7 +121,7 @@ func init() {
 	updateCmd.Flags().StringSliceP("label", "", []string{}, "Specify labels of the function")
 	updateCmd.Flags().StringArrayP("env", "", []string{}, "Specify environment variable of the function")
 	updateCmd.Flags().StringP("namespace", "", api.NamespaceDefault, "Specify namespace for the function")
-	updateCmd.Flags().StringP("trigger-topic", "", "kubeless", "Deploy a pubsub function to Kubeless")
+	updateCmd.Flags().StringP("trigger-topic", "", "", "Deploy a pubsub function to Kubeless")
 	updateCmd.Flags().StringP("schedule", "", "", "Specify schedule in cron format for scheduled function")
 	updateCmd.Flags().Bool("trigger-http", false, "Deploy a http-based function to Kubeless")
 	updateCmd.Flags().StringP("runtime-image", "", "", "Custom runtime image")

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -6,7 +6,7 @@ get-python-verify:
 	kubeless function call get-python |egrep hello.world
 
 get-python-update:
-	printf 'def foo():\n%4sreturn "hello world updated"\n' | kubeless function update get-python --runtime python2.7 --handler helloget.foo --from-file /dev/stdin
+	printf 'def foo():\n%4sreturn "hello world updated"\n' | kubeless function update get-python --from-file /dev/stdin
 	echo "curl localhost:8080/api/v1/proxy/namespaces/default/services/get-python/"
 
 get-python-update-verify:

--- a/script/libtest.bash
+++ b/script/libtest.bash
@@ -235,16 +235,6 @@ test_must_pass_with_rbac_roles() {
     _call_simple_function 0
 }
 
-retry() {
-    n=0
-    until [ $n -ge 3 ]
-    do
-      "$@" && break
-      n=$[$n+1]
-      sleep 5
-    done
-}
-
 test_kubeless_function() {
     local func=${1:?} func_topic
     echo_info "TEST: $func"
@@ -260,8 +250,7 @@ test_kubeless_function() {
             echo_info "FUNC TOPIC: $func_topic"
             _wait_for_kubeless_kafka_topic_ready ${func_topic:?};;
     esac
-    # TODO: Remove retries when not using PortForwarding
-    retry make -sC examples ${func}-verify
+    make -sC examples ${func}-verify
 }
 
 test_kubeless_function_update() {
@@ -270,7 +259,6 @@ test_kubeless_function_update() {
     make -sC examples ${func}-update
     sleep 10
     k8s_wait_for_uniq_pod -l function=${func}
-    # TODO: Remove retries when not using PortForwarding
-    retry make -sC examples ${func}-update-verify
+    make -sC examples ${func}-update-verify
 }
 # vim: sw=4 ts=4 et si

--- a/script/libtest.bash
+++ b/script/libtest.bash
@@ -24,7 +24,7 @@ KUBECFG_BIN=$(which kubecfg)
 : ${KUBECTL_BIN:?ERROR: missing binary: kubectl}
 : ${KUBECFG_BIN:?ERROR: missing binary: kubecfg}
 
-export TEST_MAX_WAIT_SEC=120
+export TEST_MAX_WAIT_SEC=360
 
 # Workaround 'bats' lack of forced output support, dup() stderr fd
 exec 9>&2
@@ -243,7 +243,7 @@ test_kubeless_function() {
     esac
     kubeless_function_delete ${func}
     make -sC examples ${func}
-    k8s_wait_for_pod_ready -l function=${func}
+    k8s_wait_for_pod_ready -l function=${func} || return 1
     case "${func}" in
         *pubsub*)
             func_topic=$(kubeless function describe "${func}" -o yaml|sed -n 's/topic: //p')
@@ -258,7 +258,7 @@ test_kubeless_function_update() {
     echo_info "UPDATE: $func"
     make -sC examples ${func}-update
     sleep 10
-    k8s_wait_for_uniq_pod -l function=${func}
+    k8s_wait_for_uniq_pod -l function=${func} || return 1
     make -sC examples ${func}-update-verify
 }
 # vim: sw=4 ts=4 et si


### PR DESCRIPTION
The default value in the topic made the update of `http-trigger`ed functions fail if that parameter is not given.

The verification tests where passing because there is a gap of more than 120 seconds in which a temporary pod is created (but always with the status Terminating) that had the updated code but not the updated trigger. That plus not catching the error returned by the functions `wait_for_*_pod` hid the issue.