### PR TITLE
Split Kafka tests in a different Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,25 +30,29 @@ env:
     - secure: qbbTVfwkOraWTkQ8SxJOAsjv7qVrWqrOINIOCeFcKzwrQPHVjzr97JeOcQK73PLTwkgYg8QurwiRGB98O0fcroiqbzgXIwVk0yFrRtbmcaQ/NYXt9ipfPeeChsn8bwF7vYRuGfz9HybCU2CBmxwjJqfTeU2iqvOFfAH2Sh4b6VmbCVkINn4GFHLATcwHKoQO16B6S+z4FGSHX/AWT3vRFTBZZ65gZF7evPURtNDbumwe28KCKzmqySF5UKw2HEmDyCD+fRozlCcWYC2lbS2iZn/d0VXZvUpZxpEDVyaHdH/n6I03DZ+gnbgCi+/uw7d96s3pjomPkCiY9VfmQPl020kR8FeREyOsc0rqYtrxwe1ImKJUHsjdUZ6nUL5HcFyWJdKX6txn6bUJwUOF/+lg1O34n0ZJym3j5sm7kyoBzh0lTRMiue7Nd9WD7iJePmPEfb+Sk6UGCjgf/KGkcGr75jaVFb3AsIjtGgbq9BDQN4SKRGW3NSmXZ6pKbwFm1b6c+LPPOTukKsPTUBwEqcCCwoNSqcgIBv325dBEKJMa945/RR7E7/KXzKoWkoLkKZUTPKtVJpjsIxVkq1spPZQmmSZ3FBUww2tC+l6stD62xDYSuBH6iqLhU/xpeAjizCMS1YjNUxjs1oVBkdu2IEUV61SOoZtYyIgDvvPGpm2YcgQ=
     - secure: HbpGKPXLPT2t24YUXuk/A4Sb0K5z1AdsTz9Xo3loQr/yuR07kDhkhV5qkrgDO7wL+4VD+n1vEwtTIqnSAwWmcP0fxaWO56efgAhstXz117wcHAcfJgFTPuwMsZKqWNPc5T4yeyUNlx8UZcs1a6oCHPH2Q8fF5dOukJ74JS82YU1KIxa+TpziFaBZ5Ti/WHkCtaNxd15u3vneRUnXmBY9XUDLelSTwmUXFUYwtDYezF9U9yr8LlZoRVlkNe1NT1YQoWLmi2UaEo4rVjOisKlL8/ejOeciL6o8zYJ2XdKO58AvdyDJi90/txYjHhPJiAcL996EWIBNkg0Ms2Y6QgIpitOD8/HrxB0qONFX4suv5XDG/u3fO++JA1FTXFlQzL8/ulG94YcCyivDBQfmUb3KVNOpU1JZKqJY7bfGZwg90IJSirjixpGMh99Gm9R2WNLjPvIkjBZug3ZGiVgVL3PR4UGGkeKYYzNX+SWcTdC2ECu8HtbF/8HklpWB69gf+lN9xGgZE31+Yi3sd/zcIeECiOW3AaIGVoYOSuf+iXooG44BqFS9kHQtx2oKu73uS9/5jFu5TqU5B3v7Yryb3VHRrKqwkRAJZDl/Sdq9pbycS0xAzZErrU52iiAj5SNJyhOI+SojeuWuxo4O40w1wKi742VEWqKPHcYKYixNz+RvJEY=
     - secure: CXyDSLR6KJGoPN4ApD4UjIqXxKWxvbSuun1Py3ViI6XuhJOjTBlNJVvCV3cZUD+Dvs98sUnNVvrZgoP/YxCIF6tPzm6VboiO75gxXKJQCDbOuUE9PhBiU2WhHCEXS0AL7emCgKqOw4hNWUdyzhx+lytZkIrFFwuT0qUVqCF/1ccDJXEl3YeMotoMqiV+XQZIvoMNQVY8ENJvYNoBWi+iFF+lSRBUMavB/4soXvZjASMfz189/BQTGfXeOeKu6E+O51zup7Z+W28b9bO1r47jjY8VFdLrnnfDPtN7qEd/An4OkICnijcMHbS4n1NO9mb/wzYvOuo7hDWU5cHDbN/rhaoFmHa/8Qp9N8UMza70ps4mO4jYg+e9ZTGZvFMRU3gcF7XRkrdqBFQOsgTVJrZsfzRFiV5M30PXv4gc7UXVvsHrSj76bRpQL+dkGdqIQZxc9OFAOJ/dRLwGowu1dS5N63444xGx5PuC5IZ81Z4qIDfzpAfM5637NHrkNT9KRFyJktAK8XK1e7c1wD95uFyEDv9UPziJLEPOtTP8/YLSs1H0TgjVAyStv6HcqHDHff5n25rFehNlULpJcktqKv1YEyYGak9nwGsSTk2h73kvKp2cAfLdlW9vN9IxF60G+G+OmB4ycK+KfU0FNg/NVm40+LeogIWgz9Xh3LV+obEeMC0=
