### PR TITLE
fix GetFunctionImage from environment variable

### DIFF
--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -9,6 +9,18 @@ Each runtime is encapsulated in a container image. The reference to these images
 
 Runtimes have a maximum timeout set by the environment variable FUNC_TIMEOUT. This environment variable can be set using the CLI option `--timeout`. The default value is 180 seconds. If a function takes more than that in being executed, the process will be terminated.
 
+## Configuring Default Runtime Container Images
+The Kubeless controller defines a set of default container images per supported runtime variant.
+These default container images can be configured via Kubernetes environment variables on the Kubeless controller's deployment container.
+Some examples:
+| Runtime Variant | Environment Variable Name |
+| --- | --- |
+| NodeJS 6.X HTTP Trigger | NODEJS6_RUNTIME |
+| NodeJS 8.X Event Trigger | NODEJS8_PUBSUB_RUNTIME |
+| Python 2.7.x HTTP Trigger | PYTHON2.7_RUNTIME |
+| Ruby 2.4.x HTTP Trigger | RUBY2.4_RUNTIME |
+| ... | ... |
+
 # Runtime variants
 ## HTTP Trigger
 This variant is used when the function is meant to be triggered through HTTP. For doing so we use a web framework that is in charge of receiving request and redirect them to the function. This kind of trigger is supported for all the runtimes.

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -13,6 +13,7 @@ Runtimes have a maximum timeout set by the environment variable FUNC_TIMEOUT. Th
 The Kubeless controller defines a set of default container images per supported runtime variant.
 These default container images can be configured via Kubernetes environment variables on the Kubeless controller's deployment container.
 Some examples:
+
 | Runtime Variant | Environment Variable Name |
 | --- | --- |
 | NodeJS 6.X HTTP Trigger | NODEJS6_RUNTIME |

--- a/pkg/langruntime/langruntime.go
+++ b/pkg/langruntime/langruntime.go
@@ -147,9 +147,9 @@ func GetFunctionImage(runtime, ftype string) (string, error) {
 
 	imageNameEnvVar := ""
 	if ftype == pubsubFunc {
-		imageNameEnvVar = strings.ToUpper(runtimeInf.ID) + "_PUBSUB_RUNTIME"
+		imageNameEnvVar = strings.ToUpper(runtimeInf.ID) + getVersionFromRuntime(runtime) + "_PUBSUB_RUNTIME"
 	} else {
-		imageNameEnvVar = strings.ToUpper(runtimeInf.ID) + "_RUNTIME"
+		imageNameEnvVar = strings.ToUpper(runtimeInf.ID) + getVersionFromRuntime(runtime) + "_RUNTIME"
 	}
 	imageName := os.Getenv(imageNameEnvVar)
 	if imageName == "" {

--- a/pkg/langruntime/langruntime_test.go
+++ b/pkg/langruntime/langruntime_test.go
@@ -54,7 +54,7 @@ func TestGetFunctionImage(t *testing.T) {
 	}
 
 	expectedImageName := "ruby-test-image"
-	os.Setenv("RUBY_RUNTIME", expectedImageName)
+	os.Setenv("RUBY2.4_RUNTIME", expectedImageName)
 	imageR, errR := GetFunctionImage("ruby2.4", "HTTP")
 	if errR != nil {
 		t.Fatalf("Retrieving the image returned err: %v", errR)
@@ -62,10 +62,10 @@ func TestGetFunctionImage(t *testing.T) {
 	if imageR != expectedImageName {
 		t.Fatalf("Expecting " + imageR + " to be set to " + expectedImageName)
 	}
-	os.Unsetenv("RUBY_RUNTIME")
+	os.Unsetenv("RUBY2.4_RUNTIME")
 
 	expectedImageName = "ruby-pubsub-test-image"
-	os.Setenv("RUBY_PUBSUB_RUNTIME", "ruby-pubsub-test-image")
+	os.Setenv("RUBY2.4_PUBSUB_RUNTIME", "ruby-pubsub-test-image")
 	imageR, errR = GetFunctionImage("ruby2.4", "PubSub")
 	if errR != nil {
 		t.Fatalf("Retrieving the image returned err: %v", errR)
@@ -73,7 +73,7 @@ func TestGetFunctionImage(t *testing.T) {
 	if imageR != expectedImageName {
 		t.Fatalf("Expecting " + imageR + " to be set to " + expectedImageName)
 	}
-	os.Unsetenv("RUBY_PUBSUB_RUNTIME")
+	os.Unsetenv("RUBY2.4_PUBSUB_RUNTIME")
 }
 
 func TestGetRuntimes(t *testing.T) {


### PR DESCRIPTION
**Issue Ref**: [Issue number related to this PR or None]
#508 
 
**Description**: 
It's possible to specify function runtime docker images via environment variables on the kubeless controller deployment. Runtime versions haven't been taken into account. This is now fixed.

[PR Description]

**TODOs**:
 - [x] Ready to review
 - [x] Automated Tests
 - [ ] Docs
