### PR TITLE
Secret cli 0.3.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,7 @@ Let's dissect the command:
 * `--handler test.foobar`: This specifies the file and the exposed function that will be used when receiving requests. In this example we are using the function `foobar` from the file `test.py`.
 * `--env` to pass env vars to the function like `--env foo=bar,bar=foo`. See the [detail](https://github.com/kubeless/kubeless/pull/316#issuecomment-332172876)
 * `--trigger-http`: This sets the function trigger.
+* `--secret-names`: This sets list of Secrets to be mounted as Volumes to the functions pod.
 
 Other available trigger options (defaults to `--trigger-http`) are:
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Let's dissect the command:
 * `--handler test.foobar`: This specifies the file and the exposed function that will be used when receiving requests. In this example we are using the function `foobar` from the file `test.py`.
 * `--env` to pass env vars to the function like `--env foo=bar,bar=foo`. See the [detail](https://github.com/kubeless/kubeless/pull/316#issuecomment-332172876)
 * `--trigger-http`: This sets the function trigger.
-* `--secret`: This sets a list of Secrets to be mounted as Volumes to the functions pod. They will be available in the path `/<secret_name>`.
+* `--secrets`: This sets a list of Secrets to be mounted as Volumes to the functions pod. They will be available in the path `/<secret_name>`.
 
 Other available trigger options (defaults to `--trigger-http`) are:
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@ Let's dissect the command:
 * `--handler test.foobar`: This specifies the file and the exposed function that will be used when receiving requests. In this example we are using the function `foobar` from the file `test.py`.
 * `--env` to pass env vars to the function like `--env foo=bar,bar=foo`. See the [detail](https://github.com/kubeless/kubeless/pull/316#issuecomment-332172876)
 * `--trigger-http`: This sets the function trigger.
-* `--secret-names`: This sets list of Secrets to be mounted as Volumes to the functions pod.
+* `--secret`: This sets a list of Secrets to be mounted as Volumes to the functions pod. They will be available in the path `/<secret_name>`.
 
 Other available trigger options (defaults to `--trigger-http`) are:
 

--- a/cmd/kubeless/function/deploy.go
+++ b/cmd/kubeless/function/deploy.go
@@ -102,6 +102,11 @@ var deployCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
+		secretNames, err := cmd.Flags().GetStringSlice("secret-names")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
 		runtimeImage, err := cmd.Flags().GetString("runtime-image")
 		if err != nil {
 			logrus.Fatal(err)
@@ -152,7 +157,7 @@ var deployCmd = &cobra.Command{
 		defaultFunctionSpec.Metadata.Labels = map[string]string{
 			"created-by": "kubeless",
 		}
-		f, err := getFunctionDescription(cli, funcName, ns, handler, file, funcDeps, runtime, topic, schedule, runtimeImage, mem, timeout, triggerHTTP, &headless, &port, envs, labels, defaultFunctionSpec)
+		f, err := getFunctionDescription(cli, funcName, ns, handler, file, funcDeps, runtime, topic, schedule, runtimeImage, mem, timeout, triggerHTTP, &headless, &port, envs, labels, secretNames, defaultFunctionSpec)
 		if err != nil {
 			logrus.Fatal(err)
 		}

--- a/cmd/kubeless/function/deploy.go
+++ b/cmd/kubeless/function/deploy.go
@@ -182,6 +182,7 @@ func init() {
 	deployCmd.Flags().StringP("handler", "", "", "Specify handler")
 	deployCmd.Flags().StringP("from-file", "", "", "Specify code file")
 	deployCmd.Flags().StringSliceP("label", "", []string{}, "Specify labels of the function. Both separator ':' and '=' are allowed. For example: --label foo1=bar1,foo2:bar2")
+	deployCmd.Flags().StringSliceP("secret-names", "", []string{}, "Specify Secrets to be mounted to the functions container. For example: --secret-names mySecret")
 	deployCmd.Flags().StringArrayP("env", "", []string{}, "Specify environment variable of the function. Both separator ':' and '=' are allowed. For example: --env foo1=bar1,foo2:bar2")
 	deployCmd.Flags().StringP("namespace", "", "", "Specify namespace for the function")
 	deployCmd.Flags().StringP("dependencies", "", "", "Specify a file containing list of dependencies for the function")

--- a/cmd/kubeless/function/deploy.go
+++ b/cmd/kubeless/function/deploy.go
@@ -102,7 +102,7 @@ var deployCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
-		secretNames, err := cmd.Flags().GetStringSlice("secret-names")
+		secrets, err := cmd.Flags().GetStringSlice("secrets")
 		if err != nil {
 			logrus.Fatal(err)
 		}
@@ -157,7 +157,7 @@ var deployCmd = &cobra.Command{
 		defaultFunctionSpec.Metadata.Labels = map[string]string{
 			"created-by": "kubeless",
 		}
-		f, err := getFunctionDescription(cli, funcName, ns, handler, file, funcDeps, runtime, topic, schedule, runtimeImage, mem, timeout, triggerHTTP, &headless, &port, envs, labels, secretNames, defaultFunctionSpec)
+		f, err := getFunctionDescription(cli, funcName, ns, handler, file, funcDeps, runtime, topic, schedule, runtimeImage, mem, timeout, triggerHTTP, &headless, &port, envs, labels, secrets, defaultFunctionSpec)
 		if err != nil {
 			logrus.Fatal(err)
 		}
@@ -182,7 +182,7 @@ func init() {
 	deployCmd.Flags().StringP("handler", "", "", "Specify handler")
 	deployCmd.Flags().StringP("from-file", "", "", "Specify code file")
 	deployCmd.Flags().StringSliceP("label", "", []string{}, "Specify labels of the function. Both separator ':' and '=' are allowed. For example: --label foo1=bar1,foo2:bar2")
-	deployCmd.Flags().StringSliceP("secret-names", "", []string{}, "Specify Secrets to be mounted to the functions container. For example: --secret-names mySecret")
+	deployCmd.Flags().StringSliceP("secrets", "", []string{}, "Specify Secrets to be mounted to the functions container. For example: --secrets mySecret")
 	deployCmd.Flags().StringArrayP("env", "", []string{}, "Specify environment variable of the function. Both separator ':' and '=' are allowed. For example: --env foo1=bar1,foo2:bar2")
 	deployCmd.Flags().StringP("namespace", "", "", "Specify namespace for the function")
 	deployCmd.Flags().StringP("dependencies", "", "", "Specify a file containing list of dependencies for the function")

--- a/cmd/kubeless/function/function.go
+++ b/cmd/kubeless/function/function.go
@@ -131,7 +131,7 @@ func getContentType(filename string, fbytes []byte) string {
 	return contentType
 }
 
-func getFunctionDescription(cli kubernetes.Interface, funcName, ns, handler, file, deps, runtime, topic, schedule, runtimeImage, mem, timeout string, triggerHTTP bool, headlessFlag *bool, portFlag *int32, envs, labels []string, secretNames []string, defaultFunction spec.Function) (*spec.Function, error) {
+func getFunctionDescription(cli kubernetes.Interface, funcName, ns, handler, file, deps, runtime, topic, schedule, runtimeImage, mem, timeout string, triggerHTTP bool, headlessFlag *bool, portFlag *int32, envs, labels []string, secrets []string, defaultFunction spec.Function) (*spec.Function, error) {
 	function := defaultFunction
 	function.TypeMeta = metav1.TypeMeta{
 		Kind:       "Function",
@@ -253,18 +253,18 @@ func getFunctionDescription(cli kubernetes.Interface, funcName, ns, handler, fil
 		function.Spec.Template.Spec.Containers[0].VolumeMounts = defaultFunction.Spec.Template.Spec.Containers[0].VolumeMounts
 	}
 
-	for _, secretName := range secretNames {
+	for _, secret := range secrets {
 		function.Spec.Template.Spec.Volumes = append(function.Spec.Template.Spec.Volumes, v1.Volume{
-			Name: secretName + "-vol",
+			Name: secret + "-vol",
 			VolumeSource: v1.VolumeSource{
 				Secret: &v1.SecretVolumeSource{
-					SecretName: secretName,
+					SecretName: secret,
 				},
 			},
 		})
 		function.Spec.Template.Spec.Containers[0].VolumeMounts = append(function.Spec.Template.Spec.Containers[0].VolumeMounts, v1.VolumeMount{
-			Name:      secretName + "-vol",
-			MountPath: "/" + secretName,
+			Name:      secret + "-vol",
+			MountPath: "/" + secret,
 		})
 
 	}

--- a/cmd/kubeless/function/function.go
+++ b/cmd/kubeless/function/function.go
@@ -131,7 +131,7 @@ func getContentType(filename string, fbytes []byte) string {
 	return contentType
 }
 
-func getFunctionDescription(cli kubernetes.Interface, funcName, ns, handler, file, deps, runtime, topic, schedule, runtimeImage, mem, timeout string, triggerHTTP bool, headlessFlag *bool, portFlag *int32, envs, labels []string, defaultFunction spec.Function) (*spec.Function, error) {
+func getFunctionDescription(cli kubernetes.Interface, funcName, ns, handler, file, deps, runtime, topic, schedule, runtimeImage, mem, timeout string, triggerHTTP bool, headlessFlag *bool, portFlag *int32, envs, labels []string, secretNames []string, defaultFunction spec.Function) (*spec.Function, error) {
 	function := defaultFunction
 	function.TypeMeta = metav1.TypeMeta{
 		Kind:       "Function",
@@ -247,6 +247,22 @@ func getFunctionDescription(cli kubernetes.Interface, funcName, ns, handler, fil
 			Resources: resources,
 			Image:     runtimeImage,
 		},
+	}
+
+	for _, secretName := range secretNames {
+		function.Spec.Template.Spec.Volumes = append(function.Spec.Template.Spec.Volumes, v1.Volume{
+			Name: secretName + "-sec",
+			VolumeSource: v1.VolumeSource{
+				Secret: &v1.SecretVolumeSource{
+					SecretName: secretName,
+				},
+			},
+		})
+		function.Spec.Template.Spec.Containers[0].VolumeMounts = append(function.Spec.Template.Spec.Containers[0].VolumeMounts, v1.VolumeMount{
+			Name:      secretName + "-sec",
+			MountPath: "/" + secretName,
+		})
+
 	}
 
 	selectorLabels := map[string]string{}

--- a/cmd/kubeless/function/function.go
+++ b/cmd/kubeless/function/function.go
@@ -249,6 +249,10 @@ func getFunctionDescription(cli kubernetes.Interface, funcName, ns, handler, fil
 		},
 	}
 
+	if len(secretNames) == 0 && len(defaultFunction.Spec.Template.Spec.Containers) != 0 {
+		function.Spec.Template.Spec.Containers[0].VolumeMounts = defaultFunction.Spec.Template.Spec.Containers[0].VolumeMounts
+	}
+
 	for _, secretName := range secretNames {
 		function.Spec.Template.Spec.Volumes = append(function.Spec.Template.Spec.Volumes, v1.Volume{
 			Name: secretName + "-sec",

--- a/cmd/kubeless/function/function.go
+++ b/cmd/kubeless/function/function.go
@@ -249,13 +249,13 @@ func getFunctionDescription(cli kubernetes.Interface, funcName, ns, handler, fil
 		},
 	}
 
-	if len(secretNames) == 0 && len(defaultFunction.Spec.Template.Spec.Containers) != 0 {
+	if len(defaultFunction.Spec.Template.Spec.Containers) != 0 {
 		function.Spec.Template.Spec.Containers[0].VolumeMounts = defaultFunction.Spec.Template.Spec.Containers[0].VolumeMounts
 	}
 
 	for _, secretName := range secretNames {
 		function.Spec.Template.Spec.Volumes = append(function.Spec.Template.Spec.Volumes, v1.Volume{
-			Name: secretName + "-sec",
+			Name: secretName + "-vol",
 			VolumeSource: v1.VolumeSource{
 				Secret: &v1.SecretVolumeSource{
 					SecretName: secretName,
@@ -263,7 +263,7 @@ func getFunctionDescription(cli kubernetes.Interface, funcName, ns, handler, fil
 			},
 		})
 		function.Spec.Template.Spec.Containers[0].VolumeMounts = append(function.Spec.Template.Spec.Containers[0].VolumeMounts, v1.VolumeMount{
-			Name:      secretName + "-sec",
+			Name:      secretName + "-vol",
 			MountPath: "/" + secretName,
 		})
 

--- a/cmd/kubeless/function/function_test.go
+++ b/cmd/kubeless/function/function_test.go
@@ -336,9 +336,9 @@ func TestGetFunctionDescription(t *testing.T) {
 	}
 
 	// It should maintain previous HPA definition
-	result5, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "file.handler", file.Name(), "dependencies", "runtime", "", "", "test-image", "128Mi", "10", true, &inputHeadless, &inputPort, []string{"TEST=1"}, []string{"test=1"}, kubelessApi.Function{
-		Spec: kubelessApi.FunctionSpec{
-			HorizontalPodAutoscaler: v2beta1.HorizontalPodAutoscaler{
+	result5, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "file.handler", file.Name(), "dependencies", "runtime", "", "", "test-image", "128Mi", "10", true, &inputHeadless, &inputPort, []string{"TEST=1"}, []string{"test=1"}, []string{}, spec.Function{
+		Spec: spec.FunctionSpec{
+			HorizontalPodAutoscaler: v2alpha1.HorizontalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name: "previous-hpa",
 				},

--- a/cmd/kubeless/function/function_test.go
+++ b/cmd/kubeless/function/function_test.go
@@ -165,7 +165,7 @@ func TestGetFunctionDescription(t *testing.T) {
 							Image: "test-image",
 							VolumeMounts: []v1.VolumeMount{
 								{
-									Name:      "secretName-sec",
+									Name:      "secretName-vol",
 									MountPath: "/secretName",
 								},
 							},
@@ -173,7 +173,7 @@ func TestGetFunctionDescription(t *testing.T) {
 					},
 					Volumes: []v1.Volume{
 						{
-							Name: "secretName-sec",
+							Name: "secretName-vol",
 							VolumeSource: v1.VolumeSource{
 								Secret: &v1.SecretVolumeSource{
 									SecretName: "secretName",
@@ -211,7 +211,7 @@ func TestGetFunctionDescription(t *testing.T) {
 	defer os.Remove(file.Name()) // clean up
 	input3Headless := false
 	input3Port := int32(8080)
-	result3, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "file.handler2", file.Name(), "dependencies2", "runtime2", "test_topic", "", "test-image2", "256Mi", "20", false, &input3Headless, &input3Port, []string{"TEST=2"}, []string{"test=2"}, []string{}, expectedFunction)
+	result3, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "file.handler2", file.Name(), "dependencies2", "runtime2", "test_topic", "", "test-image2", "256Mi", "20", false, &input3Headless, &input3Port, []string{"TEST=2"}, []string{"test=2"}, []string{"secret2"}, expectedFunction)
 	if err != nil {
 		t.Error(err)
 	}
@@ -274,18 +274,28 @@ func TestGetFunctionDescription(t *testing.T) {
 							Image: "test-image2",
 							VolumeMounts: []v1.VolumeMount{
 								{
-									Name:      "secretName-sec",
+									Name:      "secretName-vol",
 									MountPath: "/secretName",
+								},{
+									Name:      "secret2-vol",
+									MountPath: "/secret2",
 								},
 							},
 						},
 					},
 					Volumes: []v1.Volume{
 						{
-							Name: "secretName-sec",
+							Name: "secretName-vol",
 							VolumeSource: v1.VolumeSource{
 								Secret: &v1.SecretVolumeSource{
 									SecretName: "secretName",
+								},
+							},
+						},{
+							Name: "secret2-vol",
+							VolumeSource: v1.VolumeSource{
+								Secret: &v1.SecretVolumeSource{
+									SecretName: "secret2",
 								},
 							},
 						},
@@ -327,7 +337,7 @@ func TestGetFunctionDescription(t *testing.T) {
 	}
 	file.Close()
 	zipW.Close()
-	result4, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "file.handler", newfile.Name(), "dependencies", "runtime", "", "", "", "", "", false, nil, nil, []string{}, []string{}, []string{"secretName"}, expectedFunction)
+	result4, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "file.handler", newfile.Name(), "dependencies", "runtime", "", "", "", "", "", false, nil, nil, []string{}, []string{}, []string{}, expectedFunction)
 	if err != nil {
 		t.Error(err)
 	}

--- a/cmd/kubeless/function/function_test.go
+++ b/cmd/kubeless/function/function_test.go
@@ -276,7 +276,7 @@ func TestGetFunctionDescription(t *testing.T) {
 								{
 									Name:      "secretName-vol",
 									MountPath: "/secretName",
-								},{
+								}, {
 									Name:      "secret2-vol",
 									MountPath: "/secret2",
 								},
@@ -291,7 +291,7 @@ func TestGetFunctionDescription(t *testing.T) {
 									SecretName: "secretName",
 								},
 							},
-						},{
+						}, {
 							Name: "secret2-vol",
 							VolumeSource: v1.VolumeSource{
 								Secret: &v1.SecretVolumeSource{

--- a/cmd/kubeless/function/function_test.go
+++ b/cmd/kubeless/function/function_test.go
@@ -190,7 +190,7 @@ func TestGetFunctionDescription(t *testing.T) {
 	}
 
 	// It should take the default values
-	result2, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "", "", "", "", "", "", "", "", "", false, nil, nil, []string{}, []string{}, []string{"secretName"}, expectedFunction)
+	result2, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "", "", "", "", "", "", "", "", "", false, nil, nil, []string{}, []string{}, []string{}, expectedFunction)
 	if err != nil {
 		t.Error(err)
 	}

--- a/cmd/kubeless/function/update.go
+++ b/cmd/kubeless/function/update.go
@@ -180,7 +180,7 @@ func init() {
 	updateCmd.Flags().StringP("from-file", "", "", "Specify code file")
 	updateCmd.Flags().StringP("memory", "", "", "Request amount of memory for the function")
 	updateCmd.Flags().StringSliceP("label", "", []string{}, "Specify labels of the function")
-	deployCmd.Flags().StringSliceP("secret-names", "", []string{}, "Specify Secrets to be mounted to the functions container. For example: --secret-names mySecret")
+	updateCmd.Flags().StringSliceP("secret-names", "", []string{}, "Specify Secrets to be mounted to the functions container. For example: --secret-names mySecret")
 	updateCmd.Flags().StringArrayP("env", "", []string{}, "Specify environment variable of the function")
 	updateCmd.Flags().StringP("namespace", "", "", "Specify namespace for the function")
 	updateCmd.Flags().StringP("dependencies", "", "", "Specify a file containing list of dependencies for the function")

--- a/cmd/kubeless/function/update.go
+++ b/cmd/kubeless/function/update.go
@@ -180,6 +180,7 @@ func init() {
 	updateCmd.Flags().StringP("from-file", "", "", "Specify code file")
 	updateCmd.Flags().StringP("memory", "", "", "Request amount of memory for the function")
 	updateCmd.Flags().StringSliceP("label", "", []string{}, "Specify labels of the function")
+	deployCmd.Flags().StringSliceP("secret-names", "", []string{}, "Specify Secrets to be mounted to the functions container. For example: --secret-names mySecret")
 	updateCmd.Flags().StringArrayP("env", "", []string{}, "Specify environment variable of the function")
 	updateCmd.Flags().StringP("namespace", "", "", "Specify namespace for the function")
 	updateCmd.Flags().StringP("dependencies", "", "", "Specify a file containing list of dependencies for the function")

--- a/cmd/kubeless/function/update.go
+++ b/cmd/kubeless/function/update.go
@@ -56,7 +56,7 @@ var updateCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
-		secretNames, err := cmd.Flags().GetStringSlice("secret-names")
+		secrets, err := cmd.Flags().GetStringSlice("secrets")
 		if err != nil {
 			logrus.Fatal(err)
 		}
@@ -155,7 +155,7 @@ var updateCmd = &cobra.Command{
 			logrus.Fatalf("Invalid port number %d specified", *port)
 		}
 		cli := utils.GetClientOutOfCluster()
-		f, err := getFunctionDescription(cli, funcName, ns, handler, file, funcDeps, runtime, topic, schedule, runtimeImage, mem, timeout, triggerHTTP, headless, port, envs, labels, secretNames, previousFunction)
+		f, err := getFunctionDescription(cli, funcName, ns, handler, file, funcDeps, runtime, topic, schedule, runtimeImage, mem, timeout, triggerHTTP, headless, port, envs, labels, secrets, previousFunction)
 		if err != nil {
 			logrus.Fatal(err)
 		}
@@ -180,7 +180,7 @@ func init() {
 	updateCmd.Flags().StringP("from-file", "", "", "Specify code file")
 	updateCmd.Flags().StringP("memory", "", "", "Request amount of memory for the function")
 	updateCmd.Flags().StringSliceP("label", "", []string{}, "Specify labels of the function")
-	updateCmd.Flags().StringSliceP("secret-names", "", []string{}, "Specify Secrets to be mounted to the functions container. For example: --secret-names mySecret")
+	updateCmd.Flags().StringSliceP("secrets", "", []string{}, "Specify Secrets to be mounted to the functions container. For example: --secrets mySecret")
 	updateCmd.Flags().StringArrayP("env", "", []string{}, "Specify environment variable of the function")
 	updateCmd.Flags().StringP("namespace", "", "", "Specify namespace for the function")
 	updateCmd.Flags().StringP("dependencies", "", "", "Specify a file containing list of dependencies for the function")

--- a/cmd/kubeless/function/update.go
+++ b/cmd/kubeless/function/update.go
@@ -56,6 +56,11 @@ var updateCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
+		secretNames, err := cmd.Flags().GetStringSlice("secret-names")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
 		runtime, err := cmd.Flags().GetString("runtime")
 		if err != nil {
 			logrus.Fatal(err)
@@ -150,7 +155,7 @@ var updateCmd = &cobra.Command{
 			logrus.Fatalf("Invalid port number %d specified", *port)
 		}
 		cli := utils.GetClientOutOfCluster()
-		f, err := getFunctionDescription(cli, funcName, ns, handler, file, funcDeps, runtime, topic, schedule, runtimeImage, mem, timeout, triggerHTTP, headless, port, envs, labels, previousFunction)
+		f, err := getFunctionDescription(cli, funcName, ns, handler, file, funcDeps, runtime, topic, schedule, runtimeImage, mem, timeout, triggerHTTP, headless, port, envs, labels, secretNames, previousFunction)
 		if err != nil {
 			logrus.Fatal(err)
 		}


### PR DESCRIPTION
**Issue Ref**: [None]
 
**Description**: This pull request adds `--secret-names` argument to deploy and update commands. The secrets with given names will be mounted as Volumes inside pod with a Function. This is back port for version 0.3.x from [pull request 572](https://github.com/kubeless/kubeless/pull/572)

[PR Description]

**TODOs**:
 - [x] Ready to review
 - [x] Automated Tests
 - [x] Docs
