### PR TITLE
Use an init container instead of securityContext

### DIFF
--- a/kubeless-openshift.jsonnet
+++ b/kubeless-openshift.jsonnet
@@ -6,5 +6,7 @@ local kubeless = import "kubeless-rbac.jsonnet";
 kubeless + {
   controller: kubeless.controller + { apiVersion: "extensions/v1beta1" },
   controllerClusterRole: kubeless.controllerClusterRole + { apiVersion: "v1" },
-  controllerClusterRoleBinding: kubeless.controllerClusterRoleBinding + { apiVersion: "v1" }
+  controllerClusterRoleBinding: kubeless.controllerClusterRoleBinding + { apiVersion: "v1" },
+  kafkaSts: kubeless.kafkaSts  + {spec+: {template+: {spec+: { initContainers: [] }}}},
+  zookeeperSts: kubeless.zookeeperSts  + {spec+: {template+: {spec+: { initContainers: [] }}}}
 }


### PR DESCRIPTION
**Issue Ref**: #480
 
**Description**: 

The goal of this PR is fixing the Kafka deployment in Minikube (+v0.24). The feature `securityContext` doesn't work there and volumes are being created without write permissions for the user with id `1001`. In previous versions of Minikube volumes were mounted setting `777` as folder permissions  but it is not the case anymore. For fixing that this PR uses an initContainer that set enough permissions for the user `1001` to write in that volume. 

**TODOs**:
 - [X] Ready to review
 ~~- [] Automated Tests~~ Minikube 0.24.X is not yet fully supported because of the autoscale feature. Tested Manually.
 ~~- [ ] Docs~~ Not needed, bug fix.