### PR TITLE
Update resources

### DIFF
--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -425,12 +425,7 @@ func EnsureFuncConfigMap(client kubernetes.Interface, funcObj *spec.Function, or
 
 	_, err = client.Core().ConfigMaps(funcObj.Metadata.Namespace).Create(configMap)
 	if err != nil && k8sErrors.IsAlreadyExists(err) {
-		var data []byte
-		data, err = json.Marshal(configMap)
-		if err != nil {
-			return err
-		}
-		_, err = client.Core().ConfigMaps(funcObj.Metadata.Namespace).Patch(configMap.Name, types.StrategicMergePatchType, data)
+		_, err = client.Core().ConfigMaps(funcObj.Metadata.Namespace).Update(configMap)
 		if err != nil && k8sErrors.IsAlreadyExists(err) {
 			// The configmap may already exist and there is nothing to update
 			return nil
@@ -442,34 +437,39 @@ func EnsureFuncConfigMap(client kubernetes.Interface, funcObj *spec.Function, or
 
 // EnsureFuncService creates/updates a function service
 func EnsureFuncService(client kubernetes.Interface, funcObj *spec.Function, or []metav1.OwnerReference) error {
-	svc := &v1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:            funcObj.Metadata.Name,
-			Labels:          funcObj.Metadata.Labels,
-			OwnerReferences: or,
-		},
-		Spec: v1.ServiceSpec{
-			Ports: []v1.ServicePort{
-				{
-					Name:       "function-port",
-					Port:       8080,
-					TargetPort: intstr.FromInt(8080),
-					NodePort:   0,
-					Protocol:   v1.ProtocolTCP,
-				},
-			},
-			Selector: funcObj.Metadata.Labels,
-			Type:     v1.ServiceTypeClusterIP,
-		},
+	svc, err := client.Core().Services(funcObj.Metadata.Namespace).Get(funcObj.Metadata.Name, metav1.GetOptions{})
+	name := funcObj.Metadata.Name
+	labels := funcObj.Metadata.Labels
+	servicePort := v1.ServicePort{
+		Name:       "function-port",
+		Port:       8080,
+		TargetPort: intstr.FromInt(8080),
+		NodePort:   0,
+		Protocol:   v1.ProtocolTCP,
 	}
-	_, err := client.Core().Services(funcObj.Metadata.Namespace).Create(svc)
-	if err != nil && k8sErrors.IsAlreadyExists(err) {
-		var data []byte
-		data, err = json.Marshal(svc)
-		if err != nil {
-			return err
+	if err != nil && k8sErrors.IsNotFound(err) {
+		svc := v1.Service{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:            name,
+				Labels:          labels,
+				OwnerReferences: or,
+			},
+			Spec: v1.ServiceSpec{
+				Ports:    []v1.ServicePort{servicePort},
+				Selector: labels,
+				Type:     v1.ServiceTypeClusterIP,
+			},
 		}
-		_, err = client.Core().Services(funcObj.Metadata.Namespace).Patch(svc.Name, types.StrategicMergePatchType, data)
+		_, err = client.Core().Services(funcObj.Metadata.Namespace).Create(&svc)
+		return err
+	} else if err == nil {
+		// In case the SVC already exists we should update
+		// just certain fields (for being able to update it)
+		svc.ObjectMeta.Labels = labels
+		svc.ObjectMeta.OwnerReferences = or
+		svc.Spec.Ports = []v1.ServicePort{servicePort}
+		svc.Spec.Selector = funcObj.Metadata.Labels
+		_, err = client.Core().Services(funcObj.Metadata.Namespace).Update(svc)
 		if err != nil && k8sErrors.IsAlreadyExists(err) {
 			// The service may already exist and there is nothing to update
 			return nil
@@ -651,12 +651,7 @@ func EnsureFuncDeployment(client kubernetes.Interface, funcObj *spec.Function, o
 
 	_, err = client.Extensions().Deployments(funcObj.Metadata.Namespace).Create(dpm)
 	if err != nil && k8sErrors.IsAlreadyExists(err) {
-		var data []byte
-		data, err = json.Marshal(dpm)
-		if err != nil {
-			return err
-		}
-		_, err = client.Extensions().Deployments(funcObj.Metadata.Namespace).Patch(dpm.Name, types.StrategicMergePatchType, data)
+		_, err = client.Extensions().Deployments(funcObj.Metadata.Namespace).Update(dpm)
 		if err != nil {
 			return err
 		}

--- a/pkg/utils/k8sutil_test.go
+++ b/pkg/utils/k8sutil_test.go
@@ -212,6 +212,13 @@ func TestEnsureService(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
+	svc, err = clientset.CoreV1().Services(ns).Get(f1Name, metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	if !reflect.DeepEqual(svc.ObjectMeta.Labels, newLabels) {
+		t.Error("Unable to update the service")
+	}
 }
 
 func TestEnsureDeployment(t *testing.T) {


### PR DESCRIPTION
_This changes are in part included in #400_

Use `.Update` instead of `.Patch` when updating a function. This avoid issues with `Patch` strategies, simplify the code and allow unit tests (fake `clientset` doesn't update the element if `Patch` is used).

cc/ @anguslees 