-    - secure: TCpdHWBIFmNlaVwr1IjATxiE3HWljTM7KG76WNYLkU6PQOjvE69a9oEj20ar1TRDlJfFyr2acq2c+PMfX6ry8MypGplSFBR8cQlF1vlNjVVSld25efTslq1eoWMTiEBFUX9D80tcHyheO/W6E+/7pj9vJ03GLnlHJyYeP35pemCEPjusxH3sJXCxfpBcgAsLR/56yATravxF86zUY21y64IlvzMpCIdrmd+i7DoJD5G5+LxwL+bUJD0JB97tOM9QGJyBuLFKr/fh39GO6b6PDMo2d4tEYIWcXEkgJbrpLtzzEJJl6D1/znmMUKcpKp1ScQuDHPtKBzArfDqZ4xl5vbSsc5+GbC+RiJvym99/FMdOeEoqyfqvJMNZfTZDpepgFZr3mltJ617lXIwhhuffKynhayLaa6SIE9TWARNtHUSP2iBTX4Us48759T7BK/JyKtz6ld3k92JutIovXJHzjIcvnoR0zJZ0XowhKSRiQNZkqjJ+vvMuJ+sNyq1hWwsfryxRgeHVqpcKXZP+TJvEpaksA+wMbrWNMYptGMDNakqcSH6+xL7Pjq/xg/1Jl2Zv8siW8hvhOTGsTVCDYqbu04PC/M6lH8WkTtOjFvryvFypJE+KZjyZTDloGFBNYCyz18HH9ZmZwQGdMjLI/msI7KpvFXoQuUxkzxuTjpQtNz0=
+    - secure: tywTqujLrvN0xzjawWvNniav1c/FNcgI+A+u2IdbPxb4yeO5k2Sc71nN2kHYCdD1o3K8ehAUTPF4DlNiEWGlfMhqofciSDEsSUXKz39ndZng7RXIJU9u8PGFhGSHwoZOPvVTTABT8Fa+i+omgdUsQkJOAghw1AZUD+W0Tp88J/PEZcWLd0WuslKPAioUEsNqftPT7kWVc+4BoGnZ2ZejlKsNwYnGNPCIVoE7eMa1MQM6UqsMfTzln8dQO8Ab0qVNEcm5tkwDlYoEl4kF6smV/GpnUJvMnXJycTnCr9XB7/t4Hxr1GJlQm6dumsweXTFoZTXDZtCsRtXbaFrFg+pqRRs+9BqOIDFXO1PFLrf1eryaztiErysdr66LR4/9pS1IZ8I2wJGh3bXEWDSY4clc0syusuXOKSlNDHQsWbPMC2IDNygQr/DigQmtYrwLpdiiUsF1XPHMyQKGmop6ewTYzd7DrJWwDGPrkW2YIJQgvxpkX58/dKNp4BZQY5wuXKQLvUQjFOa3gelfsbFFuhQEEbcIfINBI9TuM5K0Q+HXPdlfef/0Cbp6pktIEUYErK46mf2iy+1phXDZ0UPz/ZXe2NmawEPQVMBJaCIkr/B75mn5p7oGSKdJ3NpN87Bbn+Pwpx3tKpuDpc9hOjlfAGo+dcU6BAYkcwUSBGInjUsRNf4=
 before_install:
   - set -e
   # Decide if we should run the tests
   - |
+    case $TEST_TARGET in
     # We will only build assets when doing unit tests or minikube end-2-end tests
-    if [[ "$TEST_TARGET" == "unit" || "$TEST_TARGET" == "minikube" ]]; then
+    unit)
+    minikube)
       export SHOULD_TEST=1
-    else
-      # In case of GKE we will only want to build if it is
-      # a build of a branch in the kubeless/kubeless repository
-      if [[ "$TEST_TARGET" == "GKE" && -n "$GKE_ADMIN" && "$TRAVIS_EVENT_TYPE" != "pull_request" ]]; then
+      ;;
+    # In case of GKE we will only want to build if it is
+    # a build of a branch in the kubeless/kubeless repository
+    GKE)
+      if [[ -n "$GKE_ADMIN" && "$TRAVIS_EVENT_TYPE" != "pull_request" ]]; then
         export SHOULD_TEST=1
         export SHOULD_INSTALL_GCLOUD=1
       fi
