### PR TITLE
doc: replace tpr by crd

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 `kubeless` is a Kubernetes-native serverless framework that lets you deploy small bits of code without having to worry about the underlying infrastructure plumbing. It leverages Kubernetes resources to provide auto-scaling, API routing, monitoring, troubleshooting and more.
 
-Kubeless stands out as we use a ThirdPartyResource (now called [Custom Resource Definition](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/)) to be able to create functions as custom kubernetes resources. We then run an in-cluster controller that watches these custom resources and launches _runtimes_ on-demand. The controller dynamically injects the functions code into the runtimes and make them available over HTTP or via a PubSub mechanism.
+Kubeless stands out as we use a [Custom Resource Definition](https://kubernetes.io/docs/tasks/access-kubernetes-api/extend-api-custom-resource-definitions/) to be able to create functions as custom kubernetes resources. We then run an in-cluster controller that watches these custom resources and launches _runtimes_ on-demand. The controller dynamically injects the functions code into the runtimes and make them available over HTTP or via a PubSub mechanism.
 
 Kubeless is purely open-source and non-affiliated to any commercial organization. Chime in at anytime, we would love the help and feedback !
 
@@ -26,7 +26,7 @@ Click on this next picture to see a screencast demonstrating our [serverless](ht
 
 ## Installation
 
-Download `kubeless` cli from the [release page](https://github.com/kubeless/kubeless/releases). Then use one of yaml manifests found in the release package to deploy kubeless. It will create a _kubeless_ namespace and a _function_ ThirdPartyResource. You will see a _kubeless_ controller, and _kafka_, _zookeeper_ statefulset running.
+Download `kubeless` cli from the [release page](https://github.com/kubeless/kubeless/releases). Then use one of yaml manifests found in the release package to deploy kubeless. It will create a _kubeless_ namespace and a _functions_ Custom Resource Definition. You will see a _kubeless_ controller, and _kafka_, _zookeeper_ statefulset running.
 
 There are several kubeless manifests being shipped for multiple k8s environments (non-rbac, rbac and openshift), please consider to pick up the correct one:
 
@@ -56,9 +56,9 @@ NAME      DESIRED   CURRENT   AGE
 kafka     1         1         1m
 zoo       1         1         1m
 
-$ kubectl get thirdpartyresource
-NAME             DESCRIPTION                                     VERSION(S)
-function.k8s.io   Kubeless: Serverless framework for Kubernetes   v1
+$ kubectl get customresourcedefinition
+NAME               KIND
+functions.k8s.io   CustomResourceDefinition.v1beta1.apiextensions.k8s.io
 
 $ kubectl get functions
 ```

--- a/chart/kubeless/README.md
+++ b/chart/kubeless/README.md
@@ -2,7 +2,7 @@
 
 It installs:
 
-* The TPR
+* The CRD
 * The controller
 * The UI
 * A single node Kafka and Zookeeper setup

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -6,34 +6,63 @@ This doc covers the architectural design of Kubeless and directory structure of 
 
 Kubeless leverages multiple concepts of Kubernetes in order to support deploy functions on top of it. In details, we have been using:
 
-- Third party resources (TPR) to simulate function's metadata
+- Custom Resource Definitions (CRD) to simulate function's metadata
 - Deployment / Pod to run the corresponding runtime.
 - Config map to inject function's code to the runtime pod.
 - Service to expose function.
 - Init container to load the dependencies that function might have.
 
-When install kubeless, there is a TPR endpoint being deploy called `function.k8s.io`:
+When install kubeless, there is a CRD endpoint being deploy called `function.k8s.io`:
 
 ```
-$ kubectl get thirdpartyresource -o yaml
+$ kubectl get customresourcedefinition -o yaml
 apiVersion: v1
 items:
-- apiVersion: extensions/v1beta1
-  description: 'Kubeless: Serverless framework for Kubernetes'
-  kind: ThirdPartyResource
+- apiVersion: apiextensions.k8s.io/v1beta1
+  kind: CustomResourceDefinition
   metadata:
-    creationTimestamp: 2017-03-23T11:55:41Z
-    name: function.k8s.io
-    resourceVersion: "123126"
-    selfLink: /apis/extensions/v1beta1/thirdpartyresourcesfunction.k8s.io
-    uid: a3933b1f-0fbf-11e7-b235-12d427b26198
-  versions:
-  - name: v1
+    annotations:
+      kubectl.kubernetes.io/last-applied-configuration: |
+        {"apiVersion":"apiextensions.k8s.io/v1beta1","description":"Kubernetes Native Serverless Framework","kind":"CustomResourceDefinition","metadata":{"annotations":{},"name":"functions.k8s.io","namespace":""},"spec":{"group":"k8s.io","names":{"kind":"Function","plural":"functions","singular":"function"},"scope":"Namespaced","version":"v1"}}
+    creationTimestamp: 2017-10-10T14:51:37Z
+    name: functions.k8s.io
+    namespace: ""
+    resourceVersion: "7943"
+    selfLink: /apis/apiextensions.k8s.io/v1beta1/customresourcedefinitions/functions.k8s.io
+    uid: 846770f8-adca-11e7-b48e-0a580a160058
+  spec:
+    group: k8s.io
+    names:
+      kind: Function
+      listKind: FunctionList
+      plural: functions
+      singular: function
+    scope: Namespaced
+    version: v1
+  status:
+    acceptedNames:
+      kind: Function
+      listKind: FunctionList
+      plural: functions
+      singular: function
+    conditions:
+    - lastTransitionTime: null
+      message: no conflicts found
+      reason: NoConflicts
+      status: "True"
+      type: NamesAccepted
+    - lastTransitionTime: 2017-10-10T14:51:37Z
+      message: the initial names have been accepted
+      reason: InitialNamesAccepted
+      status: "True"
+      type: Established
 kind: List
-metadata: {}
+metadata:
+  resourceVersion: ""
+  selfLink: ""
 ```
 
-Then function custom objects will be created under this thirdparty endpoint. A function object looks like this:
+Then function custom objects will be created under this CRD endpoint. A function object looks like this:
 
 ```
 $ kubectl get function -o yaml
@@ -42,24 +71,37 @@ items:
 - apiVersion: k8s.io/v1
   kind: Function
   metadata:
-    creationTimestamp: 2017-03-27T13:56:02Z
+    clusterName: ""
+    creationTimestamp: 2017-10-10T16:09:06Z
+    deletionGracePeriodSeconds: null
+    deletionTimestamp: null
     name: get-python
     namespace: default
-    resourceVersion: "146417"
+    resourceVersion: "13299"
     selfLink: /apis/k8s.io/v1/namespaces/default/functions/get-python
-    uid: 1d08377f-12f5-11e7-953d-0eaf474e070b
+    uid: 5759e3f3-add5-11e7-b48e-0a580a160058
   spec:
     deps: ""
     function: |
-      import json
-      def foo():
-          return "hello world"
-    handler: helloget.foo
+      def foobar(context):
+         print context.json
+         return context.json
+    handler: test.foobar
     runtime: python2.7
+    schedule: ""
+    template:
+      metadata:
+        creationTimestamp: null
+      spec:
+        containers:
+        - name: ""
+          resources: {}
     topic: ""
     type: HTTP
 kind: List
-metadata: {}
+metadata:
+  resourceVersion: ""
+  selfLink: ""
 ```
 
 `function.spec` contains function's metadata including code, handler, runtime, type (http or pubsub) and probably its dependency file.
@@ -94,7 +136,7 @@ Diving into these above commands for more details.
 
 Kubeless controller is written in Go programming language, and uses the Kubernetes go client to interact with the Kubernetes API server. Detailed implementation of the controller could be found at https://github.com/kubeless/kubeless/blob/master/pkg/controller/controller.go#L113
 
-Kubeless CLI is written in Go as well, using the popular cli library `github.com/spf13/cobra`. Basically it is a bundle of HTTP requests and kubectl commands. We send http requests to the Kubernetes API server in order to 'crud' TPR objects. Other actions are just wrapping up `kubectl port-forward`, `kubectl exec` and `kubectl logs` in order to make direct call to function, inject message to Kafka controller or get function log. Checkout https://github.com/kubeless/kubeless/tree/master/cmd/kubeless for more details.
+Kubeless CLI is written in Go as well, using the popular cli library `github.com/spf13/cobra`. Basically it is a bundle of HTTP requests and kubectl commands. We send http requests to the Kubernetes API server in order to 'crud' CRD objects. Other actions are just wrapping up `kubectl port-forward`, `kubectl exec` and `kubectl logs` in order to make direct call to function, inject message to Kafka controller or get function log. Checkout https://github.com/kubeless/kubeless/tree/master/cmd/kubeless for more details.
 
 ## Directory structure
 

--- a/script/kubeless_uninstall.sh
+++ b/script/kubeless_uninstall.sh
@@ -8,4 +8,4 @@ kubectl delete svc --namespace kubeless broker
 kubectl delete svc --namespace kubeless kafka
 kubectl delete svc --namespace kubeless zoo
 kubectl delete svc --namespace kubeless zookeeper
-#kubectl delete thirdpartyresources function.k8s.io
+#kubectl delete customresourcedefinition function.k8s.io


### PR DESCRIPTION
This is a follow up to https://github.com/kubeless/kubeless/pull/290

Since Kubeless migrated from Third Party Resource (TPR) to Custom
Resource Definition (CRD), the commands mentioned in the README were not
correct anymore. This patch updates the doc in a few places.

/cc @asymmetric