### PR TITLE
add label `created-by=kubeless` to all objects for filtering

### DIFF
--- a/cmd/kubeless/autoscaleList.go
+++ b/cmd/kubeless/autoscaleList.go
@@ -93,7 +93,7 @@ func printAutoscale(w io.Writer, ass []v2alpha1.HorizontalPodAutoscaler, output 
 				v = i.Spec.Metrics[0].Object.TargetValue.String()
 			} else if i.Spec.Metrics[0].Resource != nil {
 				m = string(i.Spec.Metrics[0].Resource.Name)
-				v = fmt.Sprint(i.Spec.Metrics[0].Resource.TargetAverageUtilization)
+				v = fmt.Sprint(*i.Spec.Metrics[0].Resource.TargetAverageUtilization)
 			}
 
 			table.AddRow(n, ns, ta, fmt.Sprint(*min), fmt.Sprint(max), m, v)

--- a/cmd/kubeless/autoscaleList.go
+++ b/cmd/kubeless/autoscaleList.go
@@ -85,7 +85,7 @@ func printAutoscale(w io.Writer, ass []v2alpha1.HorizontalPodAutoscaler, output 
 			m := ""
 			v := ""
 			if len(i.Spec.Metrics) == 0 {
-				fmt.Errorf("The function autoscale %s isn't in correct format. It has no metric defined.", i.Name)
+				logrus.Errorf("The function autoscale %s isn't in correct format. It has no metric defined.", i.Name)
 				continue
 			}
 			if i.Spec.Metrics[0].Object != nil {

--- a/cmd/kubeless/autoscaleList.go
+++ b/cmd/kubeless/autoscaleList.go
@@ -59,7 +59,9 @@ func init() {
 }
 
 func doAutoscaleList(w io.Writer, client kubernetes.Interface, ns, output string) error {
-	asList, err := client.AutoscalingV2alpha1().HorizontalPodAutoscalers(ns).List(metav1.ListOptions{})
+	asList, err := client.AutoscalingV2alpha1().HorizontalPodAutoscalers(ns).List(metav1.ListOptions{
+		LabelSelector: "created-by=kubeless",
+	})
 	if err != nil {
 		return err
 	}
@@ -82,6 +84,10 @@ func printAutoscale(w io.Writer, ass []v2alpha1.HorizontalPodAutoscaler, output 
 			max := i.Spec.MaxReplicas
 			m := ""
 			v := ""
+			if len(i.Spec.Metrics) == 0 {
+				fmt.Errorf("The function autoscale %s isn't in correct format. It has no metric defined.", i.Name)
+				continue
+			}
 			if i.Spec.Metrics[0].Object != nil {
 				m = i.Spec.Metrics[0].Object.MetricName
 				v = i.Spec.Metrics[0].Object.TargetValue.String()

--- a/cmd/kubeless/autoscaleList_test.go
+++ b/cmd/kubeless/autoscaleList_test.go
@@ -32,6 +32,9 @@ func TestAutoscaleList(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: "myns",
+			Labels: map[string]string{
+				"created-by": "kubeless",
+			},
 		},
 		Spec: av2alpha1.HorizontalPodAutoscalerSpec{
 			ScaleTargetRef: av2alpha1.CrossVersionObjectReference{
@@ -56,6 +59,9 @@ func TestAutoscaleList(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bar",
 			Namespace: "myns",
+			Labels: map[string]string{
+				"created-by": "kubeless",
+			},
 		},
 		Spec: av2alpha1.HorizontalPodAutoscalerSpec{
 			ScaleTargetRef: av2alpha1.CrossVersionObjectReference{
@@ -80,13 +86,24 @@ func TestAutoscaleList(t *testing.T) {
 		},
 	}
 
-	client := fake.NewSimpleClientset(&as1, &as2)
+	as3 := av2alpha1.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foobar",
+			Namespace: "myns",
+		},
+	}
+
+	client := fake.NewSimpleClientset(&as1, &as2, &as3)
 
 	output := listAutoscaleOutput(t, client, "myns", "")
 	t.Log("output is", output)
 
 	if !strings.Contains(output, "foo") || !strings.Contains(output, "bar") {
-		t.Errorf("table output didn't mention both functions")
+		t.Errorf("table output didn't mention both autoscales")
+	}
+
+	if strings.Contains(output, "foobar") {
+		t.Errorf("table output shouldn't mention foobar autoscale as it isn't created by kubeless")
 	}
 
 	// json output

--- a/cmd/kubeless/deploy.go
+++ b/cmd/kubeless/deploy.go
@@ -129,6 +129,9 @@ var deployCmd = &cobra.Command{
 		cli := utils.GetClientOutOfCluster()
 		defaultFunctionSpec := spec.Function{}
 		defaultFunctionSpec.Spec.Type = "HTTP"
+		defaultFunctionSpec.Metadata.Labels = map[string]string{
+			"created-by": "kubeless",
+		}
 		f, err := getFunctionDescription(cli, funcName, ns, handler, file, funcDeps, runtime, topic, schedule, runtimeImage, mem, timeout, triggerHTTP, envs, labels, defaultFunctionSpec)
 		if err != nil {
 			logrus.Fatal(err)

--- a/cmd/kubeless/function.go
+++ b/cmd/kubeless/function.go
@@ -72,7 +72,7 @@ func getKV(input string) (string, string) {
 }
 
 func parseLabel(labels []string) map[string]string {
-	funcLabels := map[string]string{}
+	funcLabels := make(map[string]string)
 	for _, label := range labels {
 		k, v := getKV(label)
 		funcLabels[k] = v
@@ -207,9 +207,13 @@ func getFunctionDescription(cli kubernetes.Interface, funcName, ns, handler, fil
 		funcEnv = defaultFunction.Spec.Template.Spec.Containers[0].Env
 	}
 
-	funcLabels := parseLabel(labels)
+	funcLabels := defaultFunction.Metadata.Labels
 	if len(funcLabels) == 0 {
-		funcLabels = defaultFunction.Metadata.Labels
+		funcLabels = make(map[string]string)
+	}
+	ls := parseLabel(labels)
+	for k, v := range ls {
+		funcLabels[k] = v
 	}
 
 	resources := v1.ResourceRequirements{}

--- a/cmd/kubeless/ingressList.go
+++ b/cmd/kubeless/ingressList.go
@@ -76,7 +76,7 @@ func printIngress(w io.Writer, ings []v1beta1.Ingress, output string) error {
 		table.SetHeader([]string{"Name", "namespace", "host", "path", "service name", "service port"})
 		for _, i := range ings {
 			if len(i.Spec.Rules) == 0 {
-				fmt.Errorf("The function ingress %s isn't in correct format. It has no rule defined.", i.Name)
+				logrus.Errorf("The function ingress %s isn't in correct format. It has no rule defined.", i.Name)
 				continue
 			}
 			n := i.Name

--- a/cmd/kubeless/ingressList.go
+++ b/cmd/kubeless/ingressList.go
@@ -59,7 +59,9 @@ func init() {
 }
 
 func doIngressList(w io.Writer, client kubernetes.Interface, ns, output string) error {
-	ingList, err := client.ExtensionsV1beta1().Ingresses(ns).List(v1.ListOptions{})
+	ingList, err := client.ExtensionsV1beta1().Ingresses(ns).List(v1.ListOptions{
+		LabelSelector: "created-by=kubeless",
+	})
 	if err != nil {
 		return err
 	}
@@ -73,6 +75,10 @@ func printIngress(w io.Writer, ings []v1beta1.Ingress, output string) error {
 		table := tablewriter.NewWriter(w)
 		table.SetHeader([]string{"Name", "namespace", "host", "path", "service name", "service port"})
 		for _, i := range ings {
+			if len(i.Spec.Rules) == 0 {
+				fmt.Errorf("The function ingress %s isn't in correct format. It has no rule defined.", i.Name)
+				continue
+			}
 			n := i.Name
 			h := i.Spec.Rules[0].Host
 			p := i.Spec.Rules[0].HTTP.Paths[0].Path

--- a/cmd/kubeless/ingressList_test.go
+++ b/cmd/kubeless/ingressList_test.go
@@ -43,6 +43,9 @@ func TestIngressList(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: "myns",
+			Labels: map[string]string{
+				"created-by": "kubeless",
+			},
 		},
 		Spec: xv1beta1.IngressSpec{
 			Rules: []xv1beta1.IngressRule{
@@ -70,6 +73,9 @@ func TestIngressList(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bar",
 			Namespace: "myns",
+			Labels: map[string]string{
+				"created-by": "kubeless",
+			},
 		},
 		Spec: xv1beta1.IngressSpec{
 			Rules: []xv1beta1.IngressRule{
@@ -93,13 +99,24 @@ func TestIngressList(t *testing.T) {
 		},
 	}
 
-	client := fake.NewSimpleClientset(&ing1, &ing2)
+	ing3 := xv1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "ing3",
+			Namespace: "myns",
+		},
+	}
+
+	client := fake.NewSimpleClientset(&ing1, &ing2, &ing3)
 
 	output := listIngressOutput(t, client, "myns", "")
 	t.Log("output is", output)
 
 	if !strings.Contains(output, "foo") || !strings.Contains(output, "bar") {
-		t.Errorf("table output didn't mention both functions")
+		t.Errorf("table output didn't mention both ingress rules")
+	}
+
+	if strings.Contains(output, "ing3") {
+		t.Errorf("table output shouldn't mention ing3 ingress rule as it isn't created by kubeless")
 	}
 
 	// json output

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -196,7 +196,6 @@ func (c *Controller) ensureK8sResources(funcObj *spec.Function) error {
 		funcObj.Metadata.Labels = make(map[string]string)
 	}
 	funcObj.Metadata.Labels["function"] = funcObj.Metadata.Name
-	funcObj.Metadata.Labels["created-by"] = "kubeless"
 
 	or, err := utils.GetOwnerReference(funcObj)
 	if err != nil {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -196,19 +196,14 @@ func (c *Controller) ensureK8sResources(funcObj *spec.Function) error {
 		funcObj.Metadata.Labels = make(map[string]string)
 	}
 	funcObj.Metadata.Labels["function"] = funcObj.Metadata.Name
+	funcObj.Metadata.Labels["created-by"] = "kubeless"
 
-	t := true
-	or := []metav1.OwnerReference{
-		{
-			Kind:               "Function",
-			APIVersion:         "k8s.io",
-			Name:               funcObj.Metadata.Name,
-			UID:                funcObj.Metadata.UID,
-			BlockOwnerDeletion: &t,
-		},
+	or, err := utils.GetOwnerReference(funcObj)
+	if err != nil {
+		return err
 	}
 
-	err := utils.EnsureFuncConfigMap(c.clientset, funcObj, or)
+	err = utils.EnsureFuncConfigMap(c.clientset, funcObj, or)
 	if err != nil {
 		return err
 	}

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -18,7 +18,6 @@ package utils
 
 import (
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/url"
 	"os"
@@ -278,7 +277,7 @@ func GetReadyPod(pods *v1.PodList) (v1.Pod, error) {
 			return pod, nil
 		}
 	}
-	return v1.Pod{}, errors.New("There is no pod ready")
+	return v1.Pod{}, fmt.Errorf("there is no pod ready")
 }
 
 func appendToCommand(orig string, command ...string) string {
@@ -484,7 +483,7 @@ func DeleteIngress(client kubernetes.Interface, name, ns string) error {
 func splitHandler(handler string) (string, string, error) {
 	str := strings.Split(handler, ".")
 	if len(str) != 2 {
-		return "", "", errors.New("Failed: incorrect handler format. It should be module_name.handler_name")
+		return "", "", fmt.Errorf("failed: incorrect handler format. It should be module_name.handler_name")
 	}
 
 	return str[0], str[1], nil
@@ -974,7 +973,7 @@ func CreateAutoscale(client kubernetes.Interface, funcObj *spec.Function, ns, me
 			return err
 		}
 	default:
-		return errors.New("metric is not supported")
+		return fmt.Errorf("metric is not supported")
 	}
 
 	hpa := &v2alpha1.HorizontalPodAutoscaler{
@@ -1065,15 +1064,17 @@ func createServiceMonitor(funcObj *spec.Function, ns string, or []metav1.OwnerRe
 		return nil
 	}
 
-	return errors.New("service monitor has already existed")
+	return fmt.Errorf("service monitor has already existed")
 }
 
+// GetOwnerReference returns ownerRef for appending to objects's metadata
+// created by kubeless-controller one a function is deployed.
 func GetOwnerReference(funcObj *spec.Function) ([]metav1.OwnerReference, error) {
 	if funcObj.Metadata.Name == "" {
-		return []metav1.OwnerReference{}, fmt.Errorf("Function name can't be empty.")
+		return []metav1.OwnerReference{}, fmt.Errorf("function name can't be empty")
 	}
 	if funcObj.Metadata.UID == "" {
-		return []metav1.OwnerReference{}, fmt.Errorf("UID of function %s can't be empty.", funcObj.Metadata.Name)
+		return []metav1.OwnerReference{}, fmt.Errorf("uid of function %s can't be empty", funcObj.Metadata.Name)
 	}
 	t := true
 	return []metav1.OwnerReference{

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -402,12 +402,19 @@ func addInitContainerAnnotation(dpm *v1beta1.Deployment) error {
 }
 
 // CreateIngress creates ingress rule for a specific function
-func CreateIngress(client kubernetes.Interface, ingressName, funcName, hostname, ns string, enableTLSAcme bool) error {
+func CreateIngress(client kubernetes.Interface, funcObj *spec.Function, ingressName, hostname, ns string, enableTLSAcme bool) error {
+
+	or, err := GetOwnerReference(funcObj)
+	if err != nil {
+		return err
+	}
 
 	ingress := &v1beta1.Ingress{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      ingressName,
-			Namespace: ns,
+			Name:            ingressName,
+			Namespace:       ns,
+			OwnerReferences: or,
+			Labels:          funcObj.Metadata.Labels,
 		},
 		Spec: v1beta1.IngressSpec{
 			Rules: []v1beta1.IngressRule{
@@ -419,7 +426,7 @@ func CreateIngress(client kubernetes.Interface, ingressName, funcName, hostname,
 								{
 									Path: "/",
 									Backend: v1beta1.IngressBackend{
-										ServiceName: funcName,
+										ServiceName: funcObj.Metadata.Name,
 										ServicePort: intstr.FromInt(8080),
 									},
 								},
@@ -447,7 +454,7 @@ func CreateIngress(client kubernetes.Interface, ingressName, funcName, hostname,
 		}
 	}
 
-	_, err := client.ExtensionsV1beta1().Ingresses(ns).Create(ingress)
+	_, err = client.ExtensionsV1beta1().Ingresses(ns).Create(ingress)
 	if err != nil {
 		return err
 	}
@@ -921,7 +928,12 @@ func EnsureFuncCronJob(client rest.Interface, funcObj *spec.Function, or []metav
 }
 
 // CreateAutoscale creates HPA object for function
-func CreateAutoscale(client kubernetes.Interface, funcName, ns, metric string, min, max int32, value string) error {
+func CreateAutoscale(client kubernetes.Interface, funcObj *spec.Function, ns, metric string, min, max int32, value string) error {
+	or, err := GetOwnerReference(funcObj)
+	if err != nil {
+		return err
+	}
+
 	m := []v2alpha1.MetricSpec{}
 	switch metric {
 	case "cpu":
@@ -952,12 +964,12 @@ func CreateAutoscale(client kubernetes.Interface, funcName, ns, metric string, m
 					TargetValue: q,
 					Target: v2alpha1.CrossVersionObjectReference{
 						Kind: "Service",
-						Name: funcName,
+						Name: funcObj.Metadata.Name,
 					},
 				},
 			},
 		}
-		err = createServiceMonitor(funcName, ns)
+		err = createServiceMonitor(funcObj, ns, or)
 		if err != nil {
 			return err
 		}
@@ -967,13 +979,15 @@ func CreateAutoscale(client kubernetes.Interface, funcName, ns, metric string, m
 
 	hpa := &v2alpha1.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      funcName,
-			Namespace: ns,
+			Name:            funcObj.Metadata.Name,
+			Namespace:       ns,
+			Labels:          funcObj.Metadata.Labels,
+			OwnerReferences: or,
 		},
 		Spec: v2alpha1.HorizontalPodAutoscalerSpec{
 			ScaleTargetRef: v2alpha1.CrossVersionObjectReference{
 				Kind: "Deployment",
-				Name: funcName,
+				Name: funcObj.Metadata.Name,
 			},
 			MinReplicas: &min,
 			MaxReplicas: max,
@@ -981,7 +995,7 @@ func CreateAutoscale(client kubernetes.Interface, funcName, ns, metric string, m
 		},
 	}
 
-	_, err := client.AutoscalingV2alpha1().HorizontalPodAutoscalers(ns).Create(hpa)
+	_, err = client.AutoscalingV2alpha1().HorizontalPodAutoscalers(ns).Create(hpa)
 	if err != nil {
 		return err
 	}
@@ -1012,27 +1026,28 @@ func DeleteServiceMonitor(name, ns string) error {
 	return nil
 }
 
-func createServiceMonitor(funcName, ns string) error {
+func createServiceMonitor(funcObj *spec.Function, ns string, or []metav1.OwnerReference) error {
 	smclient, err := GetServiceMonitorClientOutOfCluster()
 	if err != nil {
 		return err
 	}
 
-	_, err = smclient.ServiceMonitors(ns).Get(funcName, metav1.GetOptions{})
+	_, err = smclient.ServiceMonitors(ns).Get(funcObj.Metadata.Name, metav1.GetOptions{})
 	if err != nil {
 		if k8sErrors.IsNotFound(err) {
 			s := &monitoringv1alpha1.ServiceMonitor{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      funcName,
+					Name:      funcObj.Metadata.Name,
 					Namespace: ns,
 					Labels: map[string]string{
 						"service-monitor": "function",
 					},
+					OwnerReferences: or,
 				},
 				Spec: monitoringv1alpha1.ServiceMonitorSpec{
 					Selector: metav1.LabelSelector{
 						MatchLabels: map[string]string{
-							"function": funcName,
+							"function": funcObj.Metadata.Name,
 						},
 					},
 					Endpoints: []monitoringv1alpha1.Endpoint{
@@ -1051,4 +1066,23 @@ func createServiceMonitor(funcName, ns string) error {
 	}
 
 	return errors.New("service monitor has already existed")
+}
+
+func GetOwnerReference(funcObj *spec.Function) ([]metav1.OwnerReference, error) {
+	if funcObj.Metadata.Name == "" {
+		return []metav1.OwnerReference{}, fmt.Errorf("Function name can't be empty.")
+	}
+	if funcObj.Metadata.UID == "" {
+		return []metav1.OwnerReference{}, fmt.Errorf("UID of function %s can't be empty.", funcObj.Metadata.Name)
+	}
+	t := true
+	return []metav1.OwnerReference{
+		{
+			Kind:               "Function",
+			APIVersion:         "k8s.io",
+			Name:               funcObj.Metadata.Name,
+			UID:                funcObj.Metadata.UID,
+			BlockOwnerDeletion: &t,
+		},
+	}, nil
 }

--- a/pkg/utils/k8sutil_test.go
+++ b/pkg/utils/k8sutil_test.go
@@ -673,10 +673,18 @@ func doesNotContain(envs []v1.EnvVar, env v1.EnvVar) bool {
 
 func TestCreateIngressResource(t *testing.T) {
 	clientset := fake.NewSimpleClientset()
-	if err := CreateIngress(clientset, "foo", "bar", "foo.bar", "myns", false); err != nil {
+	f1 := &spec.Function{
+		Metadata: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "myns",
+			UID:       "1234",
+		},
+		Spec: spec.FunctionSpec{},
+	}
+	if err := CreateIngress(clientset, f1, "bar", "foo.bar", "myns", false); err != nil {
 		t.Fatalf("Creating ingress returned err: %v", err)
 	}
-	if err := CreateIngress(clientset, "foo", "bar", "foo.bar", "myns", false); err != nil {
+	if err := CreateIngress(clientset, f1, "bar", "foo.bar", "myns", false); err != nil {
 		if !k8sErrors.IsAlreadyExists(err) {
 			t.Fatalf("Expect object is already exists, got %v", err)
 		}
@@ -685,7 +693,16 @@ func TestCreateIngressResource(t *testing.T) {
 
 func TestCreateIngressResourceWithTLSAcme(t *testing.T) {
 	clientset := fake.NewSimpleClientset()
-	if err := CreateIngress(clientset, "foo", "bar", "foo.bar", "myns", true); err != nil {
+	f1 := &spec.Function{
+		Metadata: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "myns",
+			UID:       "1234",
+		},
+		Spec: spec.FunctionSpec{},
+	}
+
+	if err := CreateIngress(clientset, f1, "foo", "foo.bar", "myns", true); err != nil {
 		t.Fatalf("Creating ingress returned err: %v", err)
 	}
 
@@ -762,7 +779,15 @@ func TestCreateAutoscaleResource(t *testing.T) {
 	min := int32(1)
 	max := int32(10)
 	clientset := fake.NewSimpleClientset()
-	if err := CreateAutoscale(clientset, "foo", "myns", "cpu", min, max, "50"); err != nil {
+	f1 := &spec.Function{
+		Metadata: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "myns",
+			UID:       "1234",
+		},
+		Spec: spec.FunctionSpec{},
+	}
+	if err := CreateAutoscale(clientset, f1, "myns", "cpu", min, max, "50"); err != nil {
 		t.Fatalf("Creating autoscale returned err: %v", err)
 	}
 


### PR DESCRIPTION
This PR aims to add a label `created-by=kubeless` to all objects. Then it won't list out non-kubeless objects, specially for ingress and autoscale.

Fix #405 