### PR TITLE
Change service port name to use prefix http to support Istio

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ For example:
 ```console
 $ kubectl proxy -p 8080 &
 
-$ curl -L --data '{"Another": "Echo"}' localhost:8080/api/v1/proxy/namespaces/default/services/get-python:function-port/ --header "Content-Type:application/json"
+$ curl -L --data '{"Another": "Echo"}' localhost:8080/api/v1/proxy/namespaces/default/services/get-python:http-function-port/ --header "Content-Type:application/json"
 {"Another": "Echo"}
 ```
 

--- a/cmd/kubeless/function/function.go
+++ b/cmd/kubeless/function/function.go
@@ -258,7 +258,7 @@ func getFunctionDescription(cli kubernetes.Interface, funcName, ns, handler, fil
 	svcSpec := v1.ServiceSpec{
 		Ports: []v1.ServicePort{
 			{
-				Name:     "function-port",
+				Name:     "http-function-port",
 				NodePort: 0,
 				Protocol: v1.ProtocolTCP,
 			},

--- a/cmd/kubeless/function/function_test.go
+++ b/cmd/kubeless/function/function_test.go
@@ -20,10 +20,11 @@ import (
 	"archive/zip"
 	"io"
 	"io/ioutil"
-	"k8s.io/api/core/v1"
 	"os"
 	"reflect"
 	"testing"
+
+	"k8s.io/api/core/v1"
 
 	kubelessApi "github.com/kubeless/kubeless/pkg/apis/kubeless/v1beta1"
 	"k8s.io/api/autoscaling/v2beta1"
@@ -132,7 +133,7 @@ func TestGetFunctionDescription(t *testing.T) {
 			ServiceSpec: v1.ServiceSpec{
 				Ports: []v1.ServicePort{
 					{
-						Name:       "function-port",
+						Name:       "http-function-port",
 						Port:       int32(80),
 						TargetPort: intstr.FromInt(80),
 						NodePort:   0,
@@ -226,7 +227,7 @@ func TestGetFunctionDescription(t *testing.T) {
 			ServiceSpec: v1.ServiceSpec{
 				Ports: []v1.ServicePort{
 					{
-						Name:       "function-port",
+						Name:       "http-function-port",
 						Port:       int32(8080),
 						TargetPort: intstr.FromInt(8080),
 						NodePort:   0,

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -470,7 +470,8 @@ func serviceSpec(funcObj *kubelessApi.Function) v1.ServiceSpec {
 	return v1.ServiceSpec{
 		Ports: []v1.ServicePort{
 			{
-				Name:       "function-port",
+				// Note: Prefix: "http-" is added to adapt to Istio so that it can discover the function services
+				Name:       "http-function-port",
 				Protocol:   v1.ProtocolTCP,
 				Port:       8080,
 				TargetPort: intstr.FromInt(8080),
@@ -902,7 +903,7 @@ func CreateServiceMonitor(smclient monitoringv1alpha1.MonitoringV1alpha1Client, 
 					},
 					Endpoints: []monitoringv1alpha1.Endpoint{
 						{
-							Port: "function-port",
+							Port: "http-function-port",
 						},
 					},
 				},

--- a/pkg/utils/k8sutil_test.go
+++ b/pkg/utils/k8sutil_test.go
@@ -185,7 +185,7 @@ func TestEnsureService(t *testing.T) {
 			ServiceSpec: v1.ServiceSpec{
 				Ports: []v1.ServicePort{
 					{
-						Name:       "function-port",
+						Name:       "http-function-port",
 						Port:       8080,
 						TargetPort: intstr.FromInt(8080),
 						NodePort:   0,
@@ -215,7 +215,7 @@ func TestEnsureService(t *testing.T) {
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
 				{
-					Name:       "function-port",
+					Name:       "http-function-port",
 					Port:       8080,
 					TargetPort: intstr.FromInt(8080),
 					NodePort:   0,
@@ -279,7 +279,7 @@ func TestEnsureDeployment(t *testing.T) {
 			ServiceSpec: v1.ServiceSpec{
 				Ports: []v1.ServicePort{
 					{
-						Name:       "function-port",
+						Name:       "http-function-port",
 						Port:       f1Port,
 						TargetPort: intstr.FromInt(int(f1Port)),
 						NodePort:   0,
@@ -944,7 +944,7 @@ func TestServiceSpec(t *testing.T) {
 	eSvc := v1.ServiceSpec{
 		Ports: []v1.ServicePort{
 			{
-				Name:       "function-port",
+				Name:       "http-function-port",
 				Protocol:   v1.ProtocolTCP,
 				Port:       8080,
 				TargetPort: intstr.FromInt(8080),


### PR DESCRIPTION
**Issue Ref**: Issue [559](https://github.com/kubeless/kubeless/issues/559)
 
**Description**: Service port name is changed to `http-function-port` 


**TODOs**:
 - [x] Ready to review
 - [x] Automated Tests
 - [x] Docs
