### PR TITLE
Avoid to write in ConfigMap volume

### DIFF
--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -277,7 +277,7 @@ func getProvisionContainer(function, checksum, fileName, handler, contentType, r
 		checksumInfo := strings.Split(checksum, ":")
 		switch checksumInfo[0] {
 		case "sha256":
-			shaFile := originFile + ".sha256"
+			shaFile := "/tmp/func.sha256"
 			prepareCommand = appendToCommand(prepareCommand,
 				fmt.Sprintf("echo '%s  %s' > %s", checksumInfo[1], originFile, shaFile),
 				fmt.Sprintf("sha256sum -c %s", shaFile),

--- a/pkg/utils/k8sutil_test.go
+++ b/pkg/utils/k8sutil_test.go
@@ -924,7 +924,7 @@ func TestGetProvisionContainer(t *testing.T) {
 		Name:            "prepare",
 		Image:           "kubeless/unzip@sha256:f162c062973cca05459834de6ed14c039d45df8cdb76097f50b028a1621b3697",
 		Command:         []string{"sh", "-c"},
-		Args:            []string{"echo 'abc1234  /deps/test.func' > /deps/test.func.sha256 && sha256sum -c /deps/test.func.sha256 && cp /deps/test.func /runtime/test.py && cp /deps/requirements.txt /runtime"},
+		Args:            []string{"echo 'abc1234  /deps/test.func' > /tmp/func.sha256 && sha256sum -c /tmp/func.sha256 && cp /deps/test.func /runtime/test.py && cp /deps/requirements.txt /runtime"},
 		VolumeMounts:    []v1.VolumeMount{rvol, dvol},
 		ImagePullPolicy: v1.PullIfNotPresent,
 	}


### PR DESCRIPTION
**Issue Ref**: Fixes #634 
 
**Description**: 

Init containers writes a file `func.sha256` that is being used to verify the integrity of the function deployed but it is using the volume mounted from the ConfigMap. After Kubernetes 1.9.4 this volume is mounted as read-only so the process fails trying to write that file.

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 ~~- [ ] Docs~~