### PR TITLE
[WIP] Add integration tests for kafka trigger

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,13 +17,14 @@ env:
   matrix:
     - TEST_TARGET=unit
     - TEST_TARGET=minikube
-    # Disable Kafka tests for the moment
-    # - TEST_TARGET=minikube_kafka
+    - TEST_TARGET=minikube_kafka
     - TEST_TARGET=GKE
   global:
     - CONTROLLER_IMAGE_NAME=bitnami/kubeless-controller-manager
     - CONTROLLER_TAG=${TRAVIS_TAG:-build-$TRAVIS_BUILD_ID}
     - CONTROLLER_IMAGE=${CONTROLLER_IMAGE_NAME}:${CONTROLLER_TAG}
+    - KAFKA_CONTROLLER_IMAGE_NAME=bitnami/kafka-trigger-controller
+    - KAFKA_CONTROLLER_IMAGE=${KAFKA_CONTROLLER_IMAGE_NAME}:${CONTROLLER_TAG}
     - CGO_ENABLED=0
     - TEST_DEBUG=1
     - GKE_VERSION=1.7.11-gke.1
@@ -92,10 +93,12 @@ script:
     if [[ "$SHOULD_TEST" == "1" ]]; then
       make VERSION=${TRAVIS_TAG:-build-$TRAVIS_BUILD_ID} binary
       make controller-image CONTROLLER_IMAGE=$CONTROLLER_IMAGE
+      make kafka-controller-image KAFKA_CONTROLLER_IMAGE=$KAFKA_CONTROLLER_IMAGE
       make all-yaml
       sed -i.bak 's/'":latest"'/'":${CONTROLLER_TAG}"'/g' kubeless.yaml
       sed -i.bak 's/'":latest"'/'":${CONTROLLER_TAG}"'/g' kubeless-rbac.yaml
       sed -i.bak 's/'":latest"'/'":${CONTROLLER_TAG}"'/g' kubeless-openshift.yaml
+      sed -i.bak 's/'":latest"'/'":${CONTROLLER_TAG}"'/g' kafka-zookeeper.yaml
       case $TEST_TARGET in
       unit)
         make test

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -293,7 +293,7 @@ pubsub-python-verify:
 
 pubsub-python34:
 	kubeless topic create s3-python34 || true
-	kubeless function deploy pubsub-python34 --trigger-topic s3-python34 --runtime python3.4 --handler pubsub-python.handler --from-file python/hellowithdata.py
+	kubeless function deploy pubsub-python34 --trigger-topic s3-python34 --runtime python3.4 --handler pubsub-python.handler --from-file python/hellowithdata34.py
 
 pubsub-python34-verify:
 	$(eval DATA := $(shell mktemp -u -t XXXXXXXX))

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -275,7 +275,7 @@ pubsub-python:
 # then "tail -f" until it shows (with timeout)
 pubsub-python-verify:
 	$(eval DATA := $(shell mktemp -u -t XXXXXXXX))
-	kubeless topic publish --topic s3-python --data "$(DATA)"
+	kubeless topic publish --topic s3-python --data '{"payload":"$(DATA)"}'
 	number="1"; \
 	timeout="60"; \
 	found=false; \
@@ -297,7 +297,7 @@ pubsub-python34:
 
 pubsub-python34-verify:
 	$(eval DATA := $(shell mktemp -u -t XXXXXXXX))
-	kubeless topic publish --topic s3-python34 --data "$(DATA)"
+	kubeless topic publish --topic s3-python34 --data '{"payload":"$(DATA)"}'
 	number="1"; \
 	timeout="60"; \
 	found=false; \
@@ -319,7 +319,7 @@ pubsub-python36:
 
 pubsub-python36-verify:
 	$(eval DATA := $(shell mktemp -u -t XXXXXXXX))
-	kubeless topic publish --topic s3-python36 --data "$(DATA)"
+	kubeless topic publish --topic s3-python36 --data '{"payload":"$(DATA)"}'
 	number="1"; \
 	timeout="60"; \
 	found=false; \
@@ -370,7 +370,7 @@ pubsub-ruby:
 
 pubsub-ruby-verify:
 	$(eval DATA := $(shell mktemp -u -t XXXXXXXX))
-	kubeless topic publish --topic s3-ruby --data "$(DATA)"
+	kubeless topic publish --topic s3-ruby --data '{"payload":"$(DATA)"}'
 	number="1"; \
 	timeout="60"; \
 	found=false; \

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -269,7 +269,7 @@ post: post-python post-nodejs post-ruby post-python-custom-port
 
 pubsub-python:
 	kubeless topic create s3-python || true
