### PR TITLE
[jjo] add simple ingress and autoscale testing

### DIFF
--- a/tests/integration-tests.bats
+++ b/tests/integration-tests.bats
@@ -37,8 +37,16 @@ load ../script/libtest
 # 'bats' lacks loop support, unroll-them-all ->
 @test "Test function: get-python" {
   test_kubeless_function get-python
+}
+@test "Test function update: get-python" {
   test_kubeless_function_update get-python
-} 
+}
+@test "Test function ingress: get-python" {
+  test_kubeless_ingress get-python
+}
+@test "Test function autoscale: get-python" {
+  test_kubeless_autoscale get-python
+}
 @test "Test function: get-nodejs" {
   test_kubeless_function get-nodejs
 }
@@ -68,6 +76,8 @@ load ../script/libtest
 }
 @test "Test function: pubsub-python" {
   test_kubeless_function pubsub-python
+}
+@test "Test function update: pubsub-python" {
   test_kubeless_function_update pubsub-python
 }
 @test "Test function: pubsub-nodejs" {


### PR DESCRIPTION
* Add simple `kubeless ingress` and `autoscale` testing,
  verify both expected `kubeless ... list` and k8s objects created
* Re-organize function update testing to have their own `bats` stanza,
  eases isolating debugging
* make `k8s_wait_for_uniq_pod` general as `k8s_wait_for_pod_count`