### PR TITLE
add issue template

### DIFF
--- a/.github/issue_template.md
+++ b/.github/issue_template.md
@@ -1,0 +1,14 @@
+**Is this a BUG REPORT or FEATURE REQUEST?**:
+
+**What happened**:
+
+**What you expected to happen**:
+
+**How to reproduce it (as minimally and precisely as possible)**:
+
+**Anything else we need to know?**:
+
+**Environment**:
+- Kubernetes version (use `kubectl version`):
+- Kubeless version (use `kubeless version`):
+- Cloud provider or physical cluster:


### PR DESCRIPTION
**Issue Ref**: None
 
**Description**: We want to get rid of asking kubeless version, kubernetes version, environment, etc multiple times when folks raise up a new issue. This PR adds an issue template for that.

**TODOs**:
 - [x] Ready to review
 - [ ] ~~Automated Tests~~
 - [ ] ~~Docs~~