### PR TITLE
Add ServiceSpec to FunctionSpec

### DIFF
--- a/cmd/kubeless/function/deploy.go
+++ b/cmd/kubeless/function/deploy.go
@@ -116,6 +116,18 @@ var deployCmd = &cobra.Command{
 		if err != nil {
 			logrus.Fatal(err)
 		}
+		headless, err := cmd.Flags().GetBool("headless")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
+		port, err := cmd.Flags().GetInt32("port")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		if port <= 0 || port > 65535 {
+			logrus.Fatalf("Invalid port number %d specified", port)
+		}
 
 		funcDeps := ""
 		if deps != "" {
@@ -140,7 +152,7 @@ var deployCmd = &cobra.Command{
 		defaultFunctionSpec.Metadata.Labels = map[string]string{
 			"created-by": "kubeless",
 		}
-		f, err := getFunctionDescription(cli, funcName, ns, handler, file, funcDeps, runtime, topic, schedule, runtimeImage, mem, timeout, triggerHTTP, envs, labels, defaultFunctionSpec)
+		f, err := getFunctionDescription(cli, funcName, ns, handler, file, funcDeps, runtime, topic, schedule, runtimeImage, mem, timeout, triggerHTTP, &headless, &port, envs, labels, defaultFunctionSpec)
 		if err != nil {
 			logrus.Fatal(err)
 		}
@@ -174,4 +186,6 @@ func init() {
 	deployCmd.Flags().Bool("trigger-http", false, "Deploy a http-based function to Kubeless")
 	deployCmd.Flags().StringP("runtime-image", "", "", "Custom runtime image")
 	deployCmd.Flags().StringP("timeout", "", "180", "Maximum timeout (in seconds) for the function to complete its execution")
+	deployCmd.Flags().Bool("headless", false, "Deploy http-based function without a single service IP and load balancing support from Kubernetes. See: https://kubernetes.io/docs/concepts/services-networking/service/#headless-services")
+	deployCmd.Flags().Int32("port", 8080, "Deploy http-based function with a custom port")
 }

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -80,6 +80,13 @@ get-nodejs:
 get-nodejs-verify:
 	kubeless function call get-nodejs |egrep hello.world
 
+get-nodejs-custom-port:
+	kubeless function deploy get-nodejs-custom-port --trigger-http --runtime nodejs6 --handler helloget.foo --from-file nodejs/helloget.js --port 8083
+	echo "curl localhost:8083/api/v1/proxy/namespaces/default/services/get-nodejs-custom-port/"
+
+get-nodejs-custom-port-verify:
+	kubeless function call get-nodejs-custom-port |egrep hello.world
+
 timeout-nodejs:
 	$(eval TMPDIR := $(shell mktemp -d))
 	printf 'module.exports = { foo: function (req, res) { while(true) {} } }\n' > $(TMPDIR)/hello-loop.js
@@ -125,6 +132,13 @@ get-ruby-deps:
 get-ruby-deps-verify:
 	kubeless function call get-ruby-deps |egrep hello.world
 
+get-ruby-custom-port:
+	kubeless function deploy get-ruby-custom-port --trigger-http --runtime ruby2.4 --handler helloget.foo --from-file ruby/helloget.rb --port 8082
+	echo "curl localhost:8082/api/v1/proxy/namespaces/default/services/get-ruby-custom-port/"
+
+get-ruby-custom-port-verify:
+	kubeless function call get-ruby-custom-port |egrep hello.world
+
 timeout-ruby:
 	$(eval TMPDIR := $(shell mktemp -d))
 	printf 'def foo(c)\n%4swhile true do;sleep(1);end\n%4s"hello world"\nend' > $(TMPDIR)/hello-loop.rb
@@ -155,7 +169,7 @@ custom-get-python-update:
 custom-get-python-update-verify:
 	kubeless function call custom-get-python |egrep hello.world.updated
 
-get: get-python get-nodejs get-python-metadata get-ruby get-ruby-deps
+get: get-python get-nodejs get-python-metadata get-ruby get-ruby-deps get-python-custom-port
 
 post-python:
 	kubeless function deploy post-python --trigger-http --runtime python2.7 --handler hellowithdata.handler --from-file python/hellowithdata.py
@@ -163,6 +177,13 @@ post-python:
 
 post-python-verify:
 	kubeless function call post-python --data '{"it-s": "alive"}'|egrep "it.*alive"
+
+post-python-custom-port:
+	kubeless function deploy post-python-custom-port --trigger-http --runtime python2.7 --handler hellowithdata.handler --from-file python/hellowithdata.py --port 8081
+	echo "curl --data '{\"hello\":\"world\"}' localhost:8081/api/v1/proxy/namespaces/default/services/post-python-custom-port/ --header \"Content-Type:application/json\""
+
+post-python-custom-port-verify:
+	kubeless function call post-python-custom-port --data '{"it-s": "alive"}'|egrep "it.*alive"
 
 post-nodejs:
 	kubeless function deploy post-nodejs --trigger-http --runtime nodejs6 --handler hellowithdata.handler --from-file nodejs/hellowithdata.js
@@ -184,7 +205,7 @@ post-dotnetcore:
 post-dotnetcore-verify:
 	kubeless function call post-dotnetcore --data '{"it-s": "alive"}'|egrep "it.*alive"
 
-post: post-python post-nodejs post-ruby
+post: post-python post-nodejs post-ruby post-python-custom-port
 
 pubsub-python:
 	kubeless topic create s3-python || true

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -21,6 +21,12 @@ get-python-deps:
 get-python-deps-verify:
 	kubeless function call get-python-deps |egrep Google
 
+get-python-custom-port:
+	kubeless function deploy get-python-custom-port --trigger-http --runtime python2.7 --handler helloget.foo --from-file python/helloget.py --port 8081
+
+get-python-custom-port-verify:
+	kubeless function call get-python-custom-port |egrep hello.world
+
 get-python-deps-update:
 	$(eval TMPDIR := $(shell mktemp -d))
 	printf 'bs4\ntwitter\n' > $(TMPDIR)/requirements.txt

--- a/pkg/langruntime/langruntime.go
+++ b/pkg/langruntime/langruntime.go
@@ -12,20 +12,20 @@ import (
 )
 
 const (
-	python27Http    = "kubeless/python@sha256:ba948a6783b93d75037b7b1806a3925d441401ae6fba18282f712a1b1a786899"
+	python27Http    = "tuna/python@sha256:777905dfd628e91192b61c104e30aca9c429b84844de2a1187398ee50593ab5e"
 	python27Pubsub  = "kubeless/python-event-consumer@sha256:1aeb6cef151222201abed6406694081db26fa2235d7ac128113dcebd8d73a6cb"
 	python27Init    = "tuna/python-pillow:2.7.11-alpine" // TODO: Migrate the image for python 2.7 to an official source (not alpine-based)
-	python34Http    = "kubeless/python@sha256:631b406ab9681fe0da9c281949a885a95b7d8c9cea4a48d7dfd0fa2c0576e23e"
+	python34Http    = "tuna/python@sha256:06c4a78fa5ce6ecc01f7e2c913336983190ea91e1d2864774f89b1e341507ed7"
 	python34Pubsub  = "kubeless/python-event-consumer@sha256:d963e4cd58229d662188d618cd87503b3c749b126b359ce724a19a375e4b3040"
 	python34Init    = "python:3.4"
-	node6Http       = "kubeless/nodejs@sha256:87c52ce90e80bb50c6abd51a1faf033fe8f0108bbc02d9484a13387295ea4c7e"
-	node6Pubsub     = "kubeless/nodejs-event-consumer@sha256:e6d840fe107187ecab8cab7a6891a39cf9d03a426e7befca75dbc818bc978b3c"
+	node6Http       = "tuna/nodejs@sha256:2b25d7380d6ed06ad817f4ee1e177340a282788596b34464173bb8a967d83c02"
+	node6Pubsub     = "tuna/nodejs-event-consumer@sha256:1861c32d6a46b2fdfc3e3996daf690ff2c3d5ca19a605abd2af503011d68e221"
 	node6Init       = "node:6.10"
-	node8Http       = "kubeless/nodejs@sha256:ff8aba5dd969e101c8307ae9e485acdd7fa5ec69f0afe7b0a2ac6dcb99573ea5"
-	node8Pubsub     = "kubeless/nodejs-event-consumer@sha256:9e2ad4ec3050caf94cb659a7914e3e14bce11eb222101ad2e000da3053f06604"
+	node8Http       = "tuna/nodejs@sha256:f1426efe274ea8480d95270c98f6007ac64645e36291dbfa36d759b5c8b7b733"
+	node8Pubsub     = "tuna/nodejs-event-consumer@sha256:b301b02e463b586d9a32d5c1cb5a68c2a11e4fba9514e28d900fc50a78759af9"
 	node8Init       = "node:8"
-	ruby24Http      = "kubeless/ruby@sha256:155a8cbd9a4e0e53efd8d3ea86f14098309a06ce1fca3b58265088460e8ad96c"
-	ruby24Pubsub    = "kubeless/ruby-event-consumer@sha256:37c2db19c8de7f953b1ab711a5e0cab0caa5229d2d9d56093eb0626e9933c047"
+	ruby24Http      = "tuna/ruby@sha256:738e4cdeb5f5feece236bbf4e46902024e4b9fc16db4f3791404fa27e8b0db15"
+	ruby24Pubsub    = "tuna/ruby-event-consumer@sha256:f9f50be51d93a98ae30689d87b067c181905a8757d339fb0fa9a81c6268c4eea"
 	ruby24Init      = "bitnami/ruby:2.4"
 	dotnetcore2Http = "allantargino/kubeless-dotnetcore@sha256:d321dc4b2c420988d98cdaa22c733743e423f57d1153c89c2b99ff0d944e8a63"
 	dotnetcore2Init = "microsoft/aspnetcore-build:2.0"

--- a/pkg/langruntime/langruntime.go
+++ b/pkg/langruntime/langruntime.go
@@ -12,20 +12,23 @@ import (
 )
 
 const (
-	python27Http    = "tuna/python@sha256:777905dfd628e91192b61c104e30aca9c429b84844de2a1187398ee50593ab5e"
+	python27Http    = "kubeless/python@sha256:0f3b64b654df5326198e481cd26e73ecccd905aae60810fc9baea4dcbb61f697"
 	python27Pubsub  = "kubeless/python-event-consumer@sha256:1aeb6cef151222201abed6406694081db26fa2235d7ac128113dcebd8d73a6cb"
 	python27Init    = "tuna/python-pillow:2.7.11-alpine" // TODO: Migrate the image for python 2.7 to an official source (not alpine-based)
-	python34Http    = "tuna/python@sha256:06c4a78fa5ce6ecc01f7e2c913336983190ea91e1d2864774f89b1e341507ed7"
+	python34Http    = "kubeless/python@sha256:e502078dc9580bb73f823504a6765dfc98f000979445cdf071900350b938c292"
 	python34Pubsub  = "kubeless/python-event-consumer@sha256:d963e4cd58229d662188d618cd87503b3c749b126b359ce724a19a375e4b3040"
 	python34Init    = "python:3.4"
-	node6Http       = "tuna/nodejs@sha256:2b25d7380d6ed06ad817f4ee1e177340a282788596b34464173bb8a967d83c02"
-	node6Pubsub     = "tuna/nodejs-event-consumer@sha256:1861c32d6a46b2fdfc3e3996daf690ff2c3d5ca19a605abd2af503011d68e221"
+	python36Http    = "kubeless/python@sha256:6300c2513ca51653ae698a31eacf6b2b8a16d2737dd3e244a8c9c11f6408fd35"
+	python36Pubsub  = "kubeless/python-event-consumer@sha256:0a2f9162de56b7966b02b70a5a0bcff03badfd9d87b8ae3d13e5381abd00220f"
+	python36Init    = "python:3.6"
+	node6Http       = "kubeless/nodejs@sha256:2b25d7380d6ed06ad817f4ee1e177340a282788596b34464173bb8a967d83c02"
+	node6Pubsub     = "kubeless/nodejs-event-consumer@sha256:1861c32d6a46b2fdfc3e3996daf690ff2c3d5ca19a605abd2af503011d68e221"
 	node6Init       = "node:6.10"
-	node8Http       = "tuna/nodejs@sha256:f1426efe274ea8480d95270c98f6007ac64645e36291dbfa36d759b5c8b7b733"
-	node8Pubsub     = "tuna/nodejs-event-consumer@sha256:b301b02e463b586d9a32d5c1cb5a68c2a11e4fba9514e28d900fc50a78759af9"
+	node8Http       = "kubeless/nodejs@sha256:f1426efe274ea8480d95270c98f6007ac64645e36291dbfa36d759b5c8b7b733"
+	node8Pubsub     = "kubeless/nodejs-event-consumer@sha256:b301b02e463b586d9a32d5c1cb5a68c2a11e4fba9514e28d900fc50a78759af9"
 	node8Init       = "node:8"
-	ruby24Http      = "tuna/ruby@sha256:738e4cdeb5f5feece236bbf4e46902024e4b9fc16db4f3791404fa27e8b0db15"
-	ruby24Pubsub    = "tuna/ruby-event-consumer@sha256:f9f50be51d93a98ae30689d87b067c181905a8757d339fb0fa9a81c6268c4eea"
+	ruby24Http      = "kubeless/ruby@sha256:738e4cdeb5f5feece236bbf4e46902024e4b9fc16db4f3791404fa27e8b0db15"
+	ruby24Pubsub    = "kubeless/ruby-event-consumer@sha256:f9f50be51d93a98ae30689d87b067c181905a8757d339fb0fa9a81c6268c4eea"
 	ruby24Init      = "bitnami/ruby:2.4"
 	dotnetcore2Http = "allantargino/kubeless-dotnetcore@sha256:d321dc4b2c420988d98cdaa22c733743e423f57d1153c89c2b99ff0d944e8a63"
 	dotnetcore2Init = "microsoft/aspnetcore-build:2.0"
@@ -54,7 +57,8 @@ var availableRuntimes []RuntimeInfo
 func init() {
 	python27 := runtimeVersion{version: "2.7", httpImage: python27Http, pubsubImage: python27Pubsub, initImage: python27Init}
 	python34 := runtimeVersion{version: "3.4", httpImage: python34Http, pubsubImage: python34Pubsub, initImage: python34Init}
-	pythonVersions = []runtimeVersion{python27, python34}
+	python36 := runtimeVersion{version: "3.6", httpImage: python36Http, pubsubImage: python36Pubsub, initImage: python36Init}
+	pythonVersions = []runtimeVersion{python27, python34, python36}
 
 	node6 := runtimeVersion{version: "6", httpImage: node6Http, pubsubImage: node6Pubsub, initImage: node6Init}
 	node8 := runtimeVersion{version: "8", httpImage: node8Http, pubsubImage: node8Pubsub, initImage: node8Init}

--- a/pkg/langruntime/langruntime_test.go
+++ b/pkg/langruntime/langruntime_test.go
@@ -78,7 +78,7 @@ func TestGetFunctionImage(t *testing.T) {
 
 func TestGetRuntimes(t *testing.T) {
 	runtimes := strings.Join(GetRuntimes(), ", ")
-	expectedRuntimes := "python2.7, python3.4, nodejs6, nodejs8, ruby2.4, dotnetcore2.0"
+	expectedRuntimes := "python2.7, python3.4, python3.6, nodejs6, nodejs8, ruby2.4, dotnetcore2.0"
 	if runtimes != expectedRuntimes {
 		t.Errorf("Expected %s but got %s", expectedRuntimes, runtimes)
 	}

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -42,7 +42,7 @@ type FunctionSpec struct {
 	Schedule                string                           `json:"schedule"`              // Function scheduled time (for Schedule type)
 	Timeout                 string                           `json:"timeout"`               // Maximum timeout for the function to complete its execution
 	Deps                    string                           `json:"deps"`                  // Function dependencies
-	ServiceSpec         v1.ServiceSpec     `json:"service"`
+	ServiceSpec             v1.ServiceSpec                   `json:"service"`
 	Template                v1.PodTemplateSpec               `json:"template" protobuf:"bytes,3,opt,name=template"`
 	HorizontalPodAutoscaler v2alpha1.HorizontalPodAutoscaler `json:"horizontalPodAutoscaler" protobuf:"bytes,3,opt,name=horizontalPodAutoscaler"`
 }

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -42,6 +42,7 @@ type FunctionSpec struct {
 	Schedule                string                           `json:"schedule"`              // Function scheduled time (for Schedule type)
 	Timeout                 string                           `json:"timeout"`               // Maximum timeout for the function to complete its execution
 	Deps                    string                           `json:"deps"`                  // Function dependencies
+	ServiceSpec         v1.ServiceSpec     `json:"service"`
 	Template                v1.PodTemplateSpec               `json:"template" protobuf:"bytes,3,opt,name=template"`
 	HorizontalPodAutoscaler v2alpha1.HorizontalPodAutoscaler `json:"horizontalPodAutoscaler" protobuf:"bytes,3,opt,name=horizontalPodAutoscaler"`
 }

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -411,7 +411,7 @@ func CreateIngress(client kubernetes.Interface, funcObj *spec.Function, ingressN
 									Path: "/",
 									Backend: v1beta1.IngressBackend{
 										ServiceName: funcObj.Metadata.Name,
-										ServicePort: intstr.FromInt(8080),
+										ServicePort: funcObj.Spec.ServiceSpec.Ports[0].TargetPort,
 									},
 								},
 							},

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -387,10 +387,18 @@ func addInitContainerAnnotation(dpm *v1beta1.Deployment) error {
 
 // CreateIngress creates ingress rule for a specific function
 func CreateIngress(client kubernetes.Interface, funcObj *spec.Function, ingressName, hostname, ns string, enableTLSAcme bool) error {
-
 	or, err := GetOwnerReference(funcObj)
 	if err != nil {
 		return err
+	}
+
+	if len(funcObj.Spec.ServiceSpec.Ports) == 0 {
+		return fmt.Errorf("can't create route due to service port isn't defined")
+	}
+
+	port := funcObj.Spec.ServiceSpec.Ports[0].TargetPort
+	if port.IntVal <= 0 || port.IntVal > 65535 {
+		return fmt.Errorf("Invalid port number %d specified", port.IntVal)
 	}
 
 	ingress := &v1beta1.Ingress{

--- a/pkg/utils/k8sutil_test.go
+++ b/pkg/utils/k8sutil_test.go
@@ -712,7 +712,15 @@ func TestCreateIngressResource(t *testing.T) {
 			Namespace: "myns",
 			UID:       "1234",
 		},
-		Spec: spec.FunctionSpec{},
+		Spec: spec.FunctionSpec{
+			ServiceSpec: v1.ServiceSpec{
+				Ports: []v1.ServicePort{
+					{
+						TargetPort: intstr.FromInt(8080),
+					},
+				},
+			},
+		},
 	}
 	if err := CreateIngress(clientset, f1, "bar", "foo.bar", "myns", false); err != nil {
 		t.Fatalf("Creating ingress returned err: %v", err)
@@ -721,6 +729,10 @@ func TestCreateIngressResource(t *testing.T) {
 		if !k8sErrors.IsAlreadyExists(err) {
 			t.Fatalf("Expect object is already exists, got %v", err)
 		}
+	}
+	f1.Spec.ServiceSpec.Ports = []v1.ServicePort{}
+	if err := CreateIngress(clientset, f1, "bar", "foo.bar", "myns", false); err == nil {
+		t.Fatal("Expect create ingress fails, got success")
 	}
 }
 
@@ -732,7 +744,15 @@ func TestCreateIngressResourceWithTLSAcme(t *testing.T) {
 			Namespace: "myns",
 			UID:       "1234",
 		},
-		Spec: spec.FunctionSpec{},
+		Spec: spec.FunctionSpec{
+			ServiceSpec: v1.ServiceSpec{
+				Ports: []v1.ServicePort{
+					{
+						TargetPort: intstr.FromInt(8080),
+					},
+				},
+			},
+		},
 	}
 
 	if err := CreateIngress(clientset, f1, "foo", "foo.bar", "myns", true); err != nil {

--- a/pkg/utils/k8sutil_test.go
+++ b/pkg/utils/k8sutil_test.go
@@ -343,7 +343,7 @@ func TestEnsureDeployment(t *testing.T) {
 	}
 	expectedContainer := v1.Container{
 		Name:  f1Name,
-		Image: "kubeless/python@sha256:ba948a6783b93d75037b7b1806a3925d441401ae6fba18282f712a1b1a786899",
+		Image: "tuna/python@sha256:777905dfd628e91192b61c104e30aca9c429b84844de2a1187398ee50593ab5e",
 		Ports: []v1.ContainerPort{
 			{
 				ContainerPort: int32(f1Port),

--- a/pkg/utils/k8sutil_test.go
+++ b/pkg/utils/k8sutil_test.go
@@ -343,7 +343,7 @@ func TestEnsureDeployment(t *testing.T) {
 	}
 	expectedContainer := v1.Container{
 		Name:  f1Name,
-		Image: "tuna/python@sha256:777905dfd628e91192b61c104e30aca9c429b84844de2a1187398ee50593ab5e",
+		Image: "kubeless/python@sha256:0f3b64b654df5326198e481cd26e73ecccd905aae60810fc9baea4dcbb61f697",
 		Ports: []v1.ContainerPort{
 			{
 				ContainerPort: int32(f1Port),

--- a/tests/integration-tests.bats
+++ b/tests/integration-tests.bats
@@ -21,6 +21,7 @@ load ../script/libtest
   deploy_function get-python
   deploy_function get-python-deps
   deploy_function scheduled-get-python
+  deploy_function get-python-custom-port
   deploy_function get-nodejs
   deploy_function get-nodejs-deps
   deploy_function timeout-nodejs
@@ -38,6 +39,9 @@ load ../script/libtest
 }
 @test "Test function: get-python-deps" {
   verify_function get-python-deps
+}
+@test "Test function: get-python-custom-port" {
+  verify_function get-python-custom-port
 }
 @test "Test function update: get-python" {
   test_kubeless_function_update get-python

--- a/tests/integration-tests.bats
+++ b/tests/integration-tests.bats
@@ -23,13 +23,16 @@ load ../script/libtest
   deploy_function scheduled-get-python
   deploy_function get-python-custom-port
   deploy_function get-nodejs
+  deploy_function get-nodejs-custom-port
   deploy_function get-nodejs-deps
   deploy_function timeout-nodejs
   deploy_function get-nodejs-multi
   deploy_function get-ruby
+  deploy_function get-ruby-custom-port
   deploy_function get-ruby-deps
   deploy_function get-python-metadata
   deploy_function post-python
+  deploy_function post-python-custom-port
   deploy_function post-nodejs
   deploy_function post-ruby
   deploy_function custom-get-python
@@ -61,6 +64,10 @@ load ../script/libtest
   verify_function get-nodejs
   kubeless_function_delete get-nodejs
 }
+@test "Test function: get-nodejs-custom-port" {
+  verify_function get-nodejs-custom-port
+  kubeless_function_delete get-nodejs-custom-port
+}
 @test "Test function: get-nodejs-deps" {
   verify_function get-nodejs-deps
   kubeless_function_delete get-nodejs-deps
@@ -76,6 +83,10 @@ load ../script/libtest
 @test "Test function: get-ruby" {
   verify_function get-ruby
   kubeless_function_delete get-ruby
+}
+@test "Test function: get-ruby-custom-port" {
+  verify_function get-ruby-custom-port
+  kubeless_function_delete get-ruby-custom-port
 }
 @test "Test function: get-ruby-deps" {
   verify_function get-ruby-deps
@@ -94,6 +105,10 @@ load ../script/libtest
 @test "Test function: post-python" {
   verify_function post-python
   kubeless_function_delete post-python
+}
+@test "Test function: post-python-custom-port" {
+  verify_function post-python-custom-port
+  kubeless_function_delete post-python-custom-port
 }
 @test "Test function: post-nodejs" {
   verify_function post-nodejs


### PR DESCRIPTION
Add ServiceSpec to FunctionSpec so it can support creating Service with customizations.

ServiceSpec contains headless (boolean) and port (integer).

I have not updated the controller yet to take advantage of this, but want to run it by the reviewers first.

- [x] Ready to review
- [x] Automated Tests
- [ ] Docs