### PR TITLE
update GKE guideline for 1.8.x

### DIFF
--- a/docs/misc/kafka-pv.yaml
+++ b/docs/misc/kafka-pv.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: kafka-pv
+  labels:
+    kubeless: kafka
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  gcePersistentDisk:
+    pdName: kubeless-kafka
+    fsType: ext4
+

--- a/docs/misc/zk-pv.yaml
+++ b/docs/misc/zk-pv.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: zookeeper-pv
+  labels:
+    kubeless: zookeeper
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  gcePersistentDisk:
+    pdName: kubeless-zookeeper
+    fsType: ext4
+


### PR DESCRIPTION
**Issue Ref**: None
 
**Description**:  On GKE 1.8.x, deploying Kubeless requires some more steps to create kafka and zookeeper PV. This PR add that step to the current guideline.

**TODOs**:
 - [x] Ready to review
 - [x] ~~Automated Tests~~
 - [x] Docs