### PR TITLE
Add error reporting to Slack messages rather than fail silently

### DIFF
--- a/examples/minio/slack/bot.py
+++ b/examples/minio/slack/bot.py
@@ -8,28 +8,14 @@ from slackclient import SlackClient
 #pip install kubernetes
 from kubernetes import client, config
 
-# pip install minio
-from minio import Minio
-from minio.error import ResponseError
-
 config.load_incluster_config()
 
 v1=client.CoreV1Api()
 
-#Get minio and slack secrets
+#Get slack secret
 for secrets in v1.list_secret_for_all_namespaces().items:
-    if secrets.metadata.name == 'minio':
-        access_key = base64.b64decode(secrets.data['access_key'])
-        secret_key = base64.b64decode(secrets.data['secret_key'])
     if secrets.metadata.name == 'slack':
         token = base64.b64decode(secrets.data['token'])
-
-
-# Replace the DNS below with the minio service name (helm release name -svc)
-client = Minio('minio-minio-svc:9000',
-                  access_key=access_key,
-                  secret_key=secret_key,
-                  secure=False)
 
 sc = SlackClient(token)
 

--- a/examples/minio/slack/bot.py
+++ b/examples/minio/slack/bot.py
@@ -40,10 +40,13 @@ def handler(context):
 
         msg = "An object called %s was uploaded to bucket %s" % (filename,bucket)
 
-        sc.api_call(
+        r = sc.api_call(
                     "chat.postMessage",
                     channel="#bot",
                     text=msg
                    )
+        if r.get('ok'):
+            return "Notification successfully sent to Slack"
+        else:
+            return "Error while sending notification to Slack: " + r.get('error')
 
-    return "Notification sent to SLACK"

--- a/examples/minio/slack/requirements.txt
+++ b/examples/minio/slack/requirements.txt
@@ -1,3 +1,2 @@
 slackclient
 kubernetes>=2.0.0,<3.0.0
-minio

--- a/examples/slack/botevents.py
+++ b/examples/slack/botevents.py
@@ -22,10 +22,13 @@ sc = SlackClient(token)
 def handler(context):
     msg = "k8s event: %s" % context
 
-    sc.api_call(
+    r = sc.api_call(
                 "chat.postMessage",
                 channel="#bot",
                 text=msg
                )
+    if r.get('ok'):
+        return "Notification successfully sent to Slack"
+    else:
+        return "Error while sending notification to Slack: " + r.get('error')
 
-    return "Notification sent to SLACK"


### PR DESCRIPTION
The example fails silently when, for example, the Slack auth token is incorrect. Worse, it implies it succeeded by mentioning in the debug console that the message was sent