### PR TITLE
Correcting documentation for ingress commands for kubeless with respect to the version v0.3.1

### DIFF
--- a/docs/routing.md
+++ b/docs/routing.md
@@ -1,6 +1,6 @@
 # Add route to Kubeless function
 
-Kubeless leverages [Kubernetes ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) to provide routing for function. By default, a deployed function will be matched to a Kubernetes service with service type is ClusterIP that means it is not exposed publicly. We provides `kubeless route` command to make the function published. This guide give you a quick sample on how to do it.
+Kubeless leverages [Kubernetes ingress](https://kubernetes.io/docs/concepts/services-networking/ingress/) to provide routing for function. By default, a deployed function will be matched to a Kubernetes service with service type is ClusterIP that means it is not exposed publicly. We provides `kubeless ingress` command to make the function published. This guide give you a quick sample on how to do it.
 
 ## Ingress controller
 
@@ -29,26 +29,32 @@ get-python   10.0.0.26    <none>        8080/TCP   44s
 ## Create route
 
 Kubeless support ingress command to create route to function.
+
+From the kubeless **version v0.3.1 (cc6e694f)**, kubeless supports the `kubeless ingress` command.
+
 ```
-$ kubeless route --help
+$ kubeless ingress --help
 ingress command allows user to list, create, delete routing rule for function on Kubeless
 
 Usage:
-  kubeless route SUBCOMMAND [flags]
-  kubeless route [command]
+  kubeless ingress SUBCOMMAND [flags]
+  kubeless ingress [command]
 
 Available Commands:
   create      create a route to function
   delete      delete a route from Kubeless
   list        list all routes in Kubeless
 
-Use "kubeless route [command] --help" for more information about a command.
+Flags:
+  -h, --help   help for ingress
+
+Use "kubeless ingress [command] --help" for more information about a command.
 ```
 
 We will create a route to `get-python` function:
 
 ```
-$ kubeless route create route1 --function get-python
+$ kubeless ingress create route1 --function get-python
 ```
 
 This command will create an ingress object. We can see it with kubectl (this guide is run on minikube):
@@ -62,7 +68,7 @@ route1    get-python.192.168.99.100.nip.io   192.168.99.100   80        59s
 Kubeless creates a default hostname in form of <function-name>.<master-address>.nip.io. Alternatively, you can provide a real hostname with `--hostname` flag like this:
 
 ```
-$ kubeless route create route2 --function get-python --hostname example.com
+$ kubeless ingress create route2 --function get-python --hostname example.com
 $ kubectl get ing
 NAME      HOSTS                              ADDRESS          PORTS     AGE
 route1    get-python.192.168.99.100.nip.io   192.168.99.100   80        3m
@@ -82,7 +88,7 @@ $ curl --data '{"Another": "Echo"}' --header "Host: get-python.192.168.99.100.ni
 By default, Kubeless doesn't take care of TLS setup for function. But you can do it manually by following the [standard procedure](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) of securing ingress. There is also [general guideline](https://docs.bitnami.com/kubernetes/how-to/secure-kubernetes-services-with-ingress-tls-letsencrypt/) to enable TLS for your Kubernetes service using LetsEncrypt and kube-lego written by Bitnami folks. When you have Kube-lego setup, you can deploy function and create route with flag `--enableTLSAcme` enabled as below:
 
 ```
-$ kubeless route create route1 --function get-python --enableTLSAcme
+$ kubeless ingress create route1 --function get-python --enableTLSAcme
 ```
 
 Running above command, Kubeless will automatically create ingress object with annotation `kubernetes.io/tls-acme: 'true'` set.


### PR DESCRIPTION
**Issue Ref**: Part of this is mentions in this issue #504 
 
**Description**:  `kubeless route` command is obsolete, so changing the documentation to `kubeless ingress` with respect to the version v0.3.1.

 - It is a simple change with the `routing.md` document.
