### PR TITLE
optimize HPA controller in autoscaling

### DIFF
--- a/manifests/autoscaling/README.md
+++ b/manifests/autoscaling/README.md
@@ -44,8 +44,11 @@ These below configurations must be set:
 2) configure controller manager to use the metrics APIs via their REST clients by these settings in `kube-controller-manager`:
 ```
 --horizontal-pod-autoscaler-use-rest-clients=true
+--horizontal-pod-autoscaler-sync-period=10s
 --master=<apiserver-address>:<port> //port should be 8080
 ```
+
+The `horizontal-pod-autoscaler-sync-period` parameter set the interval time (in second) that the HPA controller synchronizes the number of pods. By default it's 30s. Sometimes we might want to optimize this parameter to make the HPA controller reacts faster.
 
 3) the autoscaling for custom metrics is supported in HPA since v1.7 via `autoscaling/v2alpha1` API. It needs to be enabled by setting the `runtime-config` in `kube-apiserver`:
 ```


### PR DESCRIPTION
I found a parameter to adjust the HPA controller interval that would help to make it reacts quickly to the function's load. I tested it with 5s and the result was reasonable - The function was scaled up and down quickly. There might be harming the system by putting HPA under stress but that would just be a suggestion for optimization.