### PR TITLE
Add status to function object.

### DIFF
--- a/cmd/kubeless/function.go
+++ b/cmd/kubeless/function.go
@@ -278,20 +278,6 @@ func getFunctionDescription(cli kubernetes.Interface, funcName, ns, handler, fil
 	}, nil
 }
 
-func getDeploymentStatus(cli kubernetes.Interface, funcName, ns string) (string, error) {
-	dpm, err := cli.ExtensionsV1beta1().Deployments(ns).Get(funcName, metav1.GetOptions{})
-	if err != nil {
-		return "", err
-	}
-	status := fmt.Sprintf("%d/%d", dpm.Status.ReadyReplicas, dpm.Status.Replicas)
-	if dpm.Status.ReadyReplicas > 0 {
-		status += " READY"
-	} else {
-		status += " NOT READY"
-	}
-	return status, nil
-}
-
 func getHorizontalAutoscaleDefinition(name, ns, metric string, min, max int32, value string, labels map[string]string) (v2alpha1.HorizontalPodAutoscaler, error) {
 	m := []v2alpha1.MetricSpec{}
 	switch metric {

--- a/cmd/kubeless/list.go
+++ b/cmd/kubeless/list.go
@@ -27,7 +27,6 @@ import (
 	"github.com/gosuri/uitable"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 
@@ -140,12 +139,7 @@ func printFunctions(w io.Writer, functions []*spec.Function, cli kubernetes.Inte
 			t := f.Spec.Type
 			tp := f.Spec.Topic
 			ns := f.Metadata.Namespace
-			status, err := getDeploymentStatus(cli, f.Metadata.Name, f.Metadata.Namespace)
-			if err != nil && k8sErrors.IsNotFound(err) {
-				status = "MISSING: Check controller logs"
-			} else if err != nil {
-				return err
-			}
+			status := f.Status.Status
 			deps, err := parseDeps(f.Spec.Deps, r)
 			if err != nil {
 				return err
@@ -170,12 +164,7 @@ func printFunctions(w io.Writer, functions []*spec.Function, cli kubernetes.Inte
 			}
 			s := f.Spec.Schedule
 			ns := f.Metadata.Namespace
-			status, err := getDeploymentStatus(cli, f.Metadata.Name, f.Metadata.Namespace)
-			if err != nil && k8sErrors.IsNotFound(err) {
-				status = "MISSING: Check controller logs"
-			} else if err != nil {
-				return err
-			}
+			status := f.Status.Status
 			mem := ""
 			env := ""
 			if len(f.Spec.Template.Spec.Containers[0].Resources.Requests) != 0 {

--- a/cmd/kubeless/list_test.go
+++ b/cmd/kubeless/list_test.go
@@ -106,6 +106,9 @@ func TestList(t *testing.T) {
 						},
 					},
 				},
+				Status: spec.FunctionStatus{
+					Status: "READY",
+				},
 			},
 			{
 				Metadata: metav1.ObjectMeta{
@@ -149,6 +152,9 @@ func TestList(t *testing.T) {
 						},
 					},
 				},
+				Status: spec.FunctionStatus{
+					Status: "NOT READY",
+				},
 			},
 			{
 				Metadata: metav1.ObjectMeta{
@@ -167,6 +173,9 @@ func TestList(t *testing.T) {
 							Containers: []v1.Container{{}},
 						},
 					},
+				},
+				Status: spec.FunctionStatus{
+					Status: "MISSING",
 				},
 			},
 		},
@@ -223,14 +232,14 @@ func TestList(t *testing.T) {
 		t.Errorf("table output didn't mention both functions")
 	}
 	// Status
-	m, err := regexp.MatchString("foo.*1/1 READY", output)
+	m, err := regexp.MatchString("foo.*READY", output)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if !m {
 		t.Errorf("table output didn't mention deployment status")
 	}
-	m, err = regexp.MatchString("bar.*0/2 NOT READY", output)
+	m, err = regexp.MatchString("bar.*NOT READY", output)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/kubeless-rbac.jsonnet
+++ b/kubeless-rbac.jsonnet
@@ -24,7 +24,7 @@ local controller_roles = [
   {
     apiGroups: ["k8s.io"],
     resources: ["functions"],
-    verbs: ["get", "list", "watch"],
+    verbs: ["get", "list",  "update", "watch"],
   },
   {
     apiGroups: ["batch"],

--- a/pkg/spec/spec.go
+++ b/pkg/spec/spec.go
@@ -28,6 +28,7 @@ type Function struct {
 	metav1.TypeMeta `json:",inline"`
 	Metadata        metav1.ObjectMeta `json:"metadata"`
 	Spec            FunctionSpec      `json:"spec"`
+	Status          FunctionStatus    `json:"status,omitempty"`
 }
 
 // FunctionSpec contains func specification
@@ -44,6 +45,25 @@ type FunctionSpec struct {
 	Deps                    string                           `json:"deps"`                  // Function dependencies
 	Template                v1.PodTemplateSpec               `json:"template" protobuf:"bytes,3,opt,name=template"`
 	HorizontalPodAutoscaler v2alpha1.HorizontalPodAutoscaler `json:"horizontalPodAutoscaler" protobuf:"bytes,3,opt,name=horizontalPodAutoscaler"`
+}
+
+// FunctionPhase is a string representation of the lifecycle phase of function
+type FunctionPhase string
+
+// TODO: As we define function, triggers and runtime the status should
+// evolve to capture the life-cycle of the function
+const (
+
+	// ReadyPhase means the function has been deployed and can respond to triggers
+	ReadyPhase FunctionPhase = "READY"
+
+	// NotReadyPhase means the function is not ready to respond to triggers
+	NotReadyPhase FunctionPhase = "NOT READY"
+)
+
+// FunctionStatus captures the current status of the function.
+type FunctionStatus struct {
+	Status FunctionPhase `json:"status"`
 }
 
 // FunctionList contains map of functions


### PR DESCRIPTION
Remove logic of inferring status from kubeless client code. We can not assume client has RBAC to access deployments. `kubeless function list` will use the status from function object.

**Issue Ref**: [Issue number related to this PR or None]
 
Fixes #482

**Description**: 

[PR Description]

**TODOs**:
 - [x] Ready to review
 - [x] Automated Tests
 - [ ] Docs