### PR TITLE
add kafka-zookeeper-${TRAVIS_TAG}.yaml to release

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -151,6 +151,7 @@ before_deploy:
       sed 's/'":${CONTROLLER_TAG}"'/'"@$NEW_DIGEST"'/g' kubeless.yaml > kubeless-${TRAVIS_TAG}.yaml
       sed 's/'":${CONTROLLER_TAG}"'/'"@$NEW_DIGEST"'/g' kubeless-rbac.yaml > kubeless-rbac-${TRAVIS_TAG}.yaml
       sed 's/'":${CONTROLLER_TAG}"'/'"@$NEW_DIGEST"'/g' kubeless-openshift.yaml > kubeless-openshift-${TRAVIS_TAG}.yaml
+      cp kafka-zookeeper.yaml kafka-zookeeper-${TRAVIS_TAG}.yaml
     fi
 
 deploy:


### PR DESCRIPTION
**Issue Ref**: None
 
**Description**: 

For unknown reason, the kafka-zookeeper manifest doesn't show up in the release package in previous PR #570. I guess I did something wrong with git squash and merge. This PR corrects it by adding proper kafka-zookeeper-${TRAVIS_TAG}.yaml file to the deploy job.

**TODOs**:
 - [x] Ready to review
 - [ ] ~~Automated Tests~~
 - [ ] ~~Docs~~