-      # In kase of minikube+kafka we want to test it if
-      # it is a Pull Request related to Kafka (discovered from the PR title)
-      # or if the build is from the "master" branch
-      if [[ "$TEST_TARGET" == "minikube_kafka" ]]; then
+      ;;
+    # In kase of minikube+kafka we want to test it if
+    # it is a Pull Request related to Kafka (discovered from the PR title)
+    # or if the build is from the "master" branch
+    minikube_kafka)
         if [[ "$TRAVIS_PULL_REQUEST" != false ]]; then
           # CHANGE SLUG
           pr_kafka_title=$(curl -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/andresmgot/kubeless/pulls/${TRAVIS_PULL_REQUEST}" | grep title | grep -i kafka || true)

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,8 +54,7 @@ before_install:
     # or if the build is from the "master" branch
     minikube_kafka)
         if [[ "$TRAVIS_PULL_REQUEST" != false ]]; then
-          # CHANGE SLUG
-          pr_kafka_title=$(curl -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/andresmgot/kubeless/pulls/${TRAVIS_PULL_REQUEST}" | grep title | grep -i kafka || true)
+          pr_kafka_title=$(curl -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/${TRAVIS_PULL_REQUEST}" | grep title | grep -i kafka || true)
         fi
         if [[ "$TRAVIS_BRANCH" == master || "$pr_kafka_title" != "" ]]; then
           export SHOULD_TEST=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,24 +17,53 @@ env:
   matrix:
     - TEST_TARGET=unit
     - TEST_TARGET=minikube
+    - TEST_TARGET=minikube_kafka
     - TEST_TARGET=GKE
   global:
     - CONTROLLER_IMAGE_NAME=bitnami/kubeless-controller
     - CONTROLLER_IMAGE=${CONTROLLER_IMAGE_NAME}:${TRAVIS_TAG:-build-$TRAVIS_BUILD_ID}
     - CGO_ENABLED=0
+    - TEST_DEBUG=1
     - GKE_VERSION=1.7.8-gke.0
     - secure: QTXmAe9Z5WkWq8KDvcP5JauyYrYaupywLUQjlE2SJWuD1wvgcQxPlkWF5NpSAL70TqnGhkmCmsfQBdJ+T59/yYjTldfnFumkp1dABdIURFPQc8h7IeF+evSSmwgaGwTc7bRPu9cprH1yflwyAEQmnzKGkT91ZHszZxfyMDFKPcFJhBdz2lcOsJRIetgrMOBS0sguZVnnY08okq6F0DEDk3SYT9RoPN0/NjyerPpxJ7arS2bN02R6ogBZM7LiTUF6aFuA3vaVKZarVBXYL5ZDr0HvHcSuT0T8F+CGDM7KALldOWgrNbDiVLXBliwRpQbxmKMti7gSftym77MYZHvfq7kKWNrJ/CkV0yXIBrvC0+CQ8Q6E7+dx6pD5HRPB4KGTvAJASZPpysDOcLvjIJh6UvCnQ6I0anoIeK3Socm3NQeEYr6gLVOtZfoiIL1D27NgOEtgviEMQ/haNW9x6O6LT4K/j5NAjm/mcW4/h5Z7vJHBnIbEVsXCe5hj8QmoH1hJvkRcgT5eB5E5dCidt+hMed/cD/ERb1XG1fnK6uBHLS3+sm86ZEyMu7/uI2OQkBtvhPthdcPsCB6rnJMdkIg2vq981vlxA7d2uWhhLX8lfhKMKLEhZtNJPBdcXNvo6a5GxbhHWlPIH7wli2be9t/UuZBRuSINnN4HBAXKWD364lo=
     - secure: NxB8NiLbhZpSwLEQoldgI6fDH3w2NuKcSFIHV/ZVqxO0zOknttP0t5UPmkCBKaVgWHo1PizkC7Iu/ukn757sqa9M4iZAlenl+uu4Zw86S6PMz5UsKwtivV1t6/fXaMqn/RryYzGFDPdgTWTSM97j0/b3iw09Ph5CvMhfT7gkinWtF/TZyx5MbSZfpFRM+zy8pm/TpwQ6xeYIFKlhshv9NMZrj5cVbp2S+9V1GR+eoYnaCXfN99cf+lNwKAMhFihKkFzYrXBy8QNflsvfc4JNJlTOzf3OQd6oQ2u+V+x4tHq4oyIjZAQBNLFR9zfF1ClbRdbmoWt8JxPEfVM0mNxzRKnSHs+o7ZkBlAs8vxSnH4f4qWMlHAD3CKzc+jDKIYLdFtwLMP/0PVNF5EvYfteSKa/+dZtGFMweJu3ZMG2ikFT9kmpJ/RBncePm40yVIpqkMgf6VlsXYnD9pdlBvIaEZK5Qa9DHpkJAhiJ2ZPV4YxoAn2n9L/++EicHB8Wy+wud3yJFVSUDx+Gg5njJGOx32pypQReY7objy7nRuR0r9dhNyQ+VgCUp8Cv9pyJjXUqjOauAF60n+2KuOo6NKYg5lA9IqcOKP7svlFwgtOpKHEC1tg9CKhdhRr82TFBuJsyuAzVulDAOcxHSMJP7bz4I9Jtxxr4EMjYrpoOfgkOlmxY=
     - secure: qbbTVfwkOraWTkQ8SxJOAsjv7qVrWqrOINIOCeFcKzwrQPHVjzr97JeOcQK73PLTwkgYg8QurwiRGB98O0fcroiqbzgXIwVk0yFrRtbmcaQ/NYXt9ipfPeeChsn8bwF7vYRuGfz9HybCU2CBmxwjJqfTeU2iqvOFfAH2Sh4b6VmbCVkINn4GFHLATcwHKoQO16B6S+z4FGSHX/AWT3vRFTBZZ65gZF7evPURtNDbumwe28KCKzmqySF5UKw2HEmDyCD+fRozlCcWYC2lbS2iZn/d0VXZvUpZxpEDVyaHdH/n6I03DZ+gnbgCi+/uw7d96s3pjomPkCiY9VfmQPl020kR8FeREyOsc0rqYtrxwe1ImKJUHsjdUZ6nUL5HcFyWJdKX6txn6bUJwUOF/+lg1O34n0ZJym3j5sm7kyoBzh0lTRMiue7Nd9WD7iJePmPEfb+Sk6UGCjgf/KGkcGr75jaVFb3AsIjtGgbq9BDQN4SKRGW3NSmXZ6pKbwFm1b6c+LPPOTukKsPTUBwEqcCCwoNSqcgIBv325dBEKJMa945/RR7E7/KXzKoWkoLkKZUTPKtVJpjsIxVkq1spPZQmmSZ3FBUww2tC+l6stD62xDYSuBH6iqLhU/xpeAjizCMS1YjNUxjs1oVBkdu2IEUV61SOoZtYyIgDvvPGpm2YcgQ=
     - secure: HbpGKPXLPT2t24YUXuk/A4Sb0K5z1AdsTz9Xo3loQr/yuR07kDhkhV5qkrgDO7wL+4VD+n1vEwtTIqnSAwWmcP0fxaWO56efgAhstXz117wcHAcfJgFTPuwMsZKqWNPc5T4yeyUNlx8UZcs1a6oCHPH2Q8fF5dOukJ74JS82YU1KIxa+TpziFaBZ5Ti/WHkCtaNxd15u3vneRUnXmBY9XUDLelSTwmUXFUYwtDYezF9U9yr8LlZoRVlkNe1NT1YQoWLmi2UaEo4rVjOisKlL8/ejOeciL6o8zYJ2XdKO58AvdyDJi90/txYjHhPJiAcL996EWIBNkg0Ms2Y6QgIpitOD8/HrxB0qONFX4suv5XDG/u3fO++JA1FTXFlQzL8/ulG94YcCyivDBQfmUb3KVNOpU1JZKqJY7bfGZwg90IJSirjixpGMh99Gm9R2WNLjPvIkjBZug3ZGiVgVL3PR4UGGkeKYYzNX+SWcTdC2ECu8HtbF/8HklpWB69gf+lN9xGgZE31+Yi3sd/zcIeECiOW3AaIGVoYOSuf+iXooG44BqFS9kHQtx2oKu73uS9/5jFu5TqU5B3v7Yryb3VHRrKqwkRAJZDl/Sdq9pbycS0xAzZErrU52iiAj5SNJyhOI+SojeuWuxo4O40w1wKi742VEWqKPHcYKYixNz+RvJEY=
     - secure: CXyDSLR6KJGoPN4ApD4UjIqXxKWxvbSuun1Py3ViI6XuhJOjTBlNJVvCV3cZUD+Dvs98sUnNVvrZgoP/YxCIF6tPzm6VboiO75gxXKJQCDbOuUE9PhBiU2WhHCEXS0AL7emCgKqOw4hNWUdyzhx+lytZkIrFFwuT0qUVqCF/1ccDJXEl3YeMotoMqiV+XQZIvoMNQVY8ENJvYNoBWi+iFF+lSRBUMavB/4soXvZjASMfz189/BQTGfXeOeKu6E+O51zup7Z+W28b9bO1r47jjY8VFdLrnnfDPtN7qEd/An4OkICnijcMHbS4n1NO9mb/wzYvOuo7hDWU5cHDbN/rhaoFmHa/8Qp9N8UMza70ps4mO4jYg+e9ZTGZvFMRU3gcF7XRkrdqBFQOsgTVJrZsfzRFiV5M30PXv4gc7UXVvsHrSj76bRpQL+dkGdqIQZxc9OFAOJ/dRLwGowu1dS5N63444xGx5PuC5IZ81Z4qIDfzpAfM5637NHrkNT9KRFyJktAK8XK1e7c1wD95uFyEDv9UPziJLEPOtTP8/YLSs1H0TgjVAyStv6HcqHDHff5n25rFehNlULpJcktqKv1YEyYGak9nwGsSTk2h73kvKp2cAfLdlW9vN9IxF60G+G+OmB4ycK+KfU0FNg/NVm40+LeogIWgz9Xh3LV+obEeMC0=
+    - secure: TCpdHWBIFmNlaVwr1IjATxiE3HWljTM7KG76WNYLkU6PQOjvE69a9oEj20ar1TRDlJfFyr2acq2c+PMfX6ry8MypGplSFBR8cQlF1vlNjVVSld25efTslq1eoWMTiEBFUX9D80tcHyheO/W6E+/7pj9vJ03GLnlHJyYeP35pemCEPjusxH3sJXCxfpBcgAsLR/56yATravxF86zUY21y64IlvzMpCIdrmd+i7DoJD5G5+LxwL+bUJD0JB97tOM9QGJyBuLFKr/fh39GO6b6PDMo2d4tEYIWcXEkgJbrpLtzzEJJl6D1/znmMUKcpKp1ScQuDHPtKBzArfDqZ4xl5vbSsc5+GbC+RiJvym99/FMdOeEoqyfqvJMNZfTZDpepgFZr3mltJ617lXIwhhuffKynhayLaa6SIE9TWARNtHUSP2iBTX4Us48759T7BK/JyKtz6ld3k92JutIovXJHzjIcvnoR0zJZ0XowhKSRiQNZkqjJ+vvMuJ+sNyq1hWwsfryxRgeHVqpcKXZP+TJvEpaksA+wMbrWNMYptGMDNakqcSH6+xL7Pjq/xg/1Jl2Zv8siW8hvhOTGsTVCDYqbu04PC/M6lH8WkTtOjFvryvFypJE+KZjyZTDloGFBNYCyz18HH9ZmZwQGdMjLI/msI7KpvFXoQuUxkzxuTjpQtNz0=
 before_install:
   - set -e
-
-install:
-  - make bootstrap
+  # Decide if we should run the tests
   - |
-    if [[ "$TEST_TARGET" == "GKE" && -n "$GKE_ADMIN" && "$TRAVIS_EVENT_TYPE" != "pull_request" ]]; then
+    # We will only build assets when doing unit tests or minikube end-2-end tests
+    if [[ "$TEST_TARGET" == "unit" || "$TEST_TARGET" == "minikube" ]]; then
+      export SHOULD_TEST=1
+    else
+      # In case of GKE we will only want to build if it is
+      # a build of a branch in the kubeless/kubeless repository
+      if [[ "$TEST_TARGET" == "GKE" && -n "$GKE_ADMIN" && "$TRAVIS_EVENT_TYPE" != "pull_request" ]]; then
+        export SHOULD_TEST=1
+        export SHOULD_INSTALL_GCLOUD=1
+      fi
+      # In kase of minikube+kafka we want to test it if
+      # it is a Pull Request related to Kafka (discovered from the PR title)
+      # or if the build is from the "master" branch
+      if [[ "$TEST_TARGET" == "minikube_kafka" ]]; then
+        if [[ "$TRAVIS_PULL_REQUEST" != false ]]; then
+          # CHANGE SLUG
+          pr_kafka_title=$(curl -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/andresmgot/kubeless/pulls/${TRAVIS_PULL_REQUEST}" | grep title | grep -i kafka || true)
+        fi
+        if [[ "$TRAVIS_BRANCH" == master || "$pr_kafka_title" != "" ]]; then
+          export SHOULD_TEST=1
+        fi
+      fi
+    fi
+install:
+  - |
+    if [[ "$SHOULD_TEST" == "1" ]]; then
+      make bootstrap
+    fi
+    if [[ "$SHOULD_INSTALL_GCLOUD" == "1" ]]; then
       export GOOGLE_APPLICATION_CREDENTIALS=$TRAVIS_BUILD_DIR/client_secrets.json
       openssl aes-256-cbc -K $encrypted_1dbafa65b3ad_key -iv $encrypted_1dbafa65b3ad_iv -in .github/gcloud.json.enc -out $GOOGLE_APPLICATION_CREDENTIALS -d
       if [ ! -d $HOME/gcloud/google-cloud-sdk ]; then
@@ -56,20 +85,24 @@ install:
 
 script:
   - |
-    make VERSION=${TRAVIS_TAG:-build-$TRAVIS_BUILD_ID} binary
-    make controller-image CONTROLLER_IMAGE=$CONTROLLER_IMAGE
-    make all-yaml
-    case $TEST_TARGET in
-    unit)
-      make test
-      make validation
-      ;;
-    minikube)
-      export TEST_DEBUG=1
-      make integration-tests
-      ;;
-    GKE)
-      if [[ -n "$GKE_ADMIN" && "$TRAVIS_EVENT_TYPE" != "pull_request" ]]; then
+    if [[ "$SHOULD_TEST" == "1" ]]; then
+      make VERSION=${TRAVIS_TAG:-build-$TRAVIS_BUILD_ID} binary
+      make controller-image CONTROLLER_IMAGE=$CONTROLLER_IMAGE
+      make all-yaml
+      case $TEST_TARGET in
+      unit)
+        make test
+        make validation
+        ;;
+      minikube)
+        ./script/integration-tests minikube deployment
+        ./script/integration-tests minikube basic
+        ;;
+      minikube_kafka)
+        ./script/integration-tests minikube deployment
+        ./script/integration-tests minikube kafka
+        ;;
+      GKE)
         docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
         docker push $CONTROLLER_IMAGE
         sed -i.bak 's/'":latest"'/'":${TRAVIS_TAG:-build-$TRAVIS_BUILD_ID}"'/g' kubeless.yaml
