### PR TITLE
add openshift special oc command to release notes

### DIFF
--- a/script/upload_release_notes.sh
+++ b/script/upload_release_notes.sh
@@ -33,6 +33,12 @@ curl -sL https://github.com/kubeless/kubeless/releases/download/$tag/kubeless-$t
 kubectl create ns kubeless\\n\
 curl -sL https://github.com/kubeless/kubeless/releases/download/$tag/kubeless-rbac-$tag.yaml | kubectl create -f -\\n\
 \`\`\`\\n\
+**OPENSHIFT:**\\n\
+\\n\
+\`\`\`console\\n\
+oc create ns kubeless\\n\
+curl -sL https://github.com/kubeless/kubeless/releases/download/$tag/kubeless-openshift-$tag.yaml | oc create -f -\\n\
+\`\`\`\\n\
 ")
   echo "${notes}"
 }


### PR DESCRIPTION
**Description**: 

Add a two liner to release note template so that people can copy/paste to get started on openshift.

points to `oc` command and openshift manifest.

**TODOs**:
 - [ x] Ready to review
 - [ N/A] Automated Tests
 - [ x] Docs

We could add a build in travis to test on openshift...but this is just a template change.
