### PR TITLE
Fixes 320

### DIFF
--- a/kubeless-rbac-novols.jsonnet
+++ b/kubeless-rbac-novols.jsonnet
@@ -1,9 +1,0 @@
-# Remove volumeClaimTemplates from kafkaSts to enable testing kubeless
-# on simple clusters deploys like kubeadm-dind-cluster
-local kubeless_rbac = import "kubeless-rbac.jsonnet";
-
-kubeless_rbac + {
-  kafkaSts+:
-   {spec+: {volumeClaimTemplates: []}} +
-   {spec+: {template+: {spec+: {volumes: [{name: "datadir", emptyDir: {}}]}}}}
-}

--- a/kubeless.jsonnet
+++ b/kubeless.jsonnet
@@ -68,7 +68,7 @@ local zookeeperPorts = [
 ];
 
 local kafkaContainer =
-  container.default("broker", "bitnami/kafka@sha256:ef0b1332408c0361d457852622d3a180f3609b9d98f1a85a9a809adaecfe9b52") +
+  container.default("broker", "bitnami/kafka@sha256:44fbc18518e7028ce87d4bec276c54b6a2cd2c2ece0c8575418d35cad0270a9c") +
   container.imagePullPolicy("IfNotPresent") +
   container.env(kafkaEnv) +
   container.ports({containerPort: 9092}) +
@@ -124,18 +124,42 @@ local kafkaVolumeCT = [
   }
 ];
 
+local zooVolumeCT = [
+  {
+    "metadata": {
+      "name": "zookeeper"
+    },
+    "spec": {
+      "accessModes": [
+        "ReadWriteOnce"
+      ],
+      "resources": {
+        "requests": {
+          "storage": "1Gi"
+        }
+      }
+    }
+  }
+];
+
+local securityCTX = {
+  "runAsUser": 1001,
+  "fsGroup": 1001
+};
+
 local kafkaSts =
   statefulset.default("kafka", namespace) +
   statefulset.spec({serviceName: "broker"}) +
   {spec+: {template: {metadata: {labels: kafkaLabel}}}} +
   {spec+: {volumeClaimTemplates: kafkaVolumeCT}} +
-  {spec+: {template+: {spec: {containers: [kafkaContainer]}}}};
+  {spec+: {template+: {spec: {securityContext: securityCTX, containers: [kafkaContainer]}}}};
 
 local zookeeperSts =
   statefulset.default("zoo", namespace) +
   statefulset.spec({serviceName: "zoo"}) +
   {spec+: {template: {metadata: {labels: zookeeperLabel}}}} +
-  {spec+: {template+: {spec: {containers: [zookeeperContainer], volumes: [{name: "zookeeper", emptyDir: {}}]}}}};
+  {spec+: {volumeClaimTemplates: zooVolumeCT}} +
+  {spec+: {template+: {spec: {securityContext: securityCTX, containers: [zookeeperContainer]}}}};
 
 local kafkaSvc =
   service.default("kafka", namespace) +

--- a/script/cluster-up-minikube.sh
+++ b/script/cluster-up-minikube.sh
@@ -25,7 +25,7 @@ touch ~/.kube/config
 export KUBECONFIG=$HOME/.kube/config
 export PATH=${PATH}:${GOPATH:?}/bin
 
-MINIKUBE_VERSION=v0.21.0
+MINIKUBE_VERSION=v0.22.3
 
 install_bin() {
     local exe=${1:?}

--- a/script/libtest.bash
+++ b/script/libtest.bash
@@ -157,7 +157,7 @@ _wait_for_kubeless_controller_logline() {
 }
 _wait_for_kubeless_kafka_server_ready() {
     [[ $(kubectl get pod -n kubeless kafka-0 -ojsonpath='{.metadata.annotations.ready}') == true ]] && return 0
-    local test_topic=test-centinel
+    local test_topic=$RANDOM
     echo_info "Waiting for kafka-0 to be ready ..."
     k8s_wait_for_pod_logline "Kafka.*Server.*started" -n kubeless kafka-0
     sleep 10
@@ -326,12 +326,9 @@ test_topic_deletion() {
 }
 sts_restart() {
     local num=1
-    local topic=$RANDOM
-    kubeless topic create $topic
     kubectl delete pod kafka-0 -n kubeless
     kubectl delete pod zoo-0 -n kubeless
     k8s_wait_for_uniq_pod -l kubeless=zookeeper -n kubeless
     k8s_wait_for_uniq_pod -l kubeless=kafka -n kubeless
-    kubeless topic list | grep $topic
 }
 # vim: sw=4 ts=4 et si

--- a/tests/integration-tests.bats
+++ b/tests/integration-tests.bats
@@ -117,4 +117,7 @@ load ../script/libtest
   wait_for_endpoint webserver
   verify_update_function webserver
 }
+@test "Verify Kafka after restart (if context=='minikube')" {
+    sts_restart
+}
 # vim: ts=2 sw=2 si et syntax=sh

--- a/tests/integration-tests.bats
+++ b/tests/integration-tests.bats
@@ -118,6 +118,9 @@ load ../script/libtest
   verify_update_function webserver
 }
 @test "Verify Kafka after restart (if context=='minikube')" {
+    local topic=$RANDOM
+    kubeless topic create $topic
     sts_restart
+    kubeless topic list | grep $topic
 }
 # vim: ts=2 sw=2 si et syntax=sh


### PR DESCRIPTION
- Update Kafka container sha256 to use the container version which correctly handles data dir persistence. 
- Add zookeeper volume claim template
- Add security contexts for ZooKeeper and Kafka pods 
- Use RBAC Ksonnet template
- Update Minikube to use a version which fixes hostPath provisioner permissions
- Fixed issue with log length 
- Implement tests for StatefulSet PV persistence 