### PR TITLE
Move topic creation to verify task

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -186,7 +186,6 @@ pubsub-python:
 # Generate a random string to inject into s3 topic,
 # then "tail -f" until it shows (with timeout)
 pubsub-python-verify:
-	kubeless topic create s3-python
 	$(eval DATA := $(shell mktemp -u -t XXXXXXXX))
 	kubeless topic publish --topic s3-python --data "$(DATA)"
 	pod=`kubectl get po -oname -l function=pubsub-python`; \
@@ -205,7 +204,6 @@ pubsub-python-verify:
 	$$found
 
 pubsub-python-update:
-	kubeless topic create s3-python-2
 	kubeless function update pubsub-python --trigger-topic s3-python-2
 
 pubsub-python-update-verify:
@@ -215,7 +213,6 @@ pubsub-python34:
 	kubeless function deploy pubsub-python34 --trigger-topic s3-python34 --runtime python3.4 --handler pubsub-python.handler --from-file python/pubsub.py
 
 pubsub-python34-verify:
-	kubeless topic create s3-python34
 	$(eval DATA := $(shell mktemp -u -t XXXXXXXX))
 	kubeless topic publish --topic s3-python34 --data "$(DATA)"
 	pod=`kubectl get po -oname -l function=pubsub-python34`; \
@@ -237,7 +234,6 @@ pubsub-nodejs:
 	kubeless function deploy pubsub-nodejs --trigger-topic s3-nodejs --runtime nodejs6 --handler pubsub-nodejs.handler --from-file nodejs/helloevent.js
 
 pubsub-nodejs-verify:
-	kubeless topic create s3-nodejs
 	$(eval DATA := $(shell mktemp -u -t XXXXXXXX))
 	kubeless topic publish --topic s3-nodejs --data '{"test": "$(DATA)"}'
 	pod=`kubectl get po -oname -l function=pubsub-nodejs`; \
@@ -259,7 +255,6 @@ pubsub-ruby:
 	kubeless function deploy pubsub-ruby --trigger-topic s3-ruby --runtime ruby2.4 --handler pubsub-ruby.handler --from-file ruby/helloevent.rb
 
 pubsub-ruby-verify:
-	kubeless topic create s3-ruby
 	$(eval DATA := $(shell mktemp -u -t XXXXXXXX))
 	kubeless topic publish --topic s3-ruby --data "$(DATA)"
 	pod=`kubectl get po -oname -l function=pubsub-ruby`; \

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -181,12 +181,12 @@ post-dotnetcore-verify:
 post: post-python post-nodejs post-ruby
 
 pubsub-python:
-	kubeless topic create s3-python
 	kubeless function deploy pubsub-python --trigger-topic s3-python --runtime python2.7 --handler pubsub.handler --from-file python/pubsub.py
 
 # Generate a random string to inject into s3 topic,
 # then "tail -f" until it shows (with timeout)
 pubsub-python-verify:
+	kubeless topic create s3-python
 	$(eval DATA := $(shell mktemp -u -t XXXXXXXX))
 	kubeless topic publish --topic s3-python --data "$(DATA)"
 	pod=`kubectl get po -oname -l function=pubsub-python`; \
@@ -212,10 +212,10 @@ pubsub-python-update-verify:
 	kubectl describe $$(kubectl get po -oname|grep pubsub-python) | grep -e "TOPIC_NAME:\s*s3-python-2"
 
 pubsub-python34:
-	kubeless topic create s3-python34
 	kubeless function deploy pubsub-python34 --trigger-topic s3-python34 --runtime python3.4 --handler pubsub-python.handler --from-file python/pubsub.py
 
 pubsub-python34-verify:
+	kubeless topic create s3-python34
 	$(eval DATA := $(shell mktemp -u -t XXXXXXXX))
 	kubeless topic publish --topic s3-python34 --data "$(DATA)"
 	pod=`kubectl get po -oname -l function=pubsub-python34`; \
@@ -234,10 +234,10 @@ pubsub-python34-verify:
 	$$found
 
 pubsub-nodejs:
-	kubeless topic create s3-nodejs
 	kubeless function deploy pubsub-nodejs --trigger-topic s3-nodejs --runtime nodejs6 --handler pubsub-nodejs.handler --from-file nodejs/helloevent.js
 
 pubsub-nodejs-verify:
+	kubeless topic create s3-nodejs
 	$(eval DATA := $(shell mktemp -u -t XXXXXXXX))
 	kubeless topic publish --topic s3-nodejs --data '{"test": "$(DATA)"}'
 	pod=`kubectl get po -oname -l function=pubsub-nodejs`; \
@@ -256,10 +256,10 @@ pubsub-nodejs-verify:
 	$$found
 
 pubsub-ruby:
-	kubeless topic create s3-ruby
 	kubeless function deploy pubsub-ruby --trigger-topic s3-ruby --runtime ruby2.4 --handler pubsub-ruby.handler --from-file ruby/helloevent.rb
 
 pubsub-ruby-verify:
+	kubeless topic create s3-ruby
 	$(eval DATA := $(shell mktemp -u -t XXXXXXXX))
 	kubeless topic publish --topic s3-ruby --data "$(DATA)"
 	pod=`kubectl get po -oname -l function=pubsub-ruby`; \


### PR DESCRIPTION
**Issue Ref**: None
 
**Description**: 

When executing the integration tests some crashes are cause due to creating all the Kafka topics at once. This PR tries to address that issue moving the topic creation to the verification step of each test.

**TODOs**:
 - [x] Ready to review
 - [x] Automated Tests
 ~~- [ ] Docs~~