### PR TITLE
Return deployment status

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,6 +94,9 @@ $ kubeless function deploy get-python --runtime python2.7 \
                                 --from-file test.py \
                                 --handler test.foobar \
                                 --trigger-http
+INFO[0000] Deploying function...
+INFO[0000] Function get-python submitted for deployment
+INFO[0000] Check the deployment status executing 'kubeless function ls get-python'
 ```
 
 Let's dissect the command:
@@ -120,8 +123,8 @@ NAME          KIND
 get-python    Function.v1.k8s.io
 
 $ kubeless function ls
-NAME        NAMESPACE   HANDLER     RUNTIME     TYPE    TOPIC
-get-python  default     test.foobar python2.7   HTTP
+NAME           	NAMESPACE	HANDLER              	RUNTIME  	TYPE  	TOPIC      	DEPENDENCIES	STATUS
+get-python     	default  	helloget.foo         	python2.7	HTTP  	           	            	1/1 READY
 ```
 
 You can then call the function with:

--- a/cmd/kubeless/deploy.go
+++ b/cmd/kubeless/deploy.go
@@ -127,6 +127,16 @@ var deployCmd = &cobra.Command{
 		if err != nil {
 			logrus.Fatal(err)
 		}
+
+		cli := utils.GetClientOutOfCluster()
+		timeout, err := getDeploymentTimeout()
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		err = waitForDeployment(cli, funcName, ns, timeout)
+		if err != nil {
+			logrus.Fatalf("Something went wrong: %s", err)
+		}
 	},
 }
 

--- a/cmd/kubeless/deploy.go
+++ b/cmd/kubeless/deploy.go
@@ -123,20 +123,13 @@ var deployCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
+		logrus.Infof("Deploying function...")
 		err = utils.CreateK8sCustomResource(crdClient, f)
 		if err != nil {
 			logrus.Fatal(err)
 		}
-
-		cli := utils.GetClientOutOfCluster()
-		timeout, err := getDeploymentTimeout()
-		if err != nil {
-			logrus.Fatal(err)
-		}
-		err = waitForDeployment(cli, funcName, ns, timeout)
-		if err != nil {
-			logrus.Fatalf("Something went wrong: %s", err)
-		}
+		logrus.Infof("Function %s submitted for deployment", funcName)
+		logrus.Infof("Check the deployment status executing 'kubeless function ls %s'", funcName)
 	},
 }
 

--- a/cmd/kubeless/function.go
+++ b/cmd/kubeless/function.go
@@ -215,7 +215,7 @@ func getDeploymentStatus(cli kubernetes.Interface, funcName, ns string) (string,
 		return "", err
 	}
 	status := fmt.Sprintf("%d/%d", dpm.Status.ReadyReplicas, dpm.Status.Replicas)
