### PR TITLE
minor fix to run script/integration-tests locally on minikube

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -64,8 +64,8 @@ validation:
 	./script/validate-git-marks
 
 integration-tests:
-	./script/integration-tests deployment
-	./script/integration-tests basic
+	./script/integration-tests minikube deployment
+	./script/integration-tests minikube basic
 
 minikube-rbac-test:
 	./script/integration-test-rbac minikube


### PR DESCRIPTION
**Issue Ref**: None
 
`script/integartion-tests` need 2 arguments. The first one should be `minikube`. If it's omitted, there will be error below:

```
./script/integration-tests deployment
error: context "deployment" does not exist
FATAL: bringing up k8s cluster 'deployment' not supported
make: *** [Makefile:67: integration-tests] Error 255
make: *** [build_and_test] Error 2
```

**TODOs**:
 - [x] Ready to review
 - [ ] ~~Automated Tests~~
 - [ ] ~~Docs~~