### PR TITLE
Add dependencies flag to update command

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -21,6 +21,16 @@ get-python-deps:
 get-python-deps-verify:
 	kubeless function call get-python-deps |egrep Google
 
+get-python-deps-update:
+	$(eval TMPDIR := $(shell mktemp -d))
+	printf 'bs4\ntwitter\n' > $(TMPDIR)/requirements.txt
+	kubeless function update get-python-deps --dependencies $(TMPDIR)/requirements.txt
+	rm -rf $(TMPDIR)
+
+get-python-deps-update-verify:
+	$(eval pod := $(shell kubectl get pod -l function=get-python-deps -o go-template -o custom-columns=:metadata.name --no-headers=true))
+	kubectl exec -it $(pod) pip freeze | grep -q "twitter=="
+
 get-python-34:
 	kubeless function deploy get-python --trigger-http --runtime python3.4 --handler helloget.foo --from-file python/helloget.py
 	echo "curl localhost:8080/api/v1/proxy/namespaces/default/services/get-python/"

--- a/tests/integration-tests.bats
+++ b/tests/integration-tests.bats
@@ -50,6 +50,9 @@ load ../script/libtest
 @test "Test function update: get-python" {
   test_kubeless_function_update get-python
 }
+@test "Test function update: get-python-deps" {
+  test_kubeless_function_update get-python-deps
+}
 @test "Test function ingress: get-python" {
   test_kubeless_ingress get-python
 }


### PR DESCRIPTION
**Issue Ref**: Fixes #453
 
**Description**: 

This PR adds the possibility of specifying the `--dependencies` flag for the `function update` command.

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 - [X] Docs (covered with --help menu)