-	kubeless function deploy pubsub-python --trigger-topic s3-python --runtime python2.7 --handler pubsub.handler --from-file python/pubsub.py
+	kubeless function deploy pubsub-python --trigger-topic s3-python --runtime python2.7 --handler pubsub.handler --from-file python/hellowithdata.py
 
 # Generate a random string to inject into s3 topic,
 # then "tail -f" until it shows (with timeout)
@@ -293,7 +293,7 @@ pubsub-python-verify:
 
 pubsub-python34:
 	kubeless topic create s3-python34 || true
-	kubeless function deploy pubsub-python34 --trigger-topic s3-python34 --runtime python3.4 --handler pubsub-python.handler --from-file python/pubsub.py
+	kubeless function deploy pubsub-python34 --trigger-topic s3-python34 --runtime python3.4 --handler pubsub-python.handler --from-file python/hellowithdata.py
 
 pubsub-python34-verify:
 	$(eval DATA := $(shell mktemp -u -t XXXXXXXX))
@@ -337,7 +337,7 @@ pubsub-python36-verify:
 
 pubsub-nodejs:
 	kubeless topic create s3-nodejs || true
-	kubeless function deploy pubsub-nodejs --trigger-topic s3-nodejs --runtime nodejs6 --handler pubsub-nodejs.handler --from-file nodejs/helloevent.js
+	kubeless function deploy pubsub-nodejs --trigger-topic s3-nodejs --runtime nodejs6 --handler pubsub-nodejs.handler --from-file nodejs/hellowithdata.js
 
 pubsub-nodejs-verify:
 	$(eval DATA := $(shell mktemp -u -t XXXXXXXX))
@@ -366,7 +366,7 @@ pubsub-nodejs-update-verify:
 
 pubsub-ruby:
 	kubeless topic create s3-ruby || true
-	kubeless function deploy pubsub-ruby --trigger-topic s3-ruby --runtime ruby2.4 --handler pubsub-ruby.handler --from-file ruby/helloevent.rb
+	kubeless function deploy pubsub-ruby --trigger-topic s3-ruby --runtime ruby2.4 --handler pubsub-ruby.handler --from-file ruby/hellowithdata.rb
 
 pubsub-ruby-verify:
 	$(eval DATA := $(shell mktemp -u -t XXXXXXXX))
@@ -386,4 +386,4 @@ pubsub-ruby-verify:
 	done; \
 	$$found
 
-post: pubsub-python pubsub-nodejs pubsub-ruby
+pubsub: pubsub-python pubsub-nodejs pubsub-ruby

--- a/examples/python/hellowithdata34.py
+++ b/examples/python/hellowithdata34.py
@@ -1,0 +1,3 @@
+def handler(event, context):
+    print (event)
+    return event['data']

--- a/script/libtest.bash
+++ b/script/libtest.bash
@@ -160,6 +160,9 @@ wait_for_kubeless_kafka_server_ready() {
     [[ $(kubectl get pod -n kubeless kafka-0 -ojsonpath='{.metadata.annotations.ready}') == true ]] && return 0
     echo_info "Waiting for kafka-0 to be ready ..."
     k8s_wait_for_pod_logline "Kafka.*Server.*started" -n kubeless kafka-0
+    echo_info "Waiting for kafka-trigger-controller pod to be ready ..."
+    k8s_wait_for_pod_ready -n kubeless -l kubeless=kafka-trigger-controller
+    _wait_for_cmd_ok kubectl get kafkatriggers 2>/dev/null
     kubectl annotate pods --overwrite -n kubeless kafka-0 ready=true
 }
 _wait_for_kubeless_kafka_topic_ready() {

--- a/script/libtest.bash
+++ b/script/libtest.bash
@@ -261,7 +261,7 @@ verify_function() {
     k8s_wait_for_pod_ready -l function=${func}
     case "${func}" in
         *pubsub*)
-            func_topic=$(kubeless function describe "${func}" -o yaml|sed -n 's/topic: //p')
+            func_topic=$(kubectl get kafkatrigger "${func}" -o yaml|sed -n 's/topic: //p')
             echo_info "FUNC TOPIC: $func_topic"
     esac
     local -i counter=0


### PR DESCRIPTION
**Description**: 

This PR adds integration tests for kafka trigger which is part of the trigger decoupling refactor. It's going to update the current kafka IT to 1) deploy kafka/zk/kafka-trigger-controller separately and 2) run through tests for pubsub funcs across supported languages.

I am going to step by step add commits to see travis result at each phase. So please don't review it now. I will call for review once it's in a good shape.

**TODOs**:
 - [ ] Ready to review
 - [ ] Automated Tests
 - [ ] Docs