### PR TITLE
[trivial] Substitute TPR with CRD

### DIFF
--- a/cmd/kubeless-controller/kubeless-controller.go
+++ b/cmd/kubeless-controller/kubeless-controller.go
@@ -41,13 +41,13 @@ var rootCmd = &cobra.Command{
 	Short: "Kubeless controller",
 	Long:  globalUsage,
 	Run: func(cmd *cobra.Command, args []string) {
-		tprClient, err := utils.GetTPRClient()
+		crdClient, err := utils.GetCRDClient()
 		if err != nil {
-			logrus.Fatalf("Cannot get TPR client: %v", err)
+			logrus.Fatalf("Cannot get CRD client: %v", err)
 		}
 		cfg := controller.Config{
 			KubeCli:   utils.GetClient(),
-			TprClient: tprClient,
+			CRDClient: crdClient,
 		}
 		c := controller.New(cfg)
 		stopCh := make(chan struct{})

--- a/cmd/kubeless/call.go
+++ b/cmd/kubeless/call.go
@@ -66,9 +66,9 @@ var callCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
-		tprClient, err := utils.GetTPRClientOutOfCluster()
+		crdClient, err := utils.GetCRDClientOutOfCluster()
 		svc := v1.Service{}
-		tprClient.Get().AbsPath("/api/v1/namespaces/" + ns + "/services/" + funcName + "/").Do().Into(&svc)
+		crdClient.Get().AbsPath("/api/v1/namespaces/" + ns + "/services/" + funcName + "/").Do().Into(&svc)
 		if svc.ObjectMeta.Name != funcName {
 			logrus.Fatalf("Unable to find the service for %s", funcName)
 		}
@@ -81,9 +81,9 @@ var callCmd = &cobra.Command{
 
 		req := &rest.Request{}
 		if get {
-			req = tprClient.Get().AbsPath(url)
+			req = crdClient.Get().AbsPath(url)
 		} else {
-			req = tprClient.Post().AbsPath(url).Body(bytes.NewBuffer(jsonStr)).SetHeader("Content-Type", "application/json")
+			req = crdClient.Post().AbsPath(url).Body(bytes.NewBuffer(jsonStr)).SetHeader("Content-Type", "application/json")
 		}
 		res, err := req.Do().Raw()
 		if err != nil {

--- a/cmd/kubeless/delete.go
+++ b/cmd/kubeless/delete.go
@@ -37,12 +37,12 @@ var deleteCmd = &cobra.Command{
 		if err != nil {
 			logrus.Fatal(err)
 		}
-		tprClient, err := utils.GetTPRClientOutOfCluster()
+		crdClient, err := utils.GetCRDClientOutOfCluster()
 		if err != nil {
 			logrus.Fatal(err)
 		}
 
-		err = utils.DeleteK8sCustomResource(tprClient, funcName, ns)
+		err = utils.DeleteK8sCustomResource(crdClient, funcName, ns)
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/cmd/kubeless/deploy.go
+++ b/cmd/kubeless/deploy.go
@@ -118,12 +118,12 @@ var deployCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
-		tprClient, err := utils.GetTPRClientOutOfCluster()
+		crdClient, err := utils.GetCRDClientOutOfCluster()
 		if err != nil {
 			logrus.Fatal(err)
 		}
 
-		err = utils.CreateK8sCustomResource(tprClient, f)
+		err = utils.CreateK8sCustomResource(crdClient, f)
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/cmd/kubeless/ingressCreate.go
+++ b/cmd/kubeless/ingressCreate.go
@@ -61,11 +61,11 @@ var ingressCreateCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
-		tprClient, err := utils.GetTPRClientOutOfCluster()
+		crdClient, err := utils.GetCRDClientOutOfCluster()
 		if err != nil {
 			logrus.Fatal(err)
 		}
-		err = functionExists(tprClient, funcName, ns)
+		err = functionExists(crdClient, funcName, ns)
 		if err != nil {
 			if k8sErrors.IsNotFound(err) {
 				logrus.Fatalf("function %s doesn't exist in namespace %s", funcName, ns)
@@ -83,9 +83,9 @@ var ingressCreateCmd = &cobra.Command{
 	},
 }
 
-func functionExists(tprClient rest.Interface, function, ns string) error {
+func functionExists(crdClient rest.Interface, function, ns string) error {
 	f := spec.Function{}
-	err := tprClient.Get().
+	err := crdClient.Get().
 		Resource("functions").
 		Namespace(ns).
 		Name(function).

--- a/cmd/kubeless/list.go
+++ b/cmd/kubeless/list.go
@@ -49,12 +49,12 @@ var listCmd = &cobra.Command{
 			logrus.Fatal(err.Error())
 		}
 
-		tprClient, err := utils.GetTPRClientOutOfCluster()
+		crdClient, err := utils.GetCRDClientOutOfCluster()
 		if err != nil {
 			logrus.Fatalf("Can not list functions: %v", err)
 		}
 
-		if err := doList(cmd.OutOrStdout(), tprClient, ns, output, args); err != nil {
+		if err := doList(cmd.OutOrStdout(), crdClient, ns, output, args); err != nil {
 			logrus.Fatal(err.Error())
 		}
 	},
@@ -65,11 +65,11 @@ func init() {
 	listCmd.Flags().StringP("namespace", "n", api.NamespaceDefault, "Specify namespace for the function")
 }
 
-func doList(w io.Writer, tprClient rest.Interface, ns, output string, args []string) error {
+func doList(w io.Writer, crdClient rest.Interface, ns, output string, args []string) error {
 	var list []*spec.Function
 	if len(args) == 0 {
 		funcList := spec.FunctionList{}
-		err := tprClient.Get().
+		err := crdClient.Get().
 			Resource("functions").
 			Namespace(ns).
 			Do().
@@ -82,7 +82,7 @@ func doList(w io.Writer, tprClient rest.Interface, ns, output string, args []str
 		list = make([]*spec.Function, 0, len(args))
 		for _, arg := range args {
 			f := spec.Function{}
-			err := tprClient.Get().
+			err := crdClient.Get().
 				Resource("functions").
 				Namespace(ns).
 				Name(arg).

--- a/cmd/kubeless/list_test.go
+++ b/cmd/kubeless/list_test.go
@@ -36,7 +36,7 @@ import (
 	"github.com/kubeless/kubeless/pkg/spec"
 )
 
-func fakeTprClient(f func(req *http.Request) (*http.Response, error)) *fake.RESTClient {
+func fakeCRDClient(f func(req *http.Request) (*http.Response, error)) *fake.RESTClient {
 	return &fake.RESTClient{
 		APIRegistry:          api.Registry,
 		NegotiatedSerializer: api.Codecs,
@@ -131,7 +131,7 @@ func TestList(t *testing.T) {
 		},
 	}
 
-	client := fakeTprClient(func(req *http.Request) (*http.Response, error) {
+	client := fakeCRDClient(func(req *http.Request) (*http.Response, error) {
 		header := http.Header{}
 		header.Set("Content-Type", runtime.ContentTypeJSON)
 		switch req.URL.Path {

--- a/cmd/kubeless/update.go
+++ b/cmd/kubeless/update.go
@@ -107,12 +107,12 @@ var updateCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
-		tprClient, err := utils.GetTPRClientOutOfCluster()
+		crdClient, err := utils.GetCRDClientOutOfCluster()
 		if err != nil {
 			logrus.Fatal(err)
 		}
 
-		err = utils.UpdateK8sCustomResource(tprClient, f)
+		err = utils.UpdateK8sCustomResource(crdClient, f)
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -38,7 +38,7 @@ import (
 )
 
 const (
-	tprName    = "function.k8s.io"
+	crdName    = "function.k8s.io"
 	maxRetries = 5
 	funcKind   = "Function"
 	funcAPI    = "k8s.io"
@@ -53,7 +53,7 @@ var (
 type Controller struct {
 	logger    *logrus.Entry
 	clientset kubernetes.Interface
-	tprclient rest.Interface
+	crdclient rest.Interface
 	Functions map[string]*spec.Function
 	queue     workqueue.RateLimitingInterface
 	informer  cache.SharedIndexInformer
@@ -62,12 +62,12 @@ type Controller struct {
 // Config contains k8s client of a controller
 type Config struct {
 	KubeCli   kubernetes.Interface
-	TprClient rest.Interface
+	CRDClient rest.Interface
 }
 
 // New initializes a controller object
 func New(cfg Config) *Controller {
-	lw := cache.NewListWatchFromClient(cfg.TprClient, "functions", api.NamespaceAll, fields.Everything())
+	lw := cache.NewListWatchFromClient(cfg.CRDClient, "functions", api.NamespaceAll, fields.Everything())
 
 	queue := workqueue.NewRateLimitingQueue(workqueue.DefaultControllerRateLimiter())
 
@@ -102,7 +102,7 @@ func New(cfg Config) *Controller {
 	return &Controller{
 		logger:    logrus.WithField("pkg", "controller"),
 		clientset: cfg.KubeCli,
-		tprclient: cfg.TprClient,
+		crdclient: cfg.CRDClient,
 		informer:  informer,
 		queue:     queue,
 	}

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -121,38 +121,38 @@ func GetRestClient() (*rest.RESTClient, error) {
 	return restClient, nil
 }
 
-// GetTPRClient returns tpr client to the request from inside of cluster
-func GetTPRClient() (*rest.RESTClient, error) {
-	tprconfig, err := rest.InClusterConfig()
+// GetCRDClient returns crd client to the request from inside of cluster
+func GetCRDClient() (*rest.RESTClient, error) {
+	crdconfig, err := rest.InClusterConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	configureClient(tprconfig)
+	configureClient(crdconfig)
 
-	tprclient, err := rest.RESTClientFor(tprconfig)
+	crdclient, err := rest.RESTClientFor(crdconfig)
 	if err != nil {
 		return nil, err
 	}
 
-	return tprclient, nil
+	return crdclient, nil
 }
 
-// GetTPRClientOutOfCluster returns tpr client to the request from outside of cluster
-func GetTPRClientOutOfCluster() (*rest.RESTClient, error) {
-	tprconfig, err := BuildOutOfClusterConfig()
+// GetCRDClientOutOfCluster returns crd client to the request from outside of cluster
+func GetCRDClientOutOfCluster() (*rest.RESTClient, error) {
+	crdconfig, err := BuildOutOfClusterConfig()
 	if err != nil {
 		return nil, err
 	}
 
-	configureClient(tprconfig)
+	configureClient(crdconfig)
 
-	tprclient, err := rest.RESTClientFor(tprconfig)
+	crdclient, err := rest.RESTClientFor(crdconfig)
 	if err != nil {
 		return nil, err
 	}
 
-	return tprclient, nil
+	return crdclient, nil
 }
 
 //GetServiceMonitorClientOutOfCluster returns sm client to the request from outside of cluster
@@ -173,12 +173,12 @@ func GetServiceMonitorClientOutOfCluster() (*monitoringv1alpha1.MonitoringV1alph
 func GetFunction(funcName, ns string) (spec.Function, error) {
 	var f spec.Function
 
-	tprClient, err := GetTPRClientOutOfCluster()
+	crdClient, err := GetCRDClientOutOfCluster()
 	if err != nil {
 		return spec.Function{}, err
 	}
 
-	err = tprClient.Get().
+	err = crdClient.Get().
 		Resource("functions").
 		Namespace(ns).
 		Name(funcName).
@@ -195,8 +195,8 @@ func GetFunction(funcName, ns string) (spec.Function, error) {
 }
 
 // CreateK8sCustomResource will create a custom function object
-func CreateK8sCustomResource(tprClient rest.Interface, f *spec.Function) error {
-	err := tprClient.Post().
+func CreateK8sCustomResource(crdClient rest.Interface, f *spec.Function) error {
+	err := crdClient.Post().
 		Resource("functions").
 		Namespace(f.Metadata.Namespace).
 		Body(f).
@@ -209,12 +209,12 @@ func CreateK8sCustomResource(tprClient rest.Interface, f *spec.Function) error {
 }
 
 // UpdateK8sCustomResource applies changes to the function custom object
-func UpdateK8sCustomResource(tprClient rest.Interface, f *spec.Function) error {
+func UpdateK8sCustomResource(crdClient rest.Interface, f *spec.Function) error {
 	data, err := json.Marshal(f)
 	if err != nil {
 		return err
 	}
-	return tprClient.Patch(types.MergePatchType).
+	return crdClient.Patch(types.MergePatchType).
 		Namespace(f.Metadata.Namespace).
 		Resource("functions").
 		Name(f.Metadata.Name).
@@ -223,8 +223,8 @@ func UpdateK8sCustomResource(tprClient rest.Interface, f *spec.Function) error {
 }
 
 // DeleteK8sCustomResource will delete custom function object
-func DeleteK8sCustomResource(tprClient *rest.RESTClient, funcName, ns string) error {
-	err := tprClient.Delete().
+func DeleteK8sCustomResource(crdClient *rest.RESTClient, funcName, ns string) error {
+	err := crdClient.Delete().
 		Resource("functions").
 		Namespace(ns).
 		Name(funcName).
@@ -260,7 +260,7 @@ func GetReadyPod(pods *v1.PodList) (v1.Pod, error) {
 	return v1.Pod{}, errors.New("There is no pod ready")
 }
 
-// configureClient configures tpr client
+// configureClient configures crd client
 func configureClient(config *rest.Config) {
 	groupversion := schema.GroupVersion{
 		Group:   "k8s.io",


### PR DESCRIPTION
Since Kubeless 0.2 we are using CRD instead of TPR to store functions information. Adapt the code to the new nomenclature.

This changes are in part included in #400 