### PR TITLE
Use REST API endpoint for CronJobs

### DIFF
--- a/pkg/utils/k8sutil_test.go
+++ b/pkg/utils/k8sutil_test.go
@@ -1,22 +1,32 @@
 package utils
 
 import (
+	"bytes"
+	"encoding/json"
 	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
 	"reflect"
 	"strings"
 	"testing"
 
 	"github.com/kubeless/kubeless/pkg/spec"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/apimachinery"
+	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/v1"
 	av2alpha1 "k8s.io/client-go/pkg/apis/autoscaling/v2alpha1"
+	batchv2alpha1 "k8s.io/client-go/pkg/apis/batch/v2alpha1"
 	xv1beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	"k8s.io/client-go/rest"
+	restFake "k8s.io/client-go/rest/fake"
 	ktesting "k8s.io/client-go/testing"
 )
 
@@ -473,8 +483,38 @@ func TestEnsureDeployment(t *testing.T) {
 	}
 }
 
+func fakeRESTClient(f func(req *http.Request) (*http.Response, error)) *restFake.RESTClient {
+	reg := registered.NewOrDie("v1")
+	legacySchema := schema.GroupVersion{
+		Group:   "",
+		Version: "v1",
+	}
+	newSchema := schema.GroupVersion{
+		Group:   "k8s.io",
+		Version: "v1",
+	}
+	reg.RegisterGroup(apimachinery.GroupMeta{
+		GroupVersion: legacySchema,
+	})
+	reg.RegisterGroup(apimachinery.GroupMeta{
+		GroupVersion: newSchema,
+	})
+	return &restFake.RESTClient{
+		APIRegistry:          reg,
+		NegotiatedSerializer: api.Codecs,
+		Client:               restFake.CreateHTTPClient(f),
+	}
+}
+
+func objBody(object interface{}) io.ReadCloser {
+	output, err := json.Marshal(object)
+	if err != nil {
+		panic(err)
+	}
+	return ioutil.NopCloser(bytes.NewReader([]byte(output)))
+}
+
 func TestEnsureCronJob(t *testing.T) {
-	clientset := fake.NewSimpleClientset()
 	or := []metav1.OwnerReference{
 		{
 			Kind:       "Function",
@@ -494,35 +534,132 @@ func TestEnsureCronJob(t *testing.T) {
 		},
 	}
 
-	err := EnsureFuncCronJob(clientset, f1, or)
-	if err != nil {
-		t.Errorf("Unexpected error: %s", err)
-	}
 	expectedMeta := metav1.ObjectMeta{
 		Name:            "trigger-" + f1Name,
 		Namespace:       ns,
 		OwnerReferences: or,
 	}
-	cronJob, err := clientset.BatchV2alpha1().CronJobs(ns).Get("trigger-"+f1Name, metav1.GetOptions{})
+
+	client := fakeRESTClient(func(req *http.Request) (*http.Response, error) {
+		header := http.Header{}
+		header.Set("Content-Type", runtime.ContentTypeJSON)
+		listObj := batchv2alpha1.CronJobList{}
+		if req.Method == "POST" {
+			reqCronJobBytes, err := ioutil.ReadAll(req.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cronJob := batchv2alpha1.CronJob{}
+			err = json.Unmarshal(reqCronJobBytes, &cronJob)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !reflect.DeepEqual(expectedMeta, cronJob.ObjectMeta) {
+				t.Errorf("Unexpected metadata metadata. Expecting\n%+v \nReceived:\n%+v", expectedMeta, cronJob.ObjectMeta)
+			}
+			if *cronJob.Spec.SuccessfulJobsHistoryLimit != int32(3) {
+				t.Errorf("Unexpected SuccessfulJobsHistoryLimit: %d", *cronJob.Spec.SuccessfulJobsHistoryLimit)
+			}
+			if *cronJob.Spec.FailedJobsHistoryLimit != int32(1) {
+				t.Errorf("Unexpected FailedJobsHistoryLimit: %d", *cronJob.Spec.FailedJobsHistoryLimit)
+			}
+			if *cronJob.Spec.JobTemplate.Spec.ActiveDeadlineSeconds != int64(120) {
+				t.Errorf("Unexpected ActiveDeadlineSeconds: %d", *cronJob.Spec.JobTemplate.Spec.ActiveDeadlineSeconds)
+			}
+			expectedCommand := []string{"wget", "-qO-", fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", f1Name, ns)}
+			if !reflect.DeepEqual(cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args, expectedCommand) {
+				t.Errorf("Unexpected command %s", strings.Join(cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args, " "))
+			}
+		} else {
+			t.Fatalf("unexpected verb %s", req.Method)
+		}
+		switch req.URL.Path {
+		case "/apis/batch/v2alpha1/namespaces/default/cronjobs":
+			return &http.Response{
+				StatusCode: 200,
+				Header:     header,
+				Body:       objBody(&listObj),
+			}, nil
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+	err := EnsureFuncCronJob(client, f1, or, "batch/v2alpha1")
 	if err != nil {
-		t.Fatalf("Unexpected error: %s", err)
+		t.Errorf("Unexpected error: %s", err)
 	}
-	if !reflect.DeepEqual(expectedMeta, cronJob.ObjectMeta) {
-		t.Errorf("Unexpected metadata metadata. Expecting\n%+v \nReceived:\n%+v", expectedMeta, cronJob.ObjectMeta)
+
+	// It should update the existing cronJob if it is already created
+	updateCalled := false
+	client = fakeRESTClient(func(req *http.Request) (*http.Response, error) {
+		header := http.Header{}
+		header.Set("Content-Type", runtime.ContentTypeJSON)
+		switch req.Method {
+		case "POST":
+			return &http.Response{
+				StatusCode: http.StatusConflict,
+				Header:     header,
+				Body:       objBody(nil),
+			}, nil
+		case "GET":
+			previousCronJob := batchv2alpha1.CronJob{
+				ObjectMeta: metav1.ObjectMeta{
+					ResourceVersion: "123456",
+				},
+			}
+			return &http.Response{
+				StatusCode: 200,
+				Header:     header,
+				Body:       objBody(&previousCronJob),
+			}, nil
+		case "PUT":
+			updateCalled = true
+			reqCronJobBytes, err := ioutil.ReadAll(req.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			cronJob := batchv2alpha1.CronJob{}
+			err = json.Unmarshal(reqCronJobBytes, &cronJob)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if cronJob.ObjectMeta.ResourceVersion != "123456" {
+				t.Error("Expecting that the object to update contains the previous information")
+			}
+			listObj := batchv2alpha1.CronJobList{}
+			return &http.Response{
+				StatusCode: 200,
+				Header:     header,
+				Body:       objBody(&listObj),
+			}, nil
+		default:
+			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
+			return nil, nil
+		}
+	})
+	err = EnsureFuncCronJob(client, f1, or, "batch/v2alpha1")
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
 	}
-	if *cronJob.Spec.SuccessfulJobsHistoryLimit != int32(3) {
-		t.Errorf("Unexpected SuccessfulJobsHistoryLimit: %d", *cronJob.Spec.SuccessfulJobsHistoryLimit)
+	if !updateCalled {
+		t.Errorf("Expect the update method to be called")
 	}
-	if *cronJob.Spec.FailedJobsHistoryLimit != int32(1) {
-		t.Errorf("Unexpected FailedJobsHistoryLimit: %d", *cronJob.Spec.FailedJobsHistoryLimit)
-	}
-	if *cronJob.Spec.JobTemplate.Spec.ActiveDeadlineSeconds != int64(120) {
-		t.Errorf("Unexpected ActiveDeadlineSeconds: %d", *cronJob.Spec.JobTemplate.Spec.ActiveDeadlineSeconds)
-	}
-	expectedCommand := []string{"wget", "-qO-", fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", f1Name, ns)}
-	if !reflect.DeepEqual(cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args, expectedCommand) {
-		t.Errorf("Unexpected command %s", strings.Join(cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args, " "))
-	}
+
+	// IT should change the endpoint
+	client = fakeRESTClient(func(req *http.Request) (*http.Response, error) {
+		header := http.Header{}
+		header.Set("Content-Type", runtime.ContentTypeJSON)
+		if req.URL.Path != "/apis/batch/v1beta1/namespaces/default/cronjobs" {
+			t.Errorf("Unexpected URL %s", req.URL.Path)
+		}
+		return &http.Response{
+			StatusCode: 200,
+			Header:     header,
+			Body:       objBody(nil),
+		}, nil
+	})
+	err = EnsureFuncCronJob(client, f1, or, "batch/v1beta1")
 }
 
 func doesNotContain(envs []v1.EnvVar, env v1.EnvVar) bool {


### PR DESCRIPTION
**Issue Ref**: #399 
 
**Description**: 

This PR discovers the API Version Group that the CronJobs are placed and uses it to do directly calls to the REST API.

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 ~~- [ ] Docs~~ (Doesn't apply, bug fix)
