### PR TITLE
Update Helm chart to use CRD

### DIFF
--- a/chart/kubeless/templates/function-crd.yaml
+++ b/chart/kubeless/templates/function-crd.yaml
@@ -1,0 +1,15 @@
+apiVersion: apiextensions.k8s.io/v1beta1
+description: Kubernetes Native Serverless Framework
+kind: CustomResourceDefinition
+metadata:
+  name: functions.k8s.io
+  labels:
+{{ include "labels.standard" . | indent 4 }}
+spec:
+  group: k8s.io
+  names:
+    kind: Function
+    plural: functions
+    singular: function
+  scope: Namespaced
+  version: v1

--- a/chart/kubeless/templates/function-tpr.yaml
+++ b/chart/kubeless/templates/function-tpr.yaml
@@ -1,9 +1,0 @@
-apiVersion: extensions/v1beta1
-description: 'Kubeless: Serverless framework for Kubernetes'
-kind: ThirdPartyResource
-metadata:
-  name: function.k8s.io
-  labels:
-{{ include "labels.standard" . | indent 4 }}
-versions:
-- name: v1

--- a/chart/kubeless/values.yaml
+++ b/chart/kubeless/values.yaml
@@ -6,7 +6,7 @@ controller:
     replicaCount: 1
     image:
       repository: bitnami/kubeless-controller@sha256
-      tag: d07986d575a80179ae15205c6fa5eb3bf9f4f4f46235c79ad6b284e5d3df22d0 
+      tag: 53592e0f023353665569313a1662a3aff18141e48caf4beca54d68436e71e0dc
       pullPolicy: IfNotPresent
 
 ## UI configuration
@@ -16,7 +16,7 @@ ui:
     ui:
       image:
         repository: bitnami/kubeless-ui
-        tag: development
+        tag: v0.1.0
         pullPolicy: IfNotPresent
     proxy:
       image:
@@ -44,5 +44,5 @@ kafka:
     replicaCount: 1
     image:
       repository: bitnami/kafka@sha256
-      tag: ef0b1332408c0361d457852622d3a180f3609b9d98f1a85a9a809adaecfe9b52
+      tag: 0c4be25cd3b31176a4c738da64d988d614b939021bedf7e1b0cc72b37a071ecb
       pullPolicy: IfNotPresent


### PR DESCRIPTION
**Issue Ref**: [512](https://github.com/kubeless/kubeless/issues/512)
 
**Description**: 

Helm chart was broken on k8s 1.8.
* Updated chart to use `CustomResourceDefinition`
* Image pulls were failing, updated tags to match [`kubeless-v0.3.1.yaml`](https://github.com/kubeless/kubeless/releases/download/v0.3.1/kubeless-v0.3.1.yaml)

**TODOs**:
 - [x] Ready to review
 - [x] ~~Automated Tests~~
 - [x] ~~Docs~~
