### PR TITLE
Add max number of jobs history

### DIFF
--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -42,8 +42,8 @@ The pods are deployed using the function handler as [group ID](https://kafka.apa
 
 This is meant for functions that should be triggered following a certain schedule. For specifying the execution frequency  we use the [Cron](https://en.wikipedia.org/wiki/Cron) format. Every time a scheduled function is executed, a [Job](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/) is started. This Job will do a HTTP GET request to the function service and will be successful as far as the function returns 200 OK.
 
-For executing scheduled functions we use Kubernetes [CronJobs](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) using the default options which means:
- - If a Job is failed it will be restarted.
+For executing scheduled functions we use Kubernetes [CronJobs](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) using mostly the default options which means:
+ - If a Job fails, it won't be restarted but it will be retried in the next scheduled event. This could lead to an exponential growth in the number of pods executed.
  - The concurrency policy is set to `Allow` so concurrent jobs may exists.
  - The history limit is set to maintain as maximum three successful jobs (and one failed).
 

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -38,6 +38,17 @@ Right now the runtimes that support this kind of events are Python, NodeJS and R
 
 The pods are deployed using the function handler as [group ID](https://kafka.apache.org/documentation/#intro_consumers). That means that the load will be balanced. If a function is scaled and its deployment has more than one replica only one pod will process a published message.
 
+## Scheduled Trigger
+
+This is meant for functions that should be triggered following a certain schedule. For specifying the execution frequency  we use the [Cron](https://en.wikipedia.org/wiki/Cron) format. Every time a scheduled function is executed, a [Job](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/) is started. This Job will do a HTTP GET request to the function service and will be successful as far as the function returns 200 OK.
+
+For executing scheduled functions we use Kubernetes [CronJobs](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) using the default options which means:
+ - If a Job is failed it will be restarted.
+ - The concurrency policy is set to `Allow` so concurrent jobs may exists.
+ - The history limit is set to maintain as maximum three successful jobs (and one failed).
+
+If for some reason you want to modify one of the default values for a certain function you can execute `kubectl edit cronjob trigger-<func_name>` (where `func_name` is the name of your function) and modify the fields required. Once it is saved the CronJob will be updated.
+
 ## Monitoring functions
 Kubeless runtimes are exposing metrics at `/metrics` endpoint and these metrics will be collected by Prometheus. We also include a prometheus setup in [`manifests/monitoring`](https://github.com/kubeless/kubeless/blob/master/manifests/monitoring/prometheus.yaml) to help you easier set it up. The metrics collected are: Number of calls, succeeded and error executions and the time spent per call.
 

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -45,7 +45,7 @@ The pods are deployed using the function handler as [group ID](https://kafka.apa
 This is meant for functions that should be triggered following a certain schedule. For specifying the execution frequency  we use the [Cron](https://en.wikipedia.org/wiki/Cron) format. Every time a scheduled function is executed, a [Job](https://kubernetes.io/docs/concepts/workloads/controllers/jobs-run-to-completion/) is started. This Job will do a HTTP GET request to the function service and will be successful as far as the function returns 200 OK.
 
 For executing scheduled functions we use Kubernetes [CronJobs](https://kubernetes.io/docs/concepts/workloads/controllers/cron-jobs/) using mostly the default options which means:
- - If a Job fails, it won't be restarted but it will be retried in the next scheduled event. This could lead to an exponential growth in the number of pods executed.
+ - If a Job fails, it won't be restarted but it will be retried in the next scheduled event. The maximum time that a Job will exist is specified with the function timeout (180 seconds by default).
  - The concurrency policy is set to `Allow` so concurrent jobs may exists.
  - The history limit is set to maintain as maximum three successful jobs (and one failed).
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -28,6 +28,12 @@ get-python-34:
 get-python-34-verify:
 	kubeless function call get-python |egrep hello.world
 
+scheduled-get-python:
+	kubeless function deploy scheduled-get-python --schedule "* * * * *" --runtime python2.7 --handler helloget.foo --from-file python/helloget.py
+
+scheduled-get-python-verify:
+	bash -c 'grep -q "GET / HTTP/1.1\" 200 11 \"\" \"Wget\"" <(timeout 70 kubectl logs -f $$(kubectl get po -l function=scheduled-get-python -oname))'
+
 get-nodejs:
 	kubeless function deploy get-nodejs --trigger-http --runtime nodejs6 --handler helloget.foo --from-file nodejs/helloget.js
 	echo "curl localhost:8080/api/v1/proxy/namespaces/default/services/get-nodejs/"

--- a/examples/python/helloget.py
+++ b/examples/python/helloget.py
@@ -1,3 +1,2 @@
 def foo():
-    foobar
     return "hello world"

--- a/examples/python/helloget.py
+++ b/examples/python/helloget.py
@@ -1,2 +1,3 @@
 def foo():
+    foobar
     return "hello world"

--- a/kubeless-rbac.jsonnet
+++ b/kubeless-rbac.jsonnet
@@ -26,6 +26,11 @@ local controller_roles = [
     resources: ["functions"],
     verbs: ["get", "list", "watch"],
   },
+  {
+    apiGroups: ["batch"],
+    resources: ["cronjobs"],
+    verbs: ["create", "get", "delete", "list", "update", "patch"],
+  },
 ];
 
 local controllerAccount = kubeless.controllerAccount;

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -55,9 +55,10 @@ import (
 )
 
 const (
-	pubsubFunc = "PubSub"
-	busybox    = "busybox@sha256:be3c11fdba7cfe299214e46edc642e09514dbb9bbefcd0d3836c05a1e0cd0642"
-	unzip      = "kubeless/unzip@sha256:f162c062973cca05459834de6ed14c039d45df8cdb76097f50b028a1621b3697"
+	pubsubFunc     = "PubSub"
+	busybox        = "busybox@sha256:be3c11fdba7cfe299214e46edc642e09514dbb9bbefcd0d3836c05a1e0cd0642"
+	unzip          = "kubeless/unzip@sha256:f162c062973cca05459834de6ed14c039d45df8cdb76097f50b028a1621b3697"
+	defaultTimeout = "180"
 )
 
 // GetClient returns a k8s clientset to the request from inside of cluster
@@ -685,7 +686,7 @@ func EnsureFuncDeployment(client kubernetes.Interface, funcObj *spec.Function, o
 		timeout := funcObj.Spec.Timeout
 		if timeout == "" {
 			// Set default timeout to 180 seconds
-			timeout = "180"
+			timeout = defaultTimeout
 		}
 		dpm.Spec.Template.Spec.Containers[0].Env = append(dpm.Spec.Template.Spec.Containers[0].Env,
 			v1.EnvVar{
@@ -821,9 +822,15 @@ func EnsureFuncCronJob(client kubernetes.Interface, funcObj *spec.Function, or [
 	var maxSucccessfulHist, maxFailedHist int32
 	maxSucccessfulHist = 3
 	maxFailedHist = 1
-	timeout, err := strconv.Atoi(funcObj.Spec.Timeout)
-	if err != nil {
-		return fmt.Errorf("Unable convert %s to a valid timeout", funcObj.Spec.Timeout)
+	var timeout int
+	if funcObj.Spec.Timeout != "" {
+		var err error
+		timeout, err = strconv.Atoi(funcObj.Spec.Timeout)
+		if err != nil {
+			return fmt.Errorf("Unable convert %s to a valid timeout", funcObj.Spec.Timeout)
+		}
+	} else {
+		timeout, _ = strconv.Atoi(defaultTimeout)
 	}
 	activeDeadlineSeconds := int64(timeout)
 	job := &batchv2alpha1.CronJob{
@@ -856,7 +863,7 @@ func EnsureFuncCronJob(client kubernetes.Interface, funcObj *spec.Function, or [
 		},
 	}
 
-	_, err = client.BatchV2alpha1().CronJobs(funcObj.Metadata.Namespace).Create(job)
+	_, err := client.BatchV2alpha1().CronJobs(funcObj.Metadata.Namespace).Create(job)
 	if err != nil && k8sErrors.IsAlreadyExists(err) {
 		var data []byte
 		data, err = json.Marshal(job)

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -815,7 +815,7 @@ func EnsureFuncCronJob(client kubernetes.Interface, funcObj *spec.Function, or [
 									Args:  []string{"wget", "-qO-", fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", funcObj.Metadata.Name, funcObj.Metadata.Namespace)},
 								},
 							},
-							RestartPolicy: v1.RestartPolicyOnFailure,
+							RestartPolicy: v1.RestartPolicyNever,
 						},
 					},
 				},

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -791,6 +791,9 @@ func EnsureFuncDeployment(client kubernetes.Interface, funcObj *spec.Function, o
 
 // EnsureFuncCronJob creates/updates a function cron job
 func EnsureFuncCronJob(client kubernetes.Interface, funcObj *spec.Function, or []metav1.OwnerReference) error {
+	var maxSucccessfulHist, maxFailedHist int32
+	maxSucccessfulHist = 3
+	maxFailedHist = 1
 	job := &batchv2alpha1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            fmt.Sprintf("trigger-%s", funcObj.Metadata.Name),
@@ -798,7 +801,9 @@ func EnsureFuncCronJob(client kubernetes.Interface, funcObj *spec.Function, or [
 			OwnerReferences: or,
 		},
 		Spec: batchv2alpha1.CronJobSpec{
-			Schedule: funcObj.Spec.Schedule,
+			Schedule:                   funcObj.Spec.Schedule,
+			SuccessfulJobsHistoryLimit: &maxSucccessfulHist,
+			FailedJobsHistoryLimit:     &maxFailedHist,
 			JobTemplate: batchv2alpha1.JobTemplateSpec{
 				Spec: batchv1.JobSpec{
 					Template: v1.PodTemplateSpec{

--- a/pkg/utils/k8sutil_test.go
+++ b/pkg/utils/k8sutil_test.go
@@ -488,6 +488,7 @@ func TestEnsureCronJob(t *testing.T) {
 			Namespace: ns,
 		},
 		Spec: spec.FunctionSpec{
+			Timeout:  "120",
 			Schedule: "*/10 * * * *",
 		},
 	}
@@ -513,6 +514,9 @@ func TestEnsureCronJob(t *testing.T) {
 	}
 	if *cronJob.Spec.FailedJobsHistoryLimit != int32(1) {
 		t.Errorf("Unexpected FailedJobsHistoryLimit: %d", *cronJob.Spec.FailedJobsHistoryLimit)
+	}
+	if *cronJob.Spec.JobTemplate.Spec.ActiveDeadlineSeconds != int64(120) {
+		t.Errorf("Unexpected ActiveDeadlineSeconds: %d", *cronJob.Spec.JobTemplate.Spec.ActiveDeadlineSeconds)
 	}
 	expectedCommand := []string{"wget", "-qO-", fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", f1Name, ns)}
 	if !reflect.DeepEqual(cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args, expectedCommand) {

--- a/tests/integration-tests.bats
+++ b/tests/integration-tests.bats
@@ -41,6 +41,12 @@ load ../script/libtest
 @test "Test function: get-python-deps" {
   test_kubeless_function get-python-deps
 }
+@test "Test function: scheduled-get-python (part I)" {
+  # We just deploy the function in this test
+  # to give the cron job time to execute the
+  # function before verifying
+  deploy_function scheduled-get-python
+}
 @test "Test function update: get-python" {
   test_kubeless_function_update get-python
 }
@@ -94,6 +100,11 @@ load ../script/libtest
 }
 @test "Test function: pubsub-ruby" {
   test_kubeless_function pubsub-ruby
+}
+@test "Test function: scheduled-get-python (part II)" {
+  # Now we can verify the scheduled function
+  # without having to wait
+  verify_function scheduled-get-python
 }
 @test "Test topic list" {
   _wait_for_kubeless_kafka_server_ready


### PR DESCRIPTION
**Issue Ref**: #436 
 
**Description**: 

This PR limits the maximum amount of jobs kept in the history. It uses the default values of Kubernetes 1.8 (not present in Kubernetes 1.7). Apart from that the restart policy is now set to `Never` so it doesn't try to restart failed jobs and it also set the `ActiveDeadlineSeconds` to the function timeout so failed jobs doesn't exist more than the maximum execution time of the function.

It also adds a unit test and a integration test that this feature had missing. Also it fix the missing permissions for the controller for the RBAC (in which it hadn't permissions to manage CronJobs).

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 - [x] Docs