### PR TITLE
Add support for adding annotations on functions

### DIFF
--- a/cmd/kubeless/deploy.go
+++ b/cmd/kubeless/deploy.go
@@ -126,13 +126,19 @@ var deployCmd = &cobra.Command{
 			funcDeps = string(bytes)
 		}
 
+		annotations, err := cmd.Flags().GetStringSlice("annotations")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
 		cli := utils.GetClientOutOfCluster()
 		defaultFunctionSpec := spec.Function{}
 		defaultFunctionSpec.Spec.Type = "HTTP"
 		defaultFunctionSpec.Metadata.Labels = map[string]string{
 			"created-by": "kubeless",
 		}
-		f, err := getFunctionDescription(cli, funcName, ns, handler, file, funcDeps, runtime, topic, schedule, runtimeImage, mem, timeout, triggerHTTP, envs, labels, defaultFunctionSpec)
+		f, err := getFunctionDescription(cli, funcName, ns, handler, file, funcDeps, runtime, topic, schedule, runtimeImage,
+			mem, timeout, triggerHTTP, envs, labels, annotations, defaultFunctionSpec)
 		if err != nil {
 			logrus.Fatal(err)
 		}
@@ -166,4 +172,5 @@ func init() {
 	deployCmd.Flags().Bool("trigger-http", false, "Deploy a http-based function to Kubeless")
 	deployCmd.Flags().StringP("runtime-image", "", "", "Custom runtime image")
 	deployCmd.Flags().StringP("timeout", "", "180", "Maximum timeout (in seconds) for the function to complete its execution")
+	deployCmd.Flags().StringSliceP("annotations", "", []string{}, "Specify annotations of the function. Both separator ':' and '=' are allowed. For example: --annotations foo1=bar1,foo2:bar2")
 }

--- a/cmd/kubeless/function_test.go
+++ b/cmd/kubeless/function_test.go
@@ -20,10 +20,11 @@ import (
 	"archive/zip"
 	"io"
 	"io/ioutil"
-	"k8s.io/client-go/pkg/api/v1"
 	"os"
 	"reflect"
 	"testing"
+
+	"k8s.io/client-go/pkg/api/v1"
 
 	"github.com/kubeless/kubeless/pkg/spec"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -98,7 +99,7 @@ func TestGetFunctionDescription(t *testing.T) {
 	file.Close()
 	defer os.Remove(file.Name()) // clean up
 
-	result, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "file.handler", file.Name(), "dependencies", "runtime", "", "", "test-image", "128Mi", "10", true, []string{"TEST=1"}, []string{"test=1"}, spec.Function{})
+	result, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "file.handler", file.Name(), "dependencies", "runtime", "", "", "test-image", "128Mi", "10", true, []string{"TEST=1"}, []string{"test=1"}, []string{"test=1"}, spec.Function{})
 	if err != nil {
 		t.Error(err)
 	}
@@ -112,6 +113,9 @@ func TestGetFunctionDescription(t *testing.T) {
 			Name:      "test",
 			Namespace: "default",
 			Labels: map[string]string{
+				"test": "1",
+			},
+			Annotations: map[string]string{
 				"test": "1",
 			},
 		},
@@ -154,7 +158,7 @@ func TestGetFunctionDescription(t *testing.T) {
 	}
 
 	// It should take the default values
-	result2, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "", "", "", "", "", "", "", "", "", false, []string{}, []string{}, expectedFunction)
+	result2, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "", "", "", "", "", "", "", "", "", false, []string{}, []string{}, []string{}, expectedFunction)
 	if err != nil {
 		t.Error(err)
 	}
@@ -173,7 +177,7 @@ func TestGetFunctionDescription(t *testing.T) {
 	}
 	file.Close()
 	defer os.Remove(file.Name()) // clean up
-	result3, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "file.handler2", file.Name(), "dependencies2", "runtime2", "test_topic", "", "test-image2", "256Mi", "20", false, []string{"TEST=2"}, []string{"test=2"}, expectedFunction)
+	result3, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "file.handler2", file.Name(), "dependencies2", "runtime2", "test_topic", "", "test-image2", "256Mi", "20", false, []string{"TEST=2"}, []string{"test=2"}, []string{"test=2"}, expectedFunction)
 	if err != nil {
 		t.Error(err)
 	}
@@ -187,6 +191,9 @@ func TestGetFunctionDescription(t *testing.T) {
 			Name:      "test",
 			Namespace: "default",
 			Labels: map[string]string{
+				"test": "2",
+			},
+			Annotations: map[string]string{
 				"test": "2",
 			},
 		},