@@ -81,13 +114,12 @@ script:
           echo "Waiting for a previous installation to be cleaned"
           bash -c 'grep -q "No resources found" <(timeout 60 kubectl get pods -n kubeless -w 2>&1)'
         fi
-        export TEST_DEBUG=1
         ./script/integration-tests gke_${GKE_PROJECT}_${ZONE}_${GKE_CLUSTER}
-      else
-        echo "Skipping GKE tests"
-      fi
-      ;;
-    esac
+        ;;
+      esac
+    else
+      echo "Skipping tests"
+    fi
 
 after_success:
   - |
@@ -99,6 +131,11 @@ after_success:
     fi
 
 before_deploy:
+  - |
+    if [[ "$SHOULD_TEST" != "1" ]]; then
+      echo "Unable to release a job that has not being tested!"
+      return 1
+    fi
   - make VERSION=${TRAVIS_TAG:-build-$TRAVIS_BUILD_ID} binary-cross
   - for d in bundles/kubeless_*; do zip -r9 $d.zip $d/; done
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -36,9 +36,8 @@ before_install:
   # Decide if we should run the tests
   - |
     case $TEST_TARGET in
-    # We will only build assets when doing unit tests or minikube end-2-end tests
-    unit)
-    minikube)
+    # We will always build assets when doing unit tests or minikube end-2-end tests
+    unit|minikube)
       export SHOULD_TEST=1
       ;;
     # In case of GKE we will only want to build if it is
