### PR TITLE
Add CPU limit argument to function commands

### DIFF
--- a/cmd/kubeless/function/deploy.go
+++ b/cmd/kubeless/function/deploy.go
@@ -138,6 +138,11 @@ var deployCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
+		cpu, err := cmd.Flags().GetString("cpu")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
 		timeout, err := cmd.Flags().GetString("timeout")
 		if err != nil {
 			logrus.Fatal(err)
@@ -177,7 +182,7 @@ var deployCmd = &cobra.Command{
 		defaultFunctionSpec.ObjectMeta.Labels = map[string]string{
 			"created-by": "kubeless",
 		}
-		f, err := getFunctionDescription(cli, funcName, ns, handler, file, funcDeps, runtime, topic, schedule, runtimeImage, mem, timeout, triggerHTTP, &headless, &port, envs, labels, secrets, defaultFunctionSpec)
+		f, err := getFunctionDescription(cli, funcName, ns, handler, file, funcDeps, runtime, topic, schedule, runtimeImage, mem, cpu, timeout, triggerHTTP, &headless, &port, envs, labels, secrets, defaultFunctionSpec)
 		if err != nil {
 			logrus.Fatal(err)
 		}
@@ -209,6 +214,7 @@ func init() {
 	deployCmd.Flags().StringP("trigger-topic", "", "", "Deploy a pubsub function to Kubeless")
 	deployCmd.Flags().StringP("schedule", "", "", "Specify schedule in cron format for scheduled function")
 	deployCmd.Flags().StringP("memory", "", "", "Request amount of memory, which is measured in bytes, for the function. It is expressed as a plain integer or a fixed-point interger with one of these suffies: E, P, T, G, M, K, Ei, Pi, Ti, Gi, Mi, Ki")
+	deployCmd.Flags().StringP("cpu", "", "", "Request amount of cpu for the function.")
 	deployCmd.Flags().Bool("trigger-http", false, "Deploy a http-based function to Kubeless")
 	deployCmd.Flags().StringP("runtime-image", "", "", "Custom runtime image")
 	deployCmd.Flags().StringP("timeout", "", "180", "Maximum timeout (in seconds) for the function to complete its execution")

--- a/cmd/kubeless/function/deploy.go
+++ b/cmd/kubeless/function/deploy.go
@@ -214,7 +214,7 @@ func init() {
 	deployCmd.Flags().StringP("trigger-topic", "", "", "Deploy a pubsub function to Kubeless")
 	deployCmd.Flags().StringP("schedule", "", "", "Specify schedule in cron format for scheduled function")
 	deployCmd.Flags().StringP("memory", "", "", "Request amount of memory, which is measured in bytes, for the function. It is expressed as a plain integer or a fixed-point interger with one of these suffies: E, P, T, G, M, K, Ei, Pi, Ti, Gi, Mi, Ki")
-	deployCmd.Flags().StringP("cpu", "", "", "Request amount of cpu for the function.")
+	deployCmd.Flags().StringP("cpu", "", "", "Request amount of cpu for the function, which is measured in units of cores. Please see the following link for more information: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu")
 	deployCmd.Flags().Bool("trigger-http", false, "Deploy a http-based function to Kubeless")
 	deployCmd.Flags().StringP("runtime-image", "", "", "Custom runtime image")
 	deployCmd.Flags().StringP("timeout", "", "180", "Maximum timeout (in seconds) for the function to complete its execution")

--- a/cmd/kubeless/function/function.go
+++ b/cmd/kubeless/function/function.go
@@ -93,8 +93,12 @@ func parseEnv(envs []string) []v1.EnvVar {
 	return funcEnv
 }
 
-func parseMemory(mem string) (resource.Quantity, error) {
-	quantity, err := resource.ParseQuantity(mem)
+func parseResource(in string) (resource.Quantity, error) {
+	if in == "" {
+		return resource.Quantity{}, nil
+	}
+
+	quantity, err := resource.ParseQuantity(in)
 	if err != nil {
 		return resource.Quantity{}, err
 	}
@@ -131,7 +135,7 @@ func getContentType(filename string, fbytes []byte) string {
 	return contentType
 }
 
-func getFunctionDescription(cli kubernetes.Interface, funcName, ns, handler, file, deps, runtime, topic, schedule, runtimeImage, mem, timeout string, triggerHTTP bool, headlessFlag *bool, portFlag *int32, envs, labels []string, secrets []string, defaultFunction kubelessApi.Function) (*kubelessApi.Function, error) {
+func getFunctionDescription(cli kubernetes.Interface, funcName, ns, handler, file, deps, runtime, topic, schedule, runtimeImage, mem, cpu, timeout string, triggerHTTP bool, headlessFlag *bool, portFlag *int32, envs, labels []string, secrets []string, defaultFunction kubelessApi.Function) (*kubelessApi.Function, error) {
 	function := defaultFunction
 	function.TypeMeta = metav1.TypeMeta{
 		Kind:       "Function",
@@ -219,15 +223,22 @@ func getFunctionDescription(cli kubernetes.Interface, funcName, ns, handler, fil
 	}
 
 	resources := v1.ResourceRequirements{}
-	if mem != "" {
-		funcMem, err := parseMemory(mem)
+	if mem != "" || cpu != "" {
+		funcMem, err := parseResource(mem)
 		if err != nil {
 			err = fmt.Errorf("Wrong format of the memory value: %v", err)
 			return &kubelessApi.Function{}, err
 		}
+		funcCPU, err := parseResource(cpu)
+		if err != nil {
+			err = fmt.Errorf("Wrong format for cpu value: %v", err)
+			return &kubelessApi.Function{}, err
+		}
 		resource := map[v1.ResourceName]resource.Quantity{
 			v1.ResourceMemory: funcMem,
+			v1.ResourceCPU:    funcCPU,
 		}
+
 		resources = v1.ResourceRequirements{
 			Limits:   resource,
 			Requests: resource,

--- a/cmd/kubeless/function/function_test.go
+++ b/cmd/kubeless/function/function_test.go
@@ -102,11 +102,12 @@ func TestGetFunctionDescription(t *testing.T) {
 
 	inputHeadless := true
 	inputPort := int32(80)
-	result, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "file.handler", file.Name(), "dependencies", "runtime", "", "", "test-image", "128Mi", "10", true, &inputHeadless, &inputPort, []string{"TEST=1"}, []string{"test=1"}, []string{"secretName"}, kubelessApi.Function{})
+	result, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "file.handler", file.Name(), "dependencies", "runtime", "", "", "test-image", "128Mi", "", "10", true, &inputHeadless, &inputPort, []string{"TEST=1"}, []string{"test=1"}, []string{"secretName"}, kubelessApi.Function{})
 	if err != nil {
 		t.Error(err)
 	}
-	parsedMem, _ := parseMemory("128Mi")
+	parsedMem, _ := parseResource("128Mi")
+	parsedCPU, _ := parseResource("")
 	expectedFunction := kubelessApi.Function{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Function",
@@ -160,9 +161,11 @@ func TestGetFunctionDescription(t *testing.T) {
 									Resources: v1.ResourceRequirements{
 										Limits: map[v1.ResourceName]resource.Quantity{
 											v1.ResourceMemory: parsedMem,
+											v1.ResourceCPU:    parsedCPU,
 										},
 										Requests: map[v1.ResourceName]resource.Quantity{
 											v1.ResourceMemory: parsedMem,
+											v1.ResourceCPU:    parsedCPU,
 										},
 									},
 									Image: "test-image",
@@ -195,7 +198,7 @@ func TestGetFunctionDescription(t *testing.T) {
 	}
 
 	// It should take the default values
-	result2, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "", "", "", "", "", "", "", "", "", false, nil, nil, []string{}, []string{}, []string{}, expectedFunction)
+	result2, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "", "", "", "", "", "", "", "", "", "", false, nil, nil, []string{}, []string{}, []string{}, expectedFunction)
 	if err != nil {
 		t.Error(err)
 	}
@@ -216,11 +219,12 @@ func TestGetFunctionDescription(t *testing.T) {
 	defer os.Remove(file.Name()) // clean up
 	input3Headless := false
 	input3Port := int32(8080)
-	result3, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "file.handler2", file.Name(), "dependencies2", "runtime2", "test_topic", "", "test-image2", "256Mi", "20", false, &input3Headless, &input3Port, []string{"TEST=2"}, []string{"test=2"}, []string{"secret2"}, expectedFunction)
+	result3, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "file.handler2", file.Name(), "dependencies2", "runtime2", "test_topic", "", "test-image2", "256Mi", "100m", "20", false, &input3Headless, &input3Port, []string{"TEST=2"}, []string{"test=2"}, []string{"secret2"}, expectedFunction)
 	if err != nil {
 		t.Error(err)
 	}
-	parsedMem2, _ := parseMemory("256Mi")
+	parsedMem2, _ := parseResource("256Mi")
+	parsedCPU2, _ := parseResource("100m")
 	newFunction := kubelessApi.Function{
 		TypeMeta: metav1.TypeMeta{
 			Kind:       "Function",
@@ -273,9 +277,11 @@ func TestGetFunctionDescription(t *testing.T) {
 									Resources: v1.ResourceRequirements{
 										Limits: map[v1.ResourceName]resource.Quantity{
 											v1.ResourceMemory: parsedMem2,
+											v1.ResourceCPU:    parsedCPU2,
 										},
 										Requests: map[v1.ResourceName]resource.Quantity{
 											v1.ResourceMemory: parsedMem2,
+											v1.ResourceCPU:    parsedCPU2,
 										},
 									},
 									Image: "test-image2",
@@ -346,7 +352,7 @@ func TestGetFunctionDescription(t *testing.T) {
 	}
 	file.Close()
 	zipW.Close()
-	result4, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "file.handler", newfile.Name(), "dependencies", "runtime", "", "", "", "", "", false, nil, nil, []string{}, []string{}, []string{}, expectedFunction)
+	result4, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "file.handler", newfile.Name(), "dependencies", "runtime", "", "", "", "", "", "", false, nil, nil, []string{}, []string{}, []string{}, expectedFunction)
 	if err != nil {
 		t.Error(err)
 	}
@@ -355,7 +361,7 @@ func TestGetFunctionDescription(t *testing.T) {
 	}
 
 	// It should maintain previous HPA definition
-	result5, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "file.handler", file.Name(), "dependencies", "runtime", "", "", "test-image", "128Mi", "10", true, &inputHeadless, &inputPort, []string{"TEST=1"}, []string{"test=1"}, []string{}, kubelessApi.Function{
+	result5, err := getFunctionDescription(fake.NewSimpleClientset(), "test", "default", "file.handler", file.Name(), "dependencies", "runtime", "", "", "test-image", "128Mi", "", "10", true, &inputHeadless, &inputPort, []string{"TEST=1"}, []string{"test=1"}, []string{}, kubelessApi.Function{
 		Spec: kubelessApi.FunctionSpec{
 			HorizontalPodAutoscaler: v2beta1.HorizontalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{

--- a/cmd/kubeless/function/list_test.go
+++ b/cmd/kubeless/function/list_test.go
@@ -45,7 +45,7 @@ func listOutput(t *testing.T, client versioned.Interface, apiV1Client kubernetes
 }
 
 func TestList(t *testing.T) {
-	funcMem, _ := parseMemory("128Mi")
+	funcMem, _ := parseResource("128Mi")
 	listObj := kubelessApi.FunctionList{
 		Items: []*kubelessApi.Function{
 			{

--- a/cmd/kubeless/function/update.go
+++ b/cmd/kubeless/function/update.go
@@ -131,6 +131,11 @@ var updateCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
+		cpu, err := cmd.Flags().GetString("cpu")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
 		timeout, err := cmd.Flags().GetString("timeout")
 		if err != nil {
 			logrus.Fatal(err)
@@ -175,7 +180,7 @@ var updateCmd = &cobra.Command{
 		if port != nil && (*port <= 0 || *port > 65535) {
 			logrus.Fatalf("Invalid port number %d specified", *port)
 		}
-		f, err := getFunctionDescription(cli, funcName, ns, handler, file, funcDeps, runtime, topic, schedule, runtimeImage, mem, timeout, triggerHTTP, headless, port, envs, labels, secrets, previousFunction)
+		f, err := getFunctionDescription(cli, funcName, ns, handler, file, funcDeps, runtime, topic, schedule, runtimeImage, mem, cpu, timeout, triggerHTTP, headless, port, envs, labels, secrets, previousFunction)
 		if err != nil {
 			logrus.Fatal(err)
 		}
@@ -199,6 +204,7 @@ func init() {
 	updateCmd.Flags().StringP("handler", "", "", "Specify handler")
 	updateCmd.Flags().StringP("from-file", "", "", "Specify code file")
 	updateCmd.Flags().StringP("memory", "", "", "Request amount of memory for the function")
+	updateCmd.Flags().StringP("cpu", "", "", "Request amount of cpu for the function.")
 	updateCmd.Flags().StringSliceP("label", "", []string{}, "Specify labels of the function")
 	updateCmd.Flags().StringSliceP("secrets", "", []string{}, "Specify Secrets to be mounted to the functions container. For example: --secrets mySecret")
 	updateCmd.Flags().StringArrayP("env", "", []string{}, "Specify environment variable of the function")

--- a/docs/autoscaling.md
+++ b/docs/autoscaling.md
@@ -51,7 +51,7 @@ The below part will walk you though setup need to be done in order to make funct
 
 To autoscale based on CPU usage, it is *required* that your function has been deployed with CPU request limits.
 
-Do do this, use the `--cpu` parameter when deploying your function. Please see the [Meaning of CPU](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu) for the format of the value that should be passed. 
+To do this, use the `--cpu` parameter when deploying your function. Please see the [Meaning of CPU](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu) for the format of the value that should be passed. 
 
 ## Autoscaling with custom metrics on k8s 1.7
 

--- a/docs/autoscaling.md
+++ b/docs/autoscaling.md
@@ -47,6 +47,12 @@ Flags:
 
 The below part will walk you though setup need to be done in order to make function auto-scaled based on `qps` metric.
 
+## Autoscaling based on CPU usage
+
+To autoscale based on CPU usage, it is *required* that your function has been deployed with CPU request limits.
+
+Do do this, use the `--cpu` parameter when deploying your function. Please see the [Meaning of CPU](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/#meaning-of-cpu) for the format of the value that should be passed. 
+
 ## Autoscaling with custom metrics on k8s 1.7
 
 This walkthrough will go over the step-by-step of setting up the prometheus-based custom API server on your cluster and configuring autoscaler (HPA) to use application metrics sourced from prometheus instance.


### PR DESCRIPTION
**Issue Ref**: #605
 
**Description**: 

Adds `--cpu` argument to `function deploy` and `function update` to enable setting CPU limits, required for HPA.

**TODOs**:
 - [x] Ready to review
 - [x] Automated Tests
 - [x] Docs