@@ -257,7 +264,7 @@ func TestGetFunctionDescription(t *testing.T) {
 	}
 	file.Close()
 	zipW.Close()
-	result4, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "file.handler", newfile.Name(), "dependencies", "runtime", "", "", "", "", "", false, []string{}, []string{}, expectedFunction)
+	result4, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "file.handler", newfile.Name(), "dependencies", "runtime", "", "", "", "", "", false, []string{}, []string{}, []string{}, expectedFunction)
 	if err != nil {
 		t.Error(err)
 	}

--- a/cmd/kubeless/list.go
+++ b/cmd/kubeless/list.go
@@ -157,7 +157,7 @@ func printFunctions(w io.Writer, functions []*spec.Function, cli kubernetes.Inte
 		table := uitable.New()
 		table.MaxColWidth = 50
 		table.Wrap = true
-		table.AddRow("NAME", "NAMESPACE", "HANDLER", "RUNTIME", "TYPE", "TOPIC", "DEPENDENCIES", "STATUS", "MEMORY", "ENV", "LABEL", "SCHEDULE")
+		table.AddRow("NAME", "NAMESPACE", "HANDLER", "RUNTIME", "TYPE", "TOPIC", "DEPENDENCIES", "STATUS", "MEMORY", "ENV", "LABEL", "ANNOTATIONS", "SCHEDULE")
 		for _, f := range functions {
 			n := f.Metadata.Name
 			h := f.Spec.Handler
@@ -196,7 +196,15 @@ func printFunctions(w io.Writer, functions []*spec.Function, cli kubernetes.Inte
 				}
 				label = buffer.String()
 			}
-			table.AddRow(n, ns, h, r, t, tp, deps, status, mem, env, label, s)
+			annotations := ""
+			if len(f.Metadata.Annotations) > 0 {
+				var buffer bytes.Buffer
+				for k, v := range f.Metadata.Annotations {
+					buffer.WriteString(k + " : " + v + "\n")
+				}
+				annotations = buffer.String()
+			}
+			table.AddRow(n, ns, h, r, t, tp, deps, status, mem, env, label, annotations, s)
 		}
 		fmt.Fprintln(w, table)
 	} else {

--- a/cmd/kubeless/update.go
+++ b/cmd/kubeless/update.go
@@ -127,8 +127,14 @@ var updateCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
+		annotations, err := cmd.Flags().GetStringSlice("annotations")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
 		cli := utils.GetClientOutOfCluster()
-		f, err := getFunctionDescription(cli, funcName, ns, handler, file, funcDeps, runtime, topic, schedule, runtimeImage, mem, timeout, triggerHTTP, envs, labels, previousFunction)
+		f, err := getFunctionDescription(cli, funcName, ns, handler, file, funcDeps, runtime, topic, schedule, runtimeImage,
+			mem, timeout, triggerHTTP, envs, labels, annotations, previousFunction)
 		if err != nil {
 			logrus.Fatal(err)
 		}
@@ -161,4 +167,5 @@ func init() {
 	updateCmd.Flags().Bool("trigger-http", false, "Deploy a http-based function to Kubeless")
 	updateCmd.Flags().StringP("runtime-image", "", "", "Custom runtime image")
 	updateCmd.Flags().StringP("timeout", "", "180", "Maximum timeout (in seconds) for the function to complete its execution")
+	updateCmd.Flags().StringSliceP("annotations", "", []string{}, "Specify annotations of the function. Both separator ':' and '=' are allowed. For example: --annotations foo1=bar1,foo2:bar2")
 }

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -514,6 +514,7 @@ func EnsureFuncConfigMap(client kubernetes.Interface, funcObj *spec.Function, or
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            funcObj.Metadata.Name,
 			Labels:          funcObj.Metadata.Labels,
+			Annotations:     funcObj.Metadata.Annotations,
 			OwnerReferences: or,
 		},
 		Data: configMapData,
@@ -529,6 +530,7 @@ func EnsureFuncConfigMap(client kubernetes.Interface, funcObj *spec.Function, or
 			return err
 		}
 		newConfigMap.ObjectMeta.Labels = funcObj.Metadata.Labels
+		newConfigMap.ObjectMeta.Annotations = funcObj.Metadata.Annotations
 		newConfigMap.ObjectMeta.OwnerReferences = or
 		newConfigMap.Data = configMap.Data
 		_, err = client.Core().ConfigMaps(funcObj.Metadata.Namespace).Update(newConfigMap)
@@ -547,6 +549,7 @@ func EnsureFuncService(client kubernetes.Interface, funcObj *spec.Function, or [
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            funcObj.Metadata.Name,
 			Labels:          funcObj.Metadata.Labels,
+			Annotations:     funcObj.Metadata.Annotations,
 			OwnerReferences: or,
 		},
 		Spec: v1.ServiceSpec{
@@ -573,6 +576,7 @@ func EnsureFuncService(client kubernetes.Interface, funcObj *spec.Function, or [
 			return err
 		}
 		newSvc.ObjectMeta.Labels = funcObj.Metadata.Labels
+		newSvc.ObjectMeta.Annotations = funcObj.Metadata.Annotations
 		newSvc.ObjectMeta.OwnerReferences = or
 		newSvc.Spec.Ports = svc.Spec.Ports
 		newSvc.Spec.Selector = svc.Spec.Selector
@@ -606,6 +610,7 @@ func EnsureFuncDeployment(client kubernetes.Interface, funcObj *spec.Function, o
 		ObjectMeta: metav1.ObjectMeta{
 			Name:            funcObj.Metadata.Name,
 			Labels:          funcObj.Metadata.Labels,
+			Annotations:     funcObj.Metadata.Annotations,
 			OwnerReferences: or,
 		},
 		Spec: v1beta1.DeploymentSpec{
@@ -633,6 +638,9 @@ func EnsureFuncDeployment(client kubernetes.Interface, funcObj *spec.Function, o
 	}
 	if len(dpm.Spec.Template.ObjectMeta.Annotations) == 0 {
 		dpm.Spec.Template.ObjectMeta.Annotations = make(map[string]string)
+	}
+	for k, v := range funcObj.Metadata.Annotations {
+		dpm.Spec.Template.ObjectMeta.Annotations[k] = v
 	}
 	for k, v := range podAnnotations {
 		//only append k-v from podAnnotations if it doesn't exist in deployment podTemplateSpec annotation
@@ -783,6 +791,7 @@ func EnsureFuncDeployment(client kubernetes.Interface, funcObj *spec.Function, o
 		var newDpm *v1beta1.Deployment
 		newDpm, err = client.Extensions().Deployments(funcObj.Metadata.Namespace).Get(funcObj.Metadata.Name, metav1.GetOptions{})
 		newDpm.ObjectMeta.Labels = funcObj.Metadata.Labels
+		newDpm.ObjectMeta.Annotations = funcObj.Metadata.Annotations
 		newDpm.ObjectMeta.OwnerReferences = or
 		newDpm.Spec = dpm.Spec
 		_, err = client.Extensions().Deployments(funcObj.Metadata.Namespace).Update(newDpm)
@@ -868,6 +877,7 @@ func EnsureFuncCronJob(client rest.Interface, funcObj *spec.Function, or []metav
 			Name:            jobName,
 			Namespace:       funcObj.Metadata.Namespace,
 			Labels:          funcObj.Metadata.Labels,
+			Annotations:     funcObj.Metadata.Annotations,
 			OwnerReferences: or,
 		},
 		Spec: batchv2alpha1.CronJobSpec{
@@ -904,6 +914,7 @@ func EnsureFuncCronJob(client rest.Interface, funcObj *spec.Function, or []metav
 			return err
 		}
 		newCronJob.ObjectMeta.Labels = funcObj.Metadata.Labels
+		newCronJob.ObjectMeta.Annotations = funcObj.Metadata.Annotations
 		newCronJob.ObjectMeta.OwnerReferences = or
 		newCronJob.Spec = job.Spec
 		err = doRESTReq(client, groupVersion, "update", "cronjobs", jobName, funcObj.Metadata.Namespace, &newCronJob, nil)


### PR DESCRIPTION
When using kubeless in an AWS environment I may
want to allow functions to interact with AWS APIs.

They will need to authenticate to do this, and
hard coded static credentials aren't cool.

EC2 instances normally get credentials via the
metadata service... can't we do something similar?

kube2iam enables us to delegate out different roles
to containers based of an annotation.

By deploying a function in a cluster where kube2iam
exists we can assign a role to the function by
specifying an annotation:

```
kubeless function deploy get-python --runtime python2.7 --from-file ~/go/src/github.com/jtblin/kube2iam/test.py --handler test.foobar --trigger-http --annotations iam.amazonaws.com/role=role-arn
```

Signed-off-by: Ian Duffy <ian.duffy@zalando.ie>
