### PR TITLE
use the namespace set in current kubecfg context as default namespace instead of "default"

### DIFF
--- a/cmd/kubeless/autoscale.go
+++ b/cmd/kubeless/autoscale.go
@@ -15,7 +15,6 @@ package main
 
 import (
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/pkg/api"
 )
 
 var autoscaleCmd = &cobra.Command{
@@ -32,7 +31,7 @@ func init() {
 
 	for _, cmd := range cmds {
 		autoscaleCmd.AddCommand(cmd)
-		cmd.Flags().StringP("namespace", "n", api.NamespaceDefault, "Specify namespace for the autoscale")
+		cmd.Flags().StringP("namespace", "n", "", "Specify namespace for the autoscale")
 
 	}
 }

--- a/cmd/kubeless/autoscaleCreate.go
+++ b/cmd/kubeless/autoscaleCreate.go
@@ -32,6 +32,10 @@ var autoscaleCreateCmd = &cobra.Command{
 		if err != nil {
 			logrus.Fatal(err.Error())
 		}
+		if ns == "" {
+			ns = utils.GetDefaultNamespace()
+		}
+
 		metric, err := cmd.Flags().GetString("metric")
 		if err != nil {
 			logrus.Fatal(err.Error())

--- a/cmd/kubeless/autoscaleDelete.go
+++ b/cmd/kubeless/autoscaleDelete.go
@@ -33,6 +33,9 @@ var autoscaleDeleteCmd = &cobra.Command{
 		if err != nil {
 			logrus.Fatal(err)
 		}
+		if ns == "" {
+			ns = utils.GetDefaultNamespace()
+		}
 
 		client := utils.GetClientOutOfCluster()
 

--- a/cmd/kubeless/autoscaleList.go
+++ b/cmd/kubeless/autoscaleList.go
@@ -42,6 +42,9 @@ var autoscaleListCmd = &cobra.Command{
 		if err != nil {
 			logrus.Fatal(err.Error())
 		}
+		if ns == "" {
+			ns = utils.GetDefaultNamespace()
+		}
 
 		client := utils.GetClientOutOfCluster()
 

--- a/cmd/kubeless/call.go
+++ b/cmd/kubeless/call.go
@@ -26,7 +26,6 @@ import (
 	"github.com/kubeless/kubeless/pkg/utils"
 	"github.com/spf13/cobra"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/rest"
 )
 
@@ -58,6 +57,9 @@ var callCmd = &cobra.Command{
 		ns, err := cmd.Flags().GetString("namespace")
 		if err != nil {
 			logrus.Fatal(err)
+		}
+		if ns == "" {
+			ns = utils.GetDefaultNamespace()
 		}
 
 		clientset := utils.GetClientOutOfCluster()
@@ -93,6 +95,6 @@ var callCmd = &cobra.Command{
 
 func init() {
 	callCmd.Flags().StringP("data", "", "", "Specify data for function")
-	callCmd.Flags().StringP("namespace", "", api.NamespaceDefault, "Specify namespace for the function")
+	callCmd.Flags().StringP("namespace", "", "", "Specify namespace for the function")
 
 }

--- a/cmd/kubeless/delete.go
+++ b/cmd/kubeless/delete.go
@@ -20,7 +20,6 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/kubeless/kubeless/pkg/utils"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/pkg/api"
 )
 
 var deleteCmd = &cobra.Command{
@@ -37,6 +36,10 @@ var deleteCmd = &cobra.Command{
 		if err != nil {
 			logrus.Fatal(err)
 		}
+		if ns == "" {
+			ns = utils.GetDefaultNamespace()
+		}
+
 		crdClient, err := utils.GetCRDClientOutOfCluster()
 		if err != nil {
 			logrus.Fatal(err)
@@ -50,5 +53,5 @@ var deleteCmd = &cobra.Command{
 }
 
 func init() {
-	deleteCmd.Flags().StringP("namespace", "", api.NamespaceDefault, "Specify namespace for the function")
+	deleteCmd.Flags().StringP("namespace", "", "", "Specify namespace for the function")
 }

--- a/cmd/kubeless/deploy.go
+++ b/cmd/kubeless/deploy.go
@@ -25,7 +25,6 @@ import (
 	"github.com/kubeless/kubeless/pkg/spec"
 	"github.com/kubeless/kubeless/pkg/utils"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/pkg/api"
 )
 
 var deployCmd = &cobra.Command{
@@ -82,6 +81,9 @@ var deployCmd = &cobra.Command{
 		if err != nil {
 			logrus.Fatal(err)
 		}
+		if ns == "" {
+			ns = utils.GetDefaultNamespace()
+		}
 
 		deps, err := cmd.Flags().GetString("dependencies")
 		if err != nil {
@@ -134,7 +136,7 @@ func init() {
 	deployCmd.Flags().StringP("from-file", "", "", "Specify code file")
 	deployCmd.Flags().StringSliceP("label", "", []string{}, "Specify labels of the function. Both separator ':' and '=' are allowed. For example: --label foo1=bar1,foo2:bar2")
 	deployCmd.Flags().StringArrayP("env", "", []string{}, "Specify environment variable of the function. Both separator ':' and '=' are allowed. For example: --env foo1=bar1,foo2:bar2")
-	deployCmd.Flags().StringP("namespace", "", api.NamespaceDefault, "Specify namespace for the function")
+	deployCmd.Flags().StringP("namespace", "", "", "Specify namespace for the function")
 	deployCmd.Flags().StringP("dependencies", "", "", "Specify a file containing list of dependencies for the function")
 	deployCmd.Flags().StringP("trigger-topic", "", "kubeless", "Deploy a pubsub function to Kubeless")
 	deployCmd.Flags().StringP("schedule", "", "", "Specify schedule in cron format for scheduled function")

--- a/cmd/kubeless/describe.go
+++ b/cmd/kubeless/describe.go
@@ -26,7 +26,6 @@ import (
 	"github.com/kubeless/kubeless/pkg/spec"
 	"github.com/kubeless/kubeless/pkg/utils"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/pkg/api"
 )
 
 var describeCmd = &cobra.Command{
@@ -43,6 +42,9 @@ var describeCmd = &cobra.Command{
 		ns, err := cmd.Flags().GetString("namespace")
 		if err != nil {
 			logrus.Fatalf("Can not describe function: %v", err)
+		}
+		if ns == "" {
+			ns = utils.GetDefaultNamespace()
 		}
 
 		output, err := cmd.Flags().GetString("out")
@@ -64,7 +66,7 @@ var describeCmd = &cobra.Command{
 
 func init() {
 	describeCmd.Flags().StringP("out", "o", "", "Output format. One of: json|yaml")
-	describeCmd.Flags().StringP("namespace", "", api.NamespaceDefault, "Specify namespace for the function")
+	describeCmd.Flags().StringP("namespace", "", "", "Specify namespace for the function")
 }
 
 func print(f spec.Function, name, output string) error {

--- a/cmd/kubeless/ingress.go
+++ b/cmd/kubeless/ingress.go
@@ -15,7 +15,6 @@ package main
 
 import (
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/pkg/api"
 )
 
 var ingressCmd = &cobra.Command{
@@ -32,7 +31,7 @@ func init() {
 
 	for _, cmd := range cmds {
 		ingressCmd.AddCommand(cmd)
-		cmd.Flags().StringP("namespace", "n", api.NamespaceDefault, "Specify namespace for the ingress")
+		cmd.Flags().StringP("namespace", "n", "", "Specify namespace for the ingress")
 
 	}
 }

--- a/cmd/kubeless/ingressCreate.go
+++ b/cmd/kubeless/ingressCreate.go
@@ -35,6 +35,9 @@ var ingressCreateCmd = &cobra.Command{
 		if err != nil {
 			logrus.Fatal(err)
 		}
+		if ns == "" {
+			ns = utils.GetDefaultNamespace()
+		}
 
 		funcName, err := cmd.Flags().GetString("function")
 		if err != nil {

--- a/cmd/kubeless/ingressDelete.go
+++ b/cmd/kubeless/ingressDelete.go
@@ -33,6 +33,9 @@ var ingressDeleteCmd = &cobra.Command{
 		if err != nil {
 			logrus.Fatal(err)
 		}
+		if ns == "" {
+			ns = utils.GetDefaultNamespace()
+		}
 
 		client := utils.GetClientOutOfCluster()
 

--- a/cmd/kubeless/ingressList.go
+++ b/cmd/kubeless/ingressList.go
@@ -42,6 +42,9 @@ var ingressListCmd = &cobra.Command{
 		if err != nil {
 			logrus.Fatal(err.Error())
 		}
+		if ns == "" {
+			ns = utils.GetDefaultNamespace()
+		}
 
 		client := utils.GetClientOutOfCluster()
 

--- a/cmd/kubeless/list.go
+++ b/cmd/kubeless/list.go
@@ -29,7 +29,6 @@ import (
 	"github.com/spf13/cobra"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/rest"
 
 	"github.com/kubeless/kubeless/pkg/spec"
@@ -50,6 +49,9 @@ var listCmd = &cobra.Command{
 		if err != nil {
 			logrus.Fatal(err.Error())
 		}
+		if ns == "" {
+			ns = utils.GetDefaultNamespace()
+		}
 
 		crdClient, err := utils.GetCRDClientOutOfCluster()
 		if err != nil {
@@ -66,7 +68,7 @@ var listCmd = &cobra.Command{
 
 func init() {
 	listCmd.Flags().StringP("out", "o", "", "Output format. One of: json|yaml")
-	listCmd.Flags().StringP("namespace", "n", api.NamespaceDefault, "Specify namespace for the function")
+	listCmd.Flags().StringP("namespace", "n", "", "Specify namespace for the function")
 }
 
 func doList(w io.Writer, crdClient rest.Interface, apiV1Client kubernetes.Interface, ns, output string, args []string) error {

--- a/cmd/kubeless/logs.go
+++ b/cmd/kubeless/logs.go
@@ -23,7 +23,6 @@ import (
 	"github.com/Sirupsen/logrus"
 	"github.com/kubeless/kubeless/pkg/utils"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/v1"
 )
 
@@ -43,6 +42,9 @@ var logsCmd = &cobra.Command{
 		ns, err := cmd.Flags().GetString("namespace")
 		if err != nil {
 			logrus.Fatal(err)
+		}
+		if ns == "" {
+			ns = utils.GetDefaultNamespace()
 		}
 
 		k8sClient := utils.GetClientOutOfCluster()
@@ -74,5 +76,5 @@ var logsCmd = &cobra.Command{
 
 func init() {
 	logsCmd.Flags().BoolP("follow", "f", false, "Specify if the logs should be streamed.")
-	logsCmd.Flags().StringP("namespace", "", api.NamespaceDefault, "Specify namespace for the function")
+	logsCmd.Flags().StringP("namespace", "", "", "Specify namespace for the function")
 }

--- a/cmd/kubeless/update.go
+++ b/cmd/kubeless/update.go
@@ -23,7 +23,6 @@ import (
 	"github.com/kubeless/kubeless/pkg/langruntime"
 	"github.com/kubeless/kubeless/pkg/utils"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/pkg/api"
 )
 
 var updateCmd = &cobra.Command{
@@ -39,6 +38,9 @@ var updateCmd = &cobra.Command{
 		ns, err := cmd.Flags().GetString("namespace")
 		if err != nil {
 			logrus.Fatal(err)
+		}
+		if ns == "" {
+			ns = utils.GetDefaultNamespace()
 		}
 
 		handler, err := cmd.Flags().GetString("handler")
@@ -122,7 +124,7 @@ func init() {
 	updateCmd.Flags().StringP("memory", "", "", "Request amount of memory for the function")
 	updateCmd.Flags().StringSliceP("label", "", []string{}, "Specify labels of the function")
 	updateCmd.Flags().StringArrayP("env", "", []string{}, "Specify environment variable of the function")
-	updateCmd.Flags().StringP("namespace", "", api.NamespaceDefault, "Specify namespace for the function")
+	updateCmd.Flags().StringP("namespace", "", "", "Specify namespace for the function")
 	updateCmd.Flags().StringP("trigger-topic", "", "", "Deploy a pubsub function to Kubeless")
 	updateCmd.Flags().StringP("schedule", "", "", "Specify schedule in cron format for scheduled function")
 	updateCmd.Flags().Bool("trigger-http", false, "Deploy a http-based function to Kubeless")

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -174,6 +174,18 @@ func GetServiceMonitorClientOutOfCluster() (*monitoringv1alpha1.MonitoringV1alph
 	return client, nil
 }
 
+//GetDefaultNamespace returns the namespace set in current cluster context
+func GetDefaultNamespace() string {
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	rules.DefaultClientConfig = &clientcmd.DefaultClientConfig
+	overrides := &clientcmd.ConfigOverrides{ClusterDefaults: clientcmd.ClusterDefaults}
+
+	if ns, _, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides).Namespace(); err == nil {
+		return ns
+	}
+	return api.NamespaceDefault
+}
+
 // GetFunction returns specification of a function
 func GetFunction(funcName, ns string) (spec.Function, error) {
 	var f spec.Function


### PR DESCRIPTION
Fixes #429