-	if dpm.Status.ReadyReplicas == dpm.Status.Replicas {
+	if dpm.Status.ReadyReplicas > 0 {
 		status += " READY"
 	} else {
 		status += " NOT READY"

--- a/cmd/kubeless/function.go
+++ b/cmd/kubeless/function.go
@@ -19,13 +19,21 @@ package main
 import (
 	"fmt"
 	"io/ioutil"
+	"os"
+	"strconv"
 	"strings"
+	"time"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/kubeless/kubeless/pkg/spec"
+	// "github.com/kubeless/kubeless/pkg/utils"
 	"github.com/spf13/cobra"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"
+	// "k8s.io/client-go/rest"
 )
 
 var functionCmd = &cobra.Command{
@@ -206,4 +214,113 @@ func getFunctionDescription(funcName, ns, handler, funcContent, deps, runtime, t
 		},
 	}
 	return
+}
+
+// Returns the maximum timeout that we will wait for a deployment
+// Defaults: 10 min
+func getDeploymentTimeout() (int, error) {
+	envTimeout := os.Getenv("KUBELESS_DEPLOYMENT_TIMEOUT")
+	if envTimeout == "" {
+		envTimeout = "600"
+	}
+	timeout, err := strconv.Atoi(envTimeout)
+	if err != nil {
+		return 0, fmt.Errorf("Wrong value for KUBELESS_DEPLOYMENT_TIMEOUT: %s", err)
+	}
+	return timeout, nil
+}
+
+func getContainerStatus(c v1.ContainerStatus) string {
+	if c.State.Terminated != nil {
+		return c.State.Terminated.Reason
+	} else if c.State.Waiting != nil {
+		return c.State.Waiting.Reason
+	} else if c.State.Running != nil {
+		return "Running"
+	}
+	return ""
+}
+
+func getPodStatus(pod v1.Pod) string {
+	if pod.DeletionTimestamp != nil {
+		return "Terminating"
+	}
+	if len(pod.Status.ContainerStatuses) > 0 {
+		return getContainerStatus(pod.Status.ContainerStatuses[0])
+	} else if len(pod.Status.InitContainerStatuses) > 0 {
+		return "Init:" + getContainerStatus(pod.Status.InitContainerStatuses[0])
+	}
+	// If the pod doesn't have containers it is a temporary Pod
+	return ""
+}
+
+func getPodList(cli kubernetes.Interface, funcName, ns string) ([]v1.Pod, error) {
+	pods, err := cli.CoreV1().Pods(ns).List(metav1.ListOptions{
+		LabelSelector: "function=" + funcName,
+	})
+	if err != nil {
+		return []v1.Pod{}, err
+	}
+	return pods.Items, nil
+}
+
+func printDeploymentLogs(cli kubernetes.Interface, funcName, ns string) error {
+	podList, err := getPodList(cli, funcName, ns)
+	if err != nil {
+		return err
+	}
+	for _, pod := range podList {
+		podStatus := getPodStatus(pod)
+		// Retrieving logs of useful pods
+		if podStatus != "Unknown" && podStatus != "Terminating" {
+			resBytes, err := cli.CoreV1().RESTClient().Get().Namespace(ns).Name(pod.Name).Resource("pods").SubResource("log").Do().Raw()
+			if err == nil {
+				logrus.Errorf("Logs from %s:\n%s", pod.Name, string(resBytes))
+			}
+		}
+	}
+	return nil
+}
+
+func waitForDeployment(cli kubernetes.Interface, funcName, ns string, timeout int) error {
+	successCount := 0
+	retriesCount := 0
+	logrus.Info("Deployment status:")
+	var previousStatus, currentStatus string
+	err := wait.Poll(time.Duration(time.Second), time.Duration(timeout)*time.Second, func() (bool, error) {
+		dpm, err := cli.ExtensionsV1beta1().Deployments(ns).Get(funcName, metav1.GetOptions{})
+		ready := false
+		if err != nil {
+			// Deployment not available
+			retriesCount++
+			if retriesCount >= 3 {
+				// The deployment may not be ready yet if the controller
+				// is still processing the function so we retry 3 times
+				// (if it takes more than that we assume there has been an error)
+				return false, fmt.Errorf("Unable to find a deployment for %s", funcName)
+			}
+		} else {
+			currentStatus = fmt.Sprintf("Ready replicas: %d/%d", dpm.Status.ReadyReplicas, dpm.Status.Replicas)
+			if currentStatus != previousStatus {
+				previousStatus = currentStatus
+				logrus.Info(currentStatus)
+			}
+			if dpm.Status.Replicas == dpm.Status.ReadyReplicas {
+				// Pods may be running for a short amount of time
+				// So we ensure that it keeps running for at least 5 seconds
+				successCount++
+			} else {
+				successCount = 0
+			}
+			if successCount == 5 {
+				logrus.Infof("Function %s is ready", funcName)
+				ready = true
+			}
+		}
+		return ready, nil
+	})
+	if err != nil {
+		printDeploymentLogs(cli, funcName, ns)
+	}
+	return err
 }

--- a/cmd/kubeless/list.go
+++ b/cmd/kubeless/list.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ghodss/yaml"
 	"github.com/gosuri/uitable"
 	"github.com/spf13/cobra"
+	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/rest"
@@ -138,7 +139,9 @@ func printFunctions(w io.Writer, functions []*spec.Function, cli kubernetes.Inte
 			tp := f.Spec.Topic
 			ns := f.Metadata.Namespace
 			status, err := getDeploymentStatus(cli, f.Metadata.Name, f.Metadata.Namespace)
-			if err != nil {
+			if err != nil && k8sErrors.IsNotFound(err) {
+				status = "MISSING: Check controller logs"
+			} else if err != nil {
 				return err
 			}
 			deps, err := parseDeps(f.Spec.Deps, r)
@@ -166,7 +169,9 @@ func printFunctions(w io.Writer, functions []*spec.Function, cli kubernetes.Inte
 			s := f.Spec.Schedule
 			ns := f.Metadata.Namespace
 			status, err := getDeploymentStatus(cli, f.Metadata.Name, f.Metadata.Namespace)
-			if err != nil {
+			if err != nil && k8sErrors.IsNotFound(err) {
+				status = "MISSING: Check controller logs"
+			} else if err != nil {
 				return err
 			}
 			mem := ""

--- a/cmd/kubeless/list_test.go
+++ b/cmd/kubeless/list_test.go
@@ -22,32 +22,36 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
+	"regexp"
 	"strings"
 	"testing"
 
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/rest"
-	"k8s.io/client-go/rest/fake"
+	restFake "k8s.io/client-go/rest/fake"
 
 	"github.com/kubeless/kubeless/pkg/spec"
 )
 
-func fakeCRDClient(f func(req *http.Request) (*http.Response, error)) *fake.RESTClient {
-	return &fake.RESTClient{
+func fakeCRDClient(f func(req *http.Request) (*http.Response, error)) *restFake.RESTClient {
+	return &restFake.RESTClient{
 		APIRegistry:          api.Registry,
 		NegotiatedSerializer: api.Codecs,
-		Client:               fake.CreateHTTPClient(f),
+		Client:               restFake.CreateHTTPClient(f),
 	}
 }
 
-func listOutput(t *testing.T, client rest.Interface, ns, output string, args []string) string {
+func listOutput(t *testing.T, client rest.Interface, apiV1Client kubernetes.Interface, ns, output string, args []string) string {
 	var buf bytes.Buffer
 
-	if err := doList(&buf, client, ns, output, args); err != nil {
+	if err := doList(&buf, client, apiV1Client, ns, output, args); err != nil {
 		t.Fatalf("doList returned error: %v", err)
 	}
 
@@ -128,6 +132,25 @@ func TestList(t *testing.T) {
 					},
 				},
 			},
+			{
+				Metadata: metav1.ObjectMeta{
+					Name:      "wrong",
+					Namespace: "myns",
+				},
+				Spec: spec.FunctionSpec{
+					Handler:  "fhandler",
+					Function: "ffunction",
+					Runtime:  "fruntime",
+					Type:     "ftype",
+					Topic:    "ftopic",
+					Deps:     "fdeps",
+					Template: v1.PodTemplateSpec{
+						Spec: v1.PodSpec{
+							Containers: []v1.Container{{}},
+						},
+					},
+				},
+			},
 		},
 	}
 
@@ -152,17 +175,60 @@ func TestList(t *testing.T) {
 			return nil, nil
 		}
 	})
+	deploymentFoo := v1beta1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "myns",
+		},
+		Status: v1beta1.DeploymentStatus{
+			Replicas:      int32(1),
+			ReadyReplicas: int32(1),
+		},
+	}
+	deploymentBar := v1beta1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "bar",
+			Namespace: "myns",
+		},
+		Status: v1beta1.DeploymentStatus{
+			Replicas:      int32(2),
+			ReadyReplicas: int32(1),
+		},
+	}
+	apiV1Client := fake.NewSimpleClientset(&deploymentFoo, &deploymentBar)
 
 	// No arg -> list everything in namespace
