### PR TITLE
Improve metrics labels for runtime nodejs http-trigger

### DIFF
--- a/docker/runtime/nodejs/event-trigger/kubeless.js
+++ b/docker/runtime/nodejs/event-trigger/kubeless.js
@@ -42,12 +42,13 @@ try {
 const { vmscript, sandbox } = helper.loadFunc(modName, functionCallingCode);
 
 kafkaConsumer.on('message', (message) => {
-  const end = statistics.timeHistogram.labels(message.topic).startTimer();
+  const funcLabel = modName + "-" + message.topic;
+  const end = statistics.timeHistogram.labels(funcLabel).startTimer();
   const handleError = (err) => {
-    statistics.errorsCounter.labels(message.topic).inc();
+    statistics.errorsCounter.labels(funcLabel).inc();
     console.error(`Function failed to execute: ${err.stack}`);
   };
-  statistics.callsCounter.labels(message.topic).inc();
+  statistics.callsCounter.labels(funcLabel).inc();
   const reqSandbox = Object.assign({
     message: message.value,
     end,

--- a/docker/runtime/nodejs/http-trigger/kubeless.js
+++ b/docker/runtime/nodejs/http-trigger/kubeless.js
@@ -40,10 +40,11 @@ app.all('*', (req, res) => {
     res.header('Access-Control-Allow-Headers', req.headers['access-control-request-headers'])
     res.end();
   } else {
-    const end = statistics.timeHistogram.labels(req.method).startTimer();
-    statistics.callsCounter.labels(req.method).inc();
+    const funcLabel = modName + "-" + req.method;
+    const end = statistics.timeHistogram.labels(funcLabel).startTimer();
+    statistics.callsCounter.labels(funcLabel).inc();
     const handleError = (err) => {
-      statistics.errorsCounter.labels(req.method).inc();
+      statistics.errorsCounter.labels(funcLabel).inc();
       res.status(500).send('Internal Server Error');
       console.error(`Function failed to execute: ${err.stack}`);
     };


### PR DESCRIPTION
**Issue Ref**: #484 
 
**Description**: Improves the metrics labels for nodejs http-trigger function's. Labels will be `function name-HTTP method`

**TODOs**:
 - [x] Ready to review
 - [ ] Automated Tests
 - [ ] Docs
