### PR TITLE
ingress create command: fixed host parsing when no port is defined. 

### DIFF
--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -784,10 +784,12 @@ func GetLocalHostname(config *rest.Config, funcName string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-
-	host, _, err := net.SplitHostPort(url.Host)
-	if err != nil {
-		return "", err
+	host := url.Host
+	if strings.Contains(url.Host, ":") {
+		host, _, err = net.SplitHostPort(url.Host)
+		if err != nil {
+			return "", err
+		}
 	}
 
 	return fmt.Sprintf("%s.%s.nip.io", funcName, host), nil


### PR DESCRIPTION
When no host name is specified we use the current config host name.
We are assuming that there will always have a port in the host name but it is not the case on a GKE cluster.

We might want to revisit what is used in the default host name on GKE. Maybe it would be better to use the cluster name or something else instead of the ip.

Fixes #379