### PR TITLE
Move HorizontalPodAutoscaler creation to the controller

### DIFF
--- a/cmd/kubeless/autoscaleCreate.go
+++ b/cmd/kubeless/autoscaleCreate.go
@@ -65,12 +65,12 @@ var autoscaleCreateCmd = &cobra.Command{
 		if err != nil {
 			logrus.Fatal(err)
 		}
-		logrus.Infof("Redeploying function with autoscaling parameters...")
+		logrus.Infof("Adding autoscaling rule to the function...")
 		err = utils.UpdateK8sCustomResource(crdClient, &function)
 		if err != nil {
 			logrus.Fatal(err)
 		}
-		logrus.Infof("Autoscale for %s submitted for deployment", funcName)
+		logrus.Infof("Autoscaling rule for %s submitted for deployment", funcName)
 	},
 }
 

--- a/cmd/kubeless/autoscaleCreate.go
+++ b/cmd/kubeless/autoscaleCreate.go
@@ -55,7 +55,7 @@ var autoscaleCreateCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
-		hpa, err := utils.GetHorizontalAutoscaleDefinition(funcName, ns, metric, min, max, value, function.Metadata.Labels)
+		hpa, err := getHorizontalAutoscaleDefinition(funcName, ns, metric, min, max, value, function.Metadata.Labels)
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/cmd/kubeless/autoscaleDelete.go
+++ b/cmd/kubeless/autoscaleDelete.go
@@ -14,7 +14,6 @@ limitations under the License.
 package main
 
 import (
-	monitoringv1alpha1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
 	"github.com/kubeless/kubeless/pkg/utils"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -45,28 +44,7 @@ var autoscaleDeleteCmd = &cobra.Command{
 		}
 
 		if function.Spec.HorizontalPodAutoscaler.Name != "" {
-			client := utils.GetClientOutOfCluster()
-
-			err = utils.DeleteAutoscale(client, function.Spec.HorizontalPodAutoscaler.Name, ns)
-			if err != nil {
-				logrus.Fatal(err)
-			}
-
-			config, err := utils.BuildOutOfClusterConfig()
-			if err != nil {
-				logrus.Fatal(err)
-			}
-			smclient, err := monitoringv1alpha1.NewForConfig(config)
-			if err != nil {
-				logrus.Fatal(err)
-			}
-			err = utils.DeleteServiceMonitor(*smclient, function.Spec.HorizontalPodAutoscaler.Name, ns)
-			if err != nil {
-				logrus.Fatal(err)
-			}
-
 			function.Spec.HorizontalPodAutoscaler = v2alpha1.HorizontalPodAutoscaler{}
-			logrus.Info(function.Spec.HorizontalPodAutoscaler)
 			crdClient, err := utils.GetCRDClientOutOfCluster()
 			if err != nil {
 				logrus.Fatal(err)

--- a/cmd/kubeless/function.go
+++ b/cmd/kubeless/function.go
@@ -26,6 +26,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path"
+	"strconv"
 	"strings"
 	"unicode/utf8"
 
@@ -35,6 +36,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/apis/autoscaling/v2alpha1"
 )
 
 var functionCmd = &cobra.Command{
@@ -288,4 +290,65 @@ func getDeploymentStatus(cli kubernetes.Interface, funcName, ns string) (string,
 		status += " NOT READY"
 	}
 	return status, nil
+}
+
+func getHorizontalAutoscaleDefinition(name, ns, metric string, min, max int32, value string, labels map[string]string) (v2alpha1.HorizontalPodAutoscaler, error) {
+	m := []v2alpha1.MetricSpec{}
+	switch metric {
+	case "cpu":
+		i, err := strconv.ParseInt(value, 10, 32)
+		if err != nil {
+			return v2alpha1.HorizontalPodAutoscaler{}, err
+		}
+		i32 := int32(i)
+		m = []v2alpha1.MetricSpec{
+			{
+				Type: v2alpha1.ResourceMetricSourceType,
+				Resource: &v2alpha1.ResourceMetricSource{
+					Name: v1.ResourceCPU,
+					TargetAverageUtilization: &i32,
+				},
+			},
+		}
+	case "qps":
+		q, err := resource.ParseQuantity(value)
+		if err != nil {
+			return v2alpha1.HorizontalPodAutoscaler{}, err
+		}
+		m = []v2alpha1.MetricSpec{
+			{
+				Type: v2alpha1.ObjectMetricSourceType,
+				Object: &v2alpha1.ObjectMetricSource{
+					MetricName:  "function_calls",
+					TargetValue: q,
+					Target: v2alpha1.CrossVersionObjectReference{
+						Kind: "Service",
+						Name: name,
+					},
+				},
+			},
+		}
+		if err != nil {
+			return v2alpha1.HorizontalPodAutoscaler{}, err
+		}
+	default:
+		return v2alpha1.HorizontalPodAutoscaler{}, fmt.Errorf("metric %s is not supported", metric)
+	}
+
+	return v2alpha1.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+			Labels:    labels,
+		},
+		Spec: v2alpha1.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: v2alpha1.CrossVersionObjectReference{
+				Kind: "Deployment",
+				Name: name,
+			},
+			MinReplicas: &min,
+			MaxReplicas: max,
+			Metrics:     m,
+		},
+	}, nil
 }

