### PR TITLE
upload once when doing the release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -138,10 +138,10 @@ before_deploy:
       echo "Unable to release a job that has not being tested!"
       return 1
     fi
-  - make VERSION=${TRAVIS_TAG:-build-$TRAVIS_BUILD_ID} binary-cross
-  - for d in bundles/kubeless_*; do zip -r9 $d.zip $d/; done
   - |
-    if [ "$TRAVIS_OS_NAME" = linux ]; then
+    if [ "$TEST_TARGET" = minikube ]; then
+      make VERSION=${TRAVIS_TAG:-build-$TRAVIS_BUILD_ID} binary-cross
+      for d in bundles/kubeless_*; do zip -r9 $d.zip $d/; done
       docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
       docker tag $CONTROLLER_IMAGE ${CONTROLLER_IMAGE_NAME}:latest
       docker push $CONTROLLER_IMAGE


### PR DESCRIPTION
**Issue Ref**: None]
 
**Description**:  I am seeing travis upload multiple times when doing release because [this check](https://github.com/kubeless/kubeless/blob/master/.travis.yml#L144) is valid for all four jobs of the matrix. This leads to the mismatch of kubeless-controller digest between release manifest and the final one (can be verified via `script/find_digest.sh` script). 

This PR aims to do the upload once at the TEST_TARGET=minikube job. 

[PR Description]

**TODOs**:
 - [x] Ready to review
 - [] ~~Automated Tests~~
 - [] ~~Docs~~