### PR TITLE
Refactor update to properly use default values

### DIFF
--- a/cmd/kubeless/function/function_test.go
+++ b/cmd/kubeless/function/function_test.go
@@ -30,6 +30,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
+	"k8s.io/client-go/pkg/apis/autoscaling/v2alpha1"
 )
 
 func TestParseLabel(t *testing.T) {
@@ -300,5 +301,19 @@ func TestGetFunctionDescription(t *testing.T) {
 	}
 	if result4.Spec.FunctionContentType != "base64+zip" {
 		t.Errorf("Should return base64+zip, received %s", result4.Spec.FunctionContentType)
+	}
+
+	// It should maintain previous HPA definition
+	result5, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "file.handler", file.Name(), "dependencies", "runtime", "", "", "test-image", "128Mi", "10", true, &inputHeadless, &inputPort, []string{"TEST=1"}, []string{"test=1"}, spec.Function{
+		Spec: spec.FunctionSpec{
+			HorizontalPodAutoscaler: v2alpha1.HorizontalPodAutoscaler{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "previous-hpa",
+				},
+			},
+		},
+	})
+	if result5.Spec.HorizontalPodAutoscaler.ObjectMeta.Name != "previous-hpa" {
+		t.Error("should maintain previous HPA definition")
 	}
 }

--- a/cmd/kubeless/function/update.go
+++ b/cmd/kubeless/function/update.go
@@ -145,7 +145,6 @@ var updateCmd = &cobra.Command{
 		if err != nil {
 			logrus.Fatal(err)
 		}
-		logrus.Info(previousFunction.Spec.HorizontalPodAutoscaler)
 
 		if port != nil && (*port <= 0 || *port > 65535) {
 			logrus.Fatalf("Invalid port number %d specified", *port)
@@ -161,7 +160,6 @@ var updateCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 		logrus.Infof("Redeploying function...")
-		logrus.Info(f.Spec.HorizontalPodAutoscaler)
 		err = utils.UpdateK8sCustomResource(crdClient, f)
 		if err != nil {
 			logrus.Fatal(err)

--- a/cmd/kubeless/function/update.go
+++ b/cmd/kubeless/function/update.go
@@ -145,6 +145,7 @@ var updateCmd = &cobra.Command{
 		if err != nil {
 			logrus.Fatal(err)
 		}
+		logrus.Info(previousFunction.Spec.HorizontalPodAutoscaler)
 
 		if port != nil && (*port <= 0 || *port > 65535) {
 			logrus.Fatalf("Invalid port number %d specified", *port)
@@ -160,6 +161,7 @@ var updateCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 		logrus.Infof("Redeploying function...")
+		logrus.Info(f.Spec.HorizontalPodAutoscaler)
 		err = utils.UpdateK8sCustomResource(crdClient, f)
 		if err != nil {
 			logrus.Fatal(err)


### PR DESCRIPTION
**Issue Ref**: None
 
**Description**: 

The previous approach build a `Function` object from scratch and obtained the default values from the `defaultFunction` parameter. That led to new properties like `HorizontalPodAutoscaler` to be deleted after updating the function. With the new approach it set the result to the `defaultFunction` and then overwrites it with the given values.

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 ~~- [ ] Docs~~