--- a/cmd/kubeless/function_test.go
+++ b/cmd/kubeless/function_test.go
@@ -29,6 +29,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/pkg/apis/autoscaling/v2alpha1"
 )
 
 func TestParseLabel(t *testing.T) {
@@ -262,5 +263,53 @@ func TestGetFunctionDescription(t *testing.T) {
 	}
 	if result4.Spec.FunctionContentType != "base64+zip" {
 		t.Errorf("Should return base64+zip, received %s", result4.Spec.FunctionContentType)
+	}
+}
+
+func TestGetHorizontalAutoscaleDefinition(t *testing.T) {
+	var min, max int32
+	min = 1
+	max = 3
+	funcName := "test-autoscale"
+	ns := "default"
+	value := "10"
+	labels := map[string]string{
+		"foo": "bar",
+	}
+	metric := "cpu"
+	hpa, err := getHorizontalAutoscaleDefinition(funcName, ns, metric, min, max, value, labels)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	expectedMeta := metav1.ObjectMeta{
+		Name:      funcName,
+		Namespace: ns,
+		Labels:    labels,
+	}
+	if hpa.Spec.ScaleTargetRef.Name != funcName {
+		t.Fatalf("Creating wrong scale target name")
+	}
+	if !reflect.DeepEqual(expectedMeta, hpa.ObjectMeta) {
+		t.Errorf("Expected \n%v to be equal to \n%v", expectedMeta, hpa.ObjectMeta)
+	}
+	if *hpa.Spec.MinReplicas != min {
+		t.Errorf("Unexpected min replicas. Expecting %d got %d", min, *hpa.Spec.MinReplicas)
+	}
+	if hpa.Spec.MaxReplicas != max {
+		t.Errorf("Unexpected max replicas. Expecting %d got %d", max, hpa.Spec.MaxReplicas)
+	}
+	if hpa.Spec.Metrics[0].Type != v2alpha1.ResourceMetricSourceType ||
+		*hpa.Spec.Metrics[0].Resource.TargetAverageUtilization != int32(10) {
+		t.Error("Unexpected metric")
+	}
+
+	metric = "qps"
+	hpa, err = getHorizontalAutoscaleDefinition(funcName, ns, metric, min, max, value, labels)
+	if err != nil {
+		t.Fatalf("Unexpected error %v", err)
+	}
+	if hpa.Spec.Metrics[0].Type != v2alpha1.ObjectMetricSourceType ||
+		hpa.Spec.Metrics[0].Object.TargetValue.String() != "10" {
+		t.Error("Unexpected metric")
 	}
 }

--- a/kubeless-rbac.jsonnet
+++ b/kubeless-rbac.jsonnet
@@ -31,6 +31,11 @@ local controller_roles = [
     resources: ["cronjobs"],
     verbs: ["create", "get", "delete", "list", "update", "patch"],
   },
+  {
+    apiGroups: ["autoscaling"],
+    resources: ["horizontalpodautoscalers"],
+    verbs: ["create", "get", "delete", "list", "update", "patch"],
+  },
 ];
 
 local controllerAccount = kubeless.controllerAccount;

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -6,7 +6,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/pkg/api/v1"
-	"k8s.io/client-go/pkg/apis/batch/v2alpha1"
+	"k8s.io/client-go/pkg/apis/autoscaling/v2alpha1"
+	batchv2alpha1 "k8s.io/client-go/pkg/apis/batch/v2alpha1"
 	xv1beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
 	ktesting "k8s.io/client-go/testing"
 )
