### PR TITLE
Restore compatibility with Kubernetes 1.7

### DIFF
--- a/cmd/kubeless/function/function_test.go
+++ b/cmd/kubeless/function/function_test.go
@@ -27,8 +27,8 @@ import (
 	"k8s.io/api/core/v1"
 
 	kubelessApi "github.com/kubeless/kubeless/pkg/apis/kubeless/v1beta1"
-	"k8s.io/api/apps/v1beta2"
 	"k8s.io/api/autoscaling/v2beta1"
+	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -148,8 +148,8 @@ func TestGetFunctionDescription(t *testing.T) {
 				Type:      v1.ServiceTypeClusterIP,
 				ClusterIP: v1.ClusterIPNone,
 			},
-			Deployment: v1beta2.Deployment{
-				Spec: v1beta2.DeploymentSpec{
+			Deployment: v1beta1.Deployment{
+				Spec: v1beta1.DeploymentSpec{
 					Template: v1.PodTemplateSpec{
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{
@@ -261,8 +261,8 @@ func TestGetFunctionDescription(t *testing.T) {
 				},
 				Type: v1.ServiceTypeClusterIP,
 			},
-			Deployment: v1beta2.Deployment{
-				Spec: v1beta2.DeploymentSpec{
+			Deployment: v1beta1.Deployment{
+				Spec: v1beta1.DeploymentSpec{
 					Template: v1.PodTemplateSpec{
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{

--- a/cmd/kubeless/function/list_test.go
+++ b/cmd/kubeless/function/list_test.go
@@ -22,7 +22,6 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/api/apps/v1beta2"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -61,8 +60,8 @@ func TestList(t *testing.T) {
 					Type:     "ftype",
 					Topic:    "ftopic",
 					Deps:     "fdeps",
-					Deployment: v1beta2.Deployment{
-						Spec: v1beta2.DeploymentSpec{
+					Deployment: v1beta1.Deployment{
+						Spec: v1beta1.DeploymentSpec{
 							Template: v1.PodTemplateSpec{
 								Spec: v1.PodSpec{
 									Containers: []v1.Container{{}},
@@ -87,8 +86,8 @@ func TestList(t *testing.T) {
 					Type:     "btype",
 					Topic:    "btopic",
 					Deps:     "{\"dependencies\": {\"test\": \"^1.0.0\"}}",
-					Deployment: v1beta2.Deployment{
-						Spec: v1beta2.DeploymentSpec{
+					Deployment: v1beta1.Deployment{
+						Spec: v1beta1.DeploymentSpec{
 							Template: v1.PodTemplateSpec{
 								Spec: v1.PodSpec{
 									Containers: []v1.Container{
@@ -131,8 +130,8 @@ func TestList(t *testing.T) {
 					Type:     "ftype",
 					Topic:    "ftopic",
 					Deps:     "fdeps",
-					Deployment: v1beta2.Deployment{
-						Spec: v1beta2.DeploymentSpec{
+					Deployment: v1beta1.Deployment{
+						Spec: v1beta1.DeploymentSpec{
 							Template: v1.PodTemplateSpec{
 								Spec: v1.PodSpec{
 									Containers: []v1.Container{{}},

--- a/pkg/apis/kubeless/v1beta1/function.go
+++ b/pkg/apis/kubeless/v1beta1/function.go
@@ -17,9 +17,9 @@ limitations under the License.
 package v1beta1
 
 import (
-	"k8s.io/api/apps/v1beta2"
 	"k8s.io/api/autoscaling/v2beta1"
 	"k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -46,7 +46,7 @@ type FunctionSpec struct {
 	Timeout                 string                          `json:"timeout"`               // Maximum timeout for the function to complete its execution
 	Deps                    string                          `json:"deps"`                  // Function dependencies
 	ServiceSpec             v1.ServiceSpec                  `json:"service"`
-	Deployment              v1beta2.Deployment              `json:"deployment" protobuf:"bytes,3,opt,name=template"`
+	Deployment              v1beta1.Deployment              `json:"deployment" protobuf:"bytes,3,opt,name=template"`
 	HorizontalPodAutoscaler v2beta1.HorizontalPodAutoscaler `json:"horizontalPodAutoscaler" protobuf:"bytes,3,opt,name=horizontalPodAutoscaler"`
 }
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -23,9 +23,9 @@ import (
 
 	monitoringv1alpha1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/apps/v1beta2"
 	"k8s.io/api/autoscaling/v2beta1"
 	corev1 "k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
@@ -193,7 +193,7 @@ func (c *Controller) ensureK8sResources(funcObj *kubelessApi.Function) error {
 	controllerNamespace := os.Getenv("KUBELESS_NAMESPACE")
 	kubelessConfig := os.Getenv("KUBELESS_CONFIG")
 	cm, _ := c.clientset.CoreV1().ConfigMaps(controllerNamespace).Get(kubelessConfig, metav1.GetOptions{})
-	deployment := v1beta2.Deployment{}
+	deployment := v1beta1.Deployment{}
 	if deploymentConfigData, ok := cm.Data["deployment"]; ok {
 		err := yaml.Unmarshal([]byte(deploymentConfigData), &deployment)
 		if err != nil {

--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -6,10 +6,10 @@ import (
 	"github.com/ghodss/yaml"
 	kubelessApi "github.com/kubeless/kubeless/pkg/apis/kubeless/v1beta1"
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/apps/v1beta2"
 	"k8s.io/api/autoscaling/v2beta1"
 	batchv2alpha1 "k8s.io/api/batch/v2alpha1"
 	"k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
 	xv1beta1 "k8s.io/api/extensions/v1beta1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -156,11 +156,11 @@ func TestEnsureK8sResourcesWithDeploymentDefinitionFromConfigMap(t *testing.T) {
 				Selector: funcLabels,
 				Type:     v1.ServiceTypeClusterIP,
 			},
-			Deployment: v1beta2.Deployment{
+			Deployment: v1beta1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: funcAnno,
 				},
-				Spec: v1beta2.DeploymentSpec{
+				Spec: v1beta1.DeploymentSpec{
 					Replicas: &replicas,
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
@@ -208,7 +208,7 @@ func TestEnsureK8sResourcesWithDeploymentDefinitionFromConfigMap(t *testing.T) {
 		},
 		Data: map[string]string{"deployment": deploymentConfigData},
 	}
-	deploymentObjFromConfigMap := v1beta2.Deployment{}
+	deploymentObjFromConfigMap := v1beta1.Deployment{}
 	_ = yaml.Unmarshal([]byte(deploymentConfigData), &deploymentObjFromConfigMap)
 	clientset.Core().ConfigMaps(namespace).Create(kubelessConfigMap)
 
@@ -219,7 +219,7 @@ func TestEnsureK8sResourcesWithDeploymentDefinitionFromConfigMap(t *testing.T) {
 	if err := controller.ensureK8sResources(&funcObj); err != nil {
 		t.Fatalf("Creating/Updating resources returned err: %v", err)
 	}
-	dpm, _ := clientset.Apps().Deployments(namespace).Get(funcName, metav1.GetOptions{})
+	dpm, _ := clientset.ExtensionsV1beta1().Deployments(namespace).Get(funcName, metav1.GetOptions{})
 	expectedAnnotations := map[string]string{
 		"bar":                "foo",
 		"foo-from-deploy-cm": "bar-from-deploy-cm",

--- a/pkg/langruntime/langruntime.go
+++ b/pkg/langruntime/langruntime.go
@@ -7,8 +7,8 @@ import (
 	"regexp"
 	"strings"
 
-	"k8s.io/api/apps/v1beta2"
 	"k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
 )
 
 const (
@@ -224,7 +224,7 @@ func GetBuildContainer(runtime string, env []v1.EnvVar, installVolume v1.VolumeM
 }
 
 // UpdateDeployment object in case of custom runtime
-func UpdateDeployment(dpm *v1beta2.Deployment, depsPath, runtime string) {
+func UpdateDeployment(dpm *v1beta1.Deployment, depsPath, runtime string) {
 	switch {
 	case strings.Contains(runtime, "python"):
 		dpm.Spec.Template.Spec.Containers[0].Env = append(dpm.Spec.Template.Spec.Containers[0].Env, v1.EnvVar{

--- a/pkg/utils/k8sutil_test.go
+++ b/pkg/utils/k8sutil_test.go
@@ -13,10 +13,10 @@ import (
 	"testing"
 
 	kubelessApi "github.com/kubeless/kubeless/pkg/apis/kubeless/v1beta1"
-	v1beta2 "k8s.io/api/apps/v1beta2"
 	v2beta1 "k8s.io/api/autoscaling/v2beta1"
 	batchv2alpha1 "k8s.io/api/batch/v2alpha1"
 	"k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
 	xv1beta1 "k8s.io/api/extensions/v1beta1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apimachinery"
@@ -290,11 +290,11 @@ func TestEnsureDeployment(t *testing.T) {
 				Selector: funcLabels,
 				Type:     v1.ServiceTypeClusterIP,
 			},
-			Deployment: v1beta2.Deployment{
+			Deployment: v1beta1.Deployment{
 				ObjectMeta: metav1.ObjectMeta{
 					Annotations: funcAnno,
 				},
-				Spec: v1beta2.DeploymentSpec{
+				Spec: v1beta1.DeploymentSpec{
 					Template: v1.PodTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Annotations: funcAnno,
@@ -321,7 +321,7 @@ func TestEnsureDeployment(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
-	dpm, err := clientset.Apps().Deployments(ns).Get(f1Name, metav1.GetOptions{})
+	dpm, err := clientset.ExtensionsV1beta1().Deployments(ns).Get(f1Name, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -422,7 +422,7 @@ func TestEnsureDeployment(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
-	dpm, err = clientset.Apps().Deployments(ns).Get("func2", metav1.GetOptions{})
+	dpm, err = clientset.ExtensionsV1beta1().Deployments(ns).Get("func2", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -436,7 +436,7 @@ func TestEnsureDeployment(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
-	dpm, err = clientset.Apps().Deployments(ns).Get("func3", metav1.GetOptions{})
+	dpm, err = clientset.ExtensionsV1beta1().Deployments(ns).Get("func3", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -454,7 +454,7 @@ func TestEnsureDeployment(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
-	dpm, err = clientset.Apps().Deployments(ns).Get("func4", metav1.GetOptions{})
+	dpm, err = clientset.ExtensionsV1beta1().Deployments(ns).Get("func4", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -471,7 +471,7 @@ func TestEnsureDeployment(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
-	dpm, err = clientset.Apps().Deployments(ns).Get("func5", metav1.GetOptions{})
+	dpm, err = clientset.ExtensionsV1beta1().Deployments(ns).Get("func5", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -488,7 +488,7 @@ func TestEnsureDeployment(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
-	dpm, err = clientset.Apps().Deployments(ns).Get(f1Name, metav1.GetOptions{})
+	dpm, err = clientset.ExtensionsV1beta1().Deployments(ns).Get(f1Name, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -519,7 +519,7 @@ func TestEnsureDeployment(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
-	dpm, err = clientset.Apps().Deployments(ns).Get("func8", metav1.GetOptions{})
+	dpm, err = clientset.ExtensionsV1beta1().Deployments(ns).Get("func8", metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -982,7 +982,7 @@ func TestServiceSpec(t *testing.T) {
 }
 
 func TestInitializeEmptyMapsInDeployment(t *testing.T) {
-	deployment := v1beta2.Deployment{}
+	deployment := v1beta1.Deployment{}
 	deployment.Spec.Selector = &metav1.LabelSelector{}
 	initializeEmptyMapsInDeployment(&deployment)
 	if deployment.ObjectMeta.Annotations == nil {
@@ -1008,7 +1008,7 @@ func TestInitializeEmptyMapsInDeployment(t *testing.T) {
 func TestMergeDeployments(t *testing.T) {
 	var replicas int32
 	replicas = 10
-	destinationDeployment := v1beta2.Deployment{
+	destinationDeployment := v1beta1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				"foo1-deploy": "bar",
@@ -1016,13 +1016,13 @@ func TestMergeDeployments(t *testing.T) {
 		},
 	}
 
-	sourceDeployment := v1beta2.Deployment{
+	sourceDeployment := v1beta1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				"foo2-deploy": "bar",
 			},
 		},
-		Spec: v1beta2.DeploymentSpec{
+		Spec: v1beta1.DeploymentSpec{
 			Replicas: &replicas,
 		},
 	}


### PR DESCRIPTION
**Issue Ref**: None
 
**Description**: 

The changes for using `v1beta2` for deployments instead of `v1beta1` was incompatible with Kubernetes 1.7 which caused master builds to fail (in the GKE scenario). This PR goes back to use `v1beta1` which is compatible both with Kubernetes 1.7 and 1.8.

cc/ @ngtuna @sayanh

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 ~~- [ ] Docs~~
