### PR TITLE
Allow the controller to manage monitoring resources when RBAC is enabled

### DIFF
--- a/kubeless-rbac.jsonnet
+++ b/kubeless-rbac.jsonnet
@@ -36,6 +36,11 @@ local controller_roles = [
     resources: ["horizontalpodautoscalers"],
     verbs: ["create", "get", "delete", "list", "update", "patch"],
   },
+  {
+    apiGroups: ["monitoring.coreos.com"],
+    resources: ["alertmanagers", "prometheuses", "servicemonitors"],
+    verbs: ["*"],
+  },
 ];
 
 local controllerAccount = kubeless.controllerAccount;

--- a/tests/integration-tests.bats
+++ b/tests/integration-tests.bats
@@ -133,4 +133,10 @@ load ../script/libtest
   verify_function scheduled-get-python
   kubeless_function_delete scheduled-get-python
 }
+@test "Test no-errors" {
+  if kubectl logs -n kubeless -l kubeless=controller | grep "level=error"; then
+    echo "Found errors in the controller logs"
+    false
+  fi
+}
 # vim: ts=2 sw=2 si et syntax=sh


### PR DESCRIPTION
**Issue Ref**: None
 
**Description**: 

When using RBAC the controller cluster role didn't have permissions to manage monitoring resources causing errors and retries:
```
time="2018-01-10T11:17:42Z" level=error msg="Can't delete function: servicemonitors.monitoring.coreos.com \"tempv1\" is forbidden: User \"system:serviceaccount:kubeless:controller-acct\" cannot delete servicemonitors.monitoring.coreos.com in the namespace \"default\": Unknown user \"system:serviceaccount:kubeless:controller-acct\"" pkg=controller
```

To ensure a correct behavior, I added a test that checks that no error is found in the controller logs.

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 ~~- [ ] Docs~~