@@ -42,7 +43,11 @@ func TestDeleteK8sResources(t *testing.T) {
 		ObjectMeta: myNsFoo,
 	}
 
-	clientset := fake.NewSimpleClientset(&deploy, &svc, &cm)
+	hpa := v2alpha1.HorizontalPodAutoscaler{
+		ObjectMeta: myNsFoo,
+	}
+
+	clientset := fake.NewSimpleClientset(&deploy, &svc, &cm, &hpa)
 
 	controller := Controller{
 		clientset: clientset,
@@ -53,7 +58,7 @@ func TestDeleteK8sResources(t *testing.T) {
 
 	t.Log("Actions:", clientset.Actions())
 
-	for _, kind := range []string{"services", "configmaps", "deployments"} {
+	for _, kind := range []string{"services", "configmaps", "deployments", "horizontalpodautoscalers"} {
 		a := findAction(clientset, "delete", kind)
 		if a == nil {
 			t.Errorf("failed to delete %s", kind)
@@ -81,7 +86,7 @@ func TestDeleteK8sResources(t *testing.T) {
 	}
 
 	// Test deleting cronjob
-	job := v2alpha1.CronJob{
+	job := batchv2alpha1.CronJob{
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "myns",
 			Name:      "trigger-foo",

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -20,6 +20,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/apis/autoscaling/v2alpha1"
 )
 
 // Function object
@@ -31,17 +32,18 @@ type Function struct {
 
 // FunctionSpec contains func specification
 type FunctionSpec struct {
-	Handler             string             `json:"handler"`               // Function handler: "file.function"
-	Function            string             `json:"function"`              // Function file content or URL of the function
-	FunctionContentType string             `json:"function-content-type"` // Function file content type (plain text, base64 or zip)
-	Checksum            string             `json:"checksum"`              // Checksum of the file
-	Runtime             string             `json:"runtime"`               // Function runtime to use
-	Type                string             `json:"type"`                  // Function trigger type
-	Topic               string             `json:"topic"`                 // Function topic trigger (for PubSub type)
-	Schedule            string             `json:"schedule"`              // Function scheduled time (for Schedule type)
-	Timeout             string             `json:"timeout"`               // Maximum timeout for the function to complete its execution
-	Deps                string             `json:"deps"`                  // Function dependencies
-	Template            v1.PodTemplateSpec `json:"template" protobuf:"bytes,3,opt,name=template"`
+	Handler                 string                           `json:"handler"`               // Function handler: "file.function"
+	Function                string                           `json:"function"`              // Function file content or URL of the function
+	FunctionContentType     string                           `json:"function-content-type"` // Function file content type (plain text, base64 or zip)
+	Checksum                string                           `json:"checksum"`              // Checksum of the file
+	Runtime                 string                           `json:"runtime"`               // Function runtime to use
+	Type                    string                           `json:"type"`                  // Function trigger type
+	Topic                   string                           `json:"topic"`                 // Function topic trigger (for PubSub type)
+	Schedule                string                           `json:"schedule"`              // Function scheduled time (for Schedule type)
+	Timeout                 string                           `json:"timeout"`               // Maximum timeout for the function to complete its execution
+	Deps                    string                           `json:"deps"`                  // Function dependencies
+	Template                v1.PodTemplateSpec               `json:"template" protobuf:"bytes,3,opt,name=template"`
+	HorizontalPodAutoscaler v2alpha1.HorizontalPodAutoscaler `json:"horizontalPodAutoscaler" protobuf:"bytes,3,opt,name=horizontalPodAutoscaler"`
 }
 
 // FunctionList contains map of functions

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -930,26 +930,9 @@ func DeleteAutoscale(client kubernetes.Interface, name, ns string) error {
 	return nil
 }
 
-func getServiceMonitorClient() (*monitoringv1alpha1.MonitoringV1alpha1Client, error) {
-	config, err := rest.InClusterConfig()
-	if err != nil {
-		return nil, err
-	}
-
-	client, err := monitoringv1alpha1.NewForConfig(config)
-	if err != nil {
-		return nil, err
-	}
-	return client, nil
-}
-
 // DeleteServiceMonitor cleans the sm if it exists
-func DeleteServiceMonitor(name, ns string) error {
-	smclient, err := getServiceMonitorClient()
-	if err != nil {
-		return err
-	}
-	err = smclient.ServiceMonitors(ns).Delete(name, &metav1.DeleteOptions{})
+func DeleteServiceMonitor(smclient monitoringv1alpha1.MonitoringV1alpha1Client, name, ns string) error {
+	err := smclient.ServiceMonitors(ns).Delete(name, &metav1.DeleteOptions{})
 	if err != nil && !k8sErrors.IsNotFound(err) {
 		return err
 	}
@@ -958,13 +941,8 @@ func DeleteServiceMonitor(name, ns string) error {
 }
 
 // CreateServiceMonitor creates a Service Monitor for the given function
-func CreateServiceMonitor(funcObj *spec.Function, ns string, or []metav1.OwnerReference) error {
-	smclient, err := getServiceMonitorClient()
-	if err != nil {
-		return err
-	}
-
-	_, err = smclient.ServiceMonitors(ns).Get(funcObj.Metadata.Name, metav1.GetOptions{})
+func CreateServiceMonitor(smclient monitoringv1alpha1.MonitoringV1alpha1Client, funcObj *spec.Function, ns string, or []metav1.OwnerReference) error {
+	_, err := smclient.ServiceMonitors(ns).Get(funcObj.Metadata.Name, metav1.GetOptions{})
 	if err != nil {
 		if k8sErrors.IsNotFound(err) {
 			s := &monitoringv1alpha1.ServiceMonitor{

--- a/pkg/utils/k8sutil_test.go
+++ b/pkg/utils/k8sutil_test.go
@@ -22,6 +22,7 @@ import (
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/pkg/api"
 	"k8s.io/client-go/pkg/api/v1"
+	"k8s.io/client-go/pkg/apis/autoscaling/v2alpha1"
 	av2alpha1 "k8s.io/client-go/pkg/apis/autoscaling/v2alpha1"
 	batchv2alpha1 "k8s.io/client-go/pkg/apis/batch/v2alpha1"
 	xv1beta1 "k8s.io/client-go/pkg/apis/extensions/v1beta1"
@@ -776,22 +777,24 @@ func TestGetLocalHostname(t *testing.T) {
 }
 
 func TestCreateAutoscaleResource(t *testing.T) {
-	min := int32(1)
-	max := int32(10)
 	clientset := fake.NewSimpleClientset()
-	hpaDef, err := GetHorizontalAutoscaleDefinition("foo", "myns", "cpu", min, max, "50", map[string]string{})
-	if err != nil {
-		t.Fatalf("Unexpected error: %s", err)
+	name := "foo"
+	ns := "myns"
+	hpaDef := v2alpha1.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: ns,
+		},
 	}
 	if err := CreateAutoscale(clientset, hpaDef); err != nil {
 		t.Fatalf("Creating autoscale returned err: %v", err)
 	}
 
-	hpa, err := clientset.AutoscalingV2alpha1().HorizontalPodAutoscalers("myns").Get("foo", metav1.GetOptions{})
+	hpa, err := clientset.AutoscalingV2alpha1().HorizontalPodAutoscalers(ns).Get(name, metav1.GetOptions{})
 	if err != nil {
 		t.Fatalf("Creating autoscale returned err: %v", err)
 	}
-	if hpa.Spec.ScaleTargetRef.Name != "foo" {
+	if hpa.ObjectMeta.Name != "foo" {
 		t.Fatalf("Creating wrong scale target name")
 	}
 }

--- a/pkg/utils/k8sutil_test.go
+++ b/pkg/utils/k8sutil_test.go
@@ -762,7 +762,11 @@ func TestCreateAutoscaleResource(t *testing.T) {
 	min := int32(1)
 	max := int32(10)
 	clientset := fake.NewSimpleClientset()
-	if err := CreateAutoscale(clientset, "foo", "myns", "cpu", min, max, "50"); err != nil {
+	hpaDef, err := GetHorizontalAutoscaleDefinition("foo", "myns", "cpu", min, max, "50")
+	if err != nil {
+		t.Fatalf("Unexpected error: %s", err)
+	}
+	if err := CreateAutoscale(clientset, hpaDef); err != nil {
 		t.Fatalf("Creating autoscale returned err: %v", err)
 	}
 


### PR DESCRIPTION
**Issue Ref**: None
 
**Description**: 

This PR moves the Horizontal Pod Autoscaler creation to the Kubeless controller. For doing so the Function spec now has an optional field `horizontalPodAutoscaler` that defines the autoscale properties if needed.

This is the first step for fixing the autoscale feature in Kubernetes 1.8

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 ~~- [ ] Docs~~