### PR TITLE
Use curl instead of wget for triggering scheduled functions

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -60,7 +60,7 @@ scheduled-get-python-verify:
 	found=false; \
 	while [ $$number -le $$timeout ] ; do \
 		pod=`kubectl get po -oname -l function=scheduled-get-python`; \
-		logs=`kubectl logs $$pod | grep "GET / HTTP/1.1\" 200 11 \"\" \"Wget\""`; \
+		logs=`kubectl logs $$pod | grep "GET / HTTP/1.1\" 200 11 \"\""`; \
     	if [ "$$logs" != "" ]; then \
 			found=true; \
 			break; \

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -913,9 +913,9 @@ func EnsureFuncCronJob(client rest.Interface, funcObj *spec.Function, or []metav
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{
 								{
-									Image: busybox,
+									Image: unzip,
 									Name:  "trigger",
-									Args:  []string{"wget", "-qO-", fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", funcObj.Metadata.Name, funcObj.Metadata.Namespace)},
+									Args:  []string{"curl", "-Lv", fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", funcObj.Metadata.Name, funcObj.Metadata.Namespace)},
 								},
 							},
 							RestartPolicy: v1.RestartPolicyNever,

--- a/pkg/utils/k8sutil_test.go
+++ b/pkg/utils/k8sutil_test.go
@@ -599,7 +599,7 @@ func TestEnsureCronJob(t *testing.T) {
 			if *cronJob.Spec.JobTemplate.Spec.ActiveDeadlineSeconds != int64(120) {
 				t.Errorf("Unexpected ActiveDeadlineSeconds: %d", *cronJob.Spec.JobTemplate.Spec.ActiveDeadlineSeconds)
 			}
-			expectedCommand := []string{"wget", "-qO-", fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", f1Name, ns)}
+			expectedCommand := []string{"curl", "-Lv", fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", f1Name, ns)}
 			if !reflect.DeepEqual(cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args, expectedCommand) {
 				t.Errorf("Unexpected command %s", strings.Join(cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args, " "))
 			}


### PR DESCRIPTION
**Issue Ref**: Fixes #548
 
**Description**: 

`wget` returns an error for some scheduled functions that are not present when using `curl` (see #548).

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 ~~- [ ] Docs~~