-	output := listOutput(t, client, "myns", "", []string{})
+	output := listOutput(t, client, apiV1Client, "myns", "", []string{})
 	t.Log("output is", output)
 
 	if !strings.Contains(output, "foo") || !strings.Contains(output, "bar") {
 		t.Errorf("table output didn't mention both functions")
 	}
+	// Status
+	m, err := regexp.MatchString("foo.*1/1 READY", output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m {
+		t.Errorf("table output didn't mention deployment status")
+	}
+	m, err = regexp.MatchString("bar.*1/2 NOT READY", output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m {
+		t.Errorf("table output didn't mention deployment status")
+	}
+	m, err = regexp.MatchString("wrong.*MISSING", output)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !m {
+		t.Errorf("table output didn't mention deployment status")
+	}
 
 	// Explicit arg(s)
-	output = listOutput(t, client, "myns", "", []string{"foo"})
+	output = listOutput(t, client, apiV1Client, "myns", "", []string{"foo"})
 	t.Log("output is", output)
 
 	if !strings.Contains(output, "foo") {
@@ -180,21 +246,21 @@ func TestList(t *testing.T) {
 	// Probably need to fix output framing first.
 
 	// json output
-	output = listOutput(t, client, "myns", "json", []string{})
+	output = listOutput(t, client, apiV1Client, "myns", "json", []string{})
 	t.Log("output is", output)
 	if !strings.Contains(output, "foo") || !strings.Contains(output, "bar") {
 		t.Errorf("table output didn't mention both functions")
 	}
 
 	// yaml output
-	output = listOutput(t, client, "myns", "yaml", []string{})
+	output = listOutput(t, client, apiV1Client, "myns", "yaml", []string{})
 	t.Log("output is", output)
 	if !strings.Contains(output, "128Mi") {
 		t.Errorf("table output didn't mention proper memory of function")
 	}
 
 	// wide output
-	output = listOutput(t, client, "myns", "wide", []string{})
+	output = listOutput(t, client, apiV1Client, "myns", "wide", []string{})
 	t.Log("output is", output)
 	if !strings.Contains(output, "foo = bar") {
 		t.Errorf("table output didn't mention proper env of function")

--- a/cmd/kubeless/list_test.go
+++ b/cmd/kubeless/list_test.go
@@ -192,7 +192,7 @@ func TestList(t *testing.T) {
 		},
 		Status: v1beta1.DeploymentStatus{
 			Replicas:      int32(2),
-			ReadyReplicas: int32(1),
+			ReadyReplicas: int32(0),
 		},
 	}
 	apiV1Client := fake.NewSimpleClientset(&deploymentFoo, &deploymentBar)
@@ -212,7 +212,7 @@ func TestList(t *testing.T) {
 	if !m {
 		t.Errorf("table output didn't mention deployment status")
 	}
-	m, err = regexp.MatchString("bar.*1/2 NOT READY", output)
+	m, err = regexp.MatchString("bar.*0/2 NOT READY", output)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/cmd/kubeless/update.go
+++ b/cmd/kubeless/update.go
@@ -111,10 +111,19 @@ var updateCmd = &cobra.Command{
 		if err != nil {
 			logrus.Fatal(err)
 		}
-
 		err = utils.UpdateK8sCustomResource(crdClient, f)
 		if err != nil {
 			logrus.Fatal(err)
+		}
+
+		cli := utils.GetClientOutOfCluster()
+		timeout, err := getDeploymentTimeout()
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		err = waitForDeployment(cli, funcName, ns, timeout)
+		if err != nil {
+			logrus.Fatalf("Something went wrong: %s", err)
 		}
 	},
 }

--- a/cmd/kubeless/update.go
+++ b/cmd/kubeless/update.go
@@ -111,20 +111,13 @@ var updateCmd = &cobra.Command{
 		if err != nil {
 			logrus.Fatal(err)
 		}
+		logrus.Infof("Redeploying function...")
 		err = utils.UpdateK8sCustomResource(crdClient, f)
 		if err != nil {
 			logrus.Fatal(err)
 		}
-
-		cli := utils.GetClientOutOfCluster()
-		timeout, err := getDeploymentTimeout()
-		if err != nil {
-			logrus.Fatal(err)
-		}
-		err = waitForDeployment(cli, funcName, ns, timeout)
-		if err != nil {
-			logrus.Fatalf("Something went wrong: %s", err)
-		}
+		logrus.Infof("Function %s submitted for deployment", funcName)
+		logrus.Infof("Check the deployment status executing 'kubeless function ls %s'", funcName)
 	},
 }
 


### PR DESCRIPTION
Fixes #87 (Gives feedback to the users about the function deployment)

TODOs:
 - [X] Unit tests
 - [X] Docs

Output example:
```
▶ kubeless function deploy pubsub-python34 --trigger-topic s3-python34 --runtime python3.4 --handler pubsub.handler --from-file examples/python/pubsub.py
INFO[0000] Deploying function...
INFO[0000] Function post-nodejs submitted for deployment
INFO[0000] Check the deployment status executing 'kubeless function ls post-nodejs'
▶ kubeless function ls post-nodejs
NAME       	NAMESPACE	HANDLER              	RUNTIME	TYPE	TOPIC	DEPENDENCIES	STATUS
post-nodejs	default  	hellowithdata.handler	nodejs6	HTTP	     	            	0/1 NOT READY
▶ kubeless function ls post-nodejs
NAME       	NAMESPACE	HANDLER              	RUNTIME	TYPE	TOPIC	DEPENDENCIES	STATUS
post-nodejs	default  	hellowithdata.handler	nodejs6	HTTP	     	            	1/1 READY
```

Case for wrong deployment:
```
▶ kubeless function deploy get-python-wrong --trigger-http --from-file examples/python/helloget.py --handler helloget.foo --runtime python2.9
INFO[0000] Deploying function...
INFO[0000] Function get-python-wrong submitted for deployment
INFO[0000] Check the deployment status executing 'kubeless function ls get-python-wrong'
▶ kubeless function ls get-python-wrong
NAME            	NAMESPACE	HANDLER     	RUNTIME  	TYPE	TOPIC	DEPENDENCIES	STATUS
get-python-wrong	default  	helloget.foo	python2.9	HTTP	     	            	MISSING: Check controller logs
```