### PR TITLE
kubeless deploy command must validate if minimum required fields are sepcified.

### DIFF
--- a/cmd/kubeless/deploy.go
+++ b/cmd/kubeless/deploy.go
@@ -109,6 +109,14 @@ var deployCmd = &cobra.Command{
 			funcDeps = string(bytes)
 		}
 
+		if runtime == "" && runtimeImage == "" {
+			logrus.Fatal("Either `--runtime` or `--runtime-image` flag must be specified.")
+		}
+
+		if runtime != "" && handler == "" {
+			logrus.Fatal("You must specify handler for the runtime.")
+		}
+
 		cli := utils.GetClientOutOfCluster()
 		f, err := getFunctionDescription(cli, funcName, ns, handler, file, funcDeps, runtime, topic, schedule, runtimeImage, mem, triggerHTTP, envs, labels, spec.Function{})
 		if err != nil {


### PR DESCRIPTION
**Issue Ref**: [#443 ]

**Description**: 

[PR Description]

kubeless deploy command must validate if minimum required fields are sepcified. Else function deploy succeeds but controller fails toprovision resources for the function.
**TODOs**:
 - [x] Ready to review
 - [ ] Automated Tests
 - [ ] Docs