@@ -53,14 +52,14 @@ before_install:
     # it is a Pull Request related to Kafka (discovered from the PR title)
     # or if the build is from the "master" branch
     minikube_kafka)
-        if [[ "$TRAVIS_PULL_REQUEST" != false ]]; then
-          pr_kafka_title=$(curl -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/${TRAVIS_PULL_REQUEST}" | grep title | grep -i kafka || true)
-        fi
-        if [[ "$TRAVIS_BRANCH" == master || "$pr_kafka_title" != "" ]]; then
-          export SHOULD_TEST=1
-        fi
+      if [[ "$TRAVIS_PULL_REQUEST" != false ]]; then
+        pr_kafka_title=$(curl -H "Authorization: token ${GITHUB_TOKEN}" "https://api.github.com/repos/$TRAVIS_REPO_SLUG/pulls/${TRAVIS_PULL_REQUEST}" | grep title | grep -i kafka || true)
       fi
-    fi
+      if [[ "$TRAVIS_BRANCH" == master || "$pr_kafka_title" != "" ]]; then
+        export SHOULD_TEST=1
+      fi
+      ;;
+    esac
 install:
   - |
     if [[ "$SHOULD_TEST" == "1" ]]; then

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ Consult the [Developer's guide](./docs/dev-guide.md) to setup yourself up.
 2. The [repo owners](OWNERS) will respond to your issue promptly.
 3. If your proposed change is accepted, fork the desired repo, develop and test your code changes.
 4. Submit a pull request making sure you fill up clearly the description, point out the particular
-   issue your PR is mitigating, and ask for code review. You will be asked to add tests (either unit or e2e tests depending on the patch) and update any affected documentation.
+   issue your PR is mitigating, and ask for code review. If the PR is related to Kafka, include at least the tag [Kafka] in the title. You will be asked to add tests (either unit or e2e tests depending on the patch) and update any affected documentation.
 
 ## Issues
 

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,8 @@ validation:
 	./script/validate-git-marks
 
 integration-tests:
-	./script/integration-tests
+	./script/integration-tests deployment
+	./script/integration-tests basic
 
 minikube-rbac-test:
 	./script/integration-test-rbac minikube

--- a/script/cluster-up-minikube.sh
+++ b/script/cluster-up-minikube.sh
@@ -43,7 +43,7 @@ check_or_build_nsenter() {
 }
 check_or_install_minikube() {
     which minikube || {
-        wget --no-clobber -O minikube \
+        wget -q --no-clobber -O minikube \
             https://storage.googleapis.com/minikube/releases/${MINIKUBE_VERSION}/minikube-linux-amd64
         install_bin ./minikube
     }

--- a/script/integration-tests
+++ b/script/integration-tests
@@ -27,6 +27,8 @@ test -n "${TRAVIS_K8S_CONTEXT}" && set -- ${TRAVIS_K8S_CONTEXT}
 # minikube seems to be more stable than dind, sp for kafka
 INTEGRATION_TESTS_CTX=${1:-minikube}
 
+INTEGRATION_TESTS_TARGET=${2:-default}
+
 # Check for some needed tools, install (some) if missing
 which bats > /dev/null || {
    echo "ERROR: 'bats' is required to run these tests," \
@@ -63,7 +65,20 @@ k8s_context_save
 
 # Run the tests thru bats:
 kubectl create namespace kubeless
-bats tests/integration-tests.bats
+case $INTEGRATION_TESTS_TARGET in
+deployment)
+    bats tests/deployment-tests.bats
+    ;;
+basic)
+    bats tests/integration-tests.bats
+    ;;
+kafka)
+    bats tests/integration-tests-kafka.bats
+    ;;
+*)
+    bats tests/deployment-tests.bats && bats tests/integration-tests.bats && bats tests/integration-tests-kafka.bats
+    ;;
+esac
 exit_code=$?
 
 # Just showing remaining k8s objects

--- a/script/libtest.bash
+++ b/script/libtest.bash
@@ -20,7 +20,7 @@ KUBELESS_MANIFEST_RBAC=kubeless-rbac.yaml
 KUBECTL_BIN=$(which kubectl)
 : ${KUBECTL_BIN:?ERROR: missing binary: kubectl}
 
-export TEST_MAX_WAIT_SEC=360
+export TEST_MAX_WAIT_SEC=600
 
 # Workaround 'bats' lack of forced output support, dup() stderr fd
 exec 9>&2

--- a/tests/deployment-tests.bats
+++ b/tests/deployment-tests.bats
@@ -1,0 +1,31 @@
+# Copyright (c) 2016-2017 Bitnami
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load ../script/libtest
+
+@test "Verify TEST_CONTEXT envvar" {
+  : ${TEST_CONTEXT:?}
+}
+@test "Verify needed kubernetes tools installed" {
+  verify_k8s_tools
+}
+@test "Verify k8s RBAC mode" {
+  verify_rbac_mode
+}
+@test "Test simple function failure without RBAC rules" {
+  test_must_fail_without_rbac_roles
+}
+@test "Redeploy with proper RBAC rules" {
+  redeploy_with_rbac_roles
+}

--- a/tests/integration-tests-kafka.bats
+++ b/tests/integration-tests-kafka.bats
@@ -31,6 +31,7 @@ load ../script/libtest
   kubeless_function_delete pubsub-python34
 }
 @test "Test function: pubsub-nodejs" {
+  skip "This test is flaky until kubeless/kubeless/issues/519 is fixed"
   deploy_function pubsub-nodejs
   verify_function pubsub-nodejs
   test_kubeless_function_update pubsub-nodejs

--- a/tests/integration-tests-kafka.bats
+++ b/tests/integration-tests-kafka.bats
@@ -1,0 +1,64 @@
+#!/usr/bin/env bats
+
+# Copyright (c) 2016-2017 Bitnami
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+load ../script/libtest
+
+# 'bats' lacks loop support, unroll-them-all ->
+@test "Wait for kafka" {
+  wait_for_kubeless_kafka_server_ready
+}
+@test "Test function: pubsub-python" {
+  deploy_function pubsub-python
+  verify_function pubsub-python
+  kubeless_function_delete pubsub-python
+}
+@test "Test function: pubsub-python34" {
+  deploy_function pubsub-python34
+  verify_function pubsub-python34
+  kubeless_function_delete pubsub-python34
+}
+@test "Test function: pubsub-nodejs" {
+  deploy_function pubsub-nodejs
+  verify_function pubsub-nodejs
+  test_kubeless_function_update pubsub-nodejs
+  kubeless_function_delete pubsub-nodejs
+}
+@test "Test function: pubsub-ruby" {
+  deploy_function pubsub-ruby
+  verify_function pubsub-ruby
+  kubeless_function_delete pubsub-ruby
+}
+@test "Test topic list" {
+  wait_for_kubeless_kafka_server_ready
+  for topic in topic1 topic2; do
+    kubeless topic create $topic
+    _wait_for_kubeless_kafka_topic_ready $topic
+  done
+
+  kubeless topic list >$BATS_TMPDIR/kubeless-topic-list
+  grep -qxF topic1 $BATS_TMPDIR/kubeless-topic-list
+  grep -qxF topic2 $BATS_TMPDIR/kubeless-topic-list
+}
+@test "Test topic deletion" {
+  test_topic_deletion
+}
+@test "Verify Kafka after restart (if context=='minikube')" {
+    local topic=$RANDOM
+    kubeless topic create $topic
+    sts_restart
+    kubeless topic list | grep $topic
+}
+# vim: ts=2 sw=2 si et syntax=sh

--- a/tests/integration-tests.bats
+++ b/tests/integration-tests.bats
@@ -16,21 +16,6 @@
 
 load ../script/libtest
 
-@test "Verify TEST_CONTEXT envvar" {
-  : ${TEST_CONTEXT:?}
-}
-@test "Verify needed kubernetes tools installed" {
-  verify_k8s_tools
-}
-@test "Verify k8s RBAC mode" {
-  verify_rbac_mode
-}
-@test "Test simple function failure without RBAC rules" {
-  test_must_fail_without_rbac_roles
-}
-@test "Redeploy with proper RBAC rules" {
-  redeploy_with_rbac_roles
-}
 # 'bats' lacks loop support, unroll-them-all ->
 @test "Deploy functions to evaluate" {
   deploy_function get-python
@@ -123,54 +108,10 @@ load ../script/libtest
   verify_function get-python-metadata
   kubeless_function_delete get-python-metadata
 }
-@test "Wait for kafka" {
-  wait_for_kubeless_kafka_server_ready
-}
-@test "Test function: pubsub-python" {
-  deploy_function pubsub-python
-  verify_function pubsub-python
-  kubeless_function_delete pubsub-python
-}
-@test "Test function: pubsub-python34" {
-  deploy_function pubsub-python34
-  verify_function pubsub-python34
-  kubeless_function_delete pubsub-python34
-}
-@test "Test function: pubsub-nodejs" {
-  deploy_function pubsub-nodejs
-  verify_function pubsub-nodejs
-  test_kubeless_function_update pubsub-nodejs
-  kubeless_function_delete pubsub-nodejs
-}
-@test "Test function: pubsub-ruby" {
-  deploy_function pubsub-ruby
-  verify_function pubsub-ruby
-  kubeless_function_delete pubsub-ruby
-}
 @test "Test function: scheduled-get-python" {
   # Now we can verify the scheduled function
   # without having to wait
   verify_function scheduled-get-python
   kubeless_function_delete scheduled-get-python
-}
-@test "Test topic list" {
-  wait_for_kubeless_kafka_server_ready
-  for topic in topic1 topic2; do
-    kubeless topic create $topic
-    _wait_for_kubeless_kafka_topic_ready $topic
-  done
-
-  kubeless topic list >$BATS_TMPDIR/kubeless-topic-list
-  grep -qxF topic1 $BATS_TMPDIR/kubeless-topic-list
-  grep -qxF topic2 $BATS_TMPDIR/kubeless-topic-list
-}
-@test "Test topic deletion" {
-  test_topic_deletion
-}
-@test "Verify Kafka after restart (if context=='minikube')" {
-    local topic=$RANDOM
-    kubeless topic create $topic
-    sts_restart
-    kubeless topic list | grep $topic
 }
 # vim: ts=2 sw=2 si et syntax=sh


### PR DESCRIPTION
**Issue Ref**: None
 
**Description**: 

This PR organizes the `.travis.yml` file and its builds so by default only basic end-to-end tests are executed. If the build is related to Kafka (checking the PR title) it will launch the tests related to Kafka. If it is a build in `master` it will run all the tests.

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 - [x] Docs