### PR TITLE
Path Definition for Ingress Enabled HTTP Triggers

### DIFF
--- a/cmd/kubeless/route/routeCreate.go
+++ b/cmd/kubeless/route/routeCreate.go
@@ -81,7 +81,7 @@ var routeCreateCmd = &cobra.Command{
 		httpTrigger.Spec.TLSAcme = enableTLSAcme
 		httpTrigger.Spec.RouteName = ingressName
 		httpTrigger.Spec.EnableIngress = true
-		httpTrigger.Spec.IngressPathName = "/"
+		httpTrigger.Spec.Path = "/"
 
 		err = utils.UpdateHTTPTriggerCustomResource(kubelessClient, httpTrigger)
 		if err != nil {

--- a/cmd/kubeless/route/routeCreate.go
+++ b/cmd/kubeless/route/routeCreate.go
@@ -81,6 +81,7 @@ var routeCreateCmd = &cobra.Command{
 		httpTrigger.Spec.TLSAcme = enableTLSAcme
 		httpTrigger.Spec.RouteName = ingressName
 		httpTrigger.Spec.EnableIngress = true
+		httpTrigger.Spec.IngressPathName = "/"
 
 		err = utils.UpdateHTTPTriggerCustomResource(kubelessClient, httpTrigger)
 		if err != nil {

--- a/pkg/apis/kubeless/v1beta1/http_trigger.go
+++ b/pkg/apis/kubeless/v1beta1/http_trigger.go
@@ -37,7 +37,7 @@ type HTTPTriggerSpec struct {
 	TLSAcme         bool   `json:"tls"`
 	RouteName       string `json:"route-name"`
 	EnableIngress   bool   `json:"ingress-enabled"`
-	IngressPathName string `json:"path-name"`
+	Path            string `json:"path"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/kubeless/v1beta1/http_trigger.go
+++ b/pkg/apis/kubeless/v1beta1/http_trigger.go
@@ -32,12 +32,12 @@ type HTTPTrigger struct {
 
 // HTTPTriggerSpec contains func specification
 type HTTPTriggerSpec struct {
-	FunctionName    string `json:"function-name"` // Name of the associated function
-	HostName        string `json:"host-name"`
-	TLSAcme         bool   `json:"tls"`
-	RouteName       string `json:"route-name"`
-	EnableIngress   bool   `json:"ingress-enabled"`
-	Path            string `json:"path"`
+	FunctionName  string `json:"function-name"` // Name of the associated function
+	HostName      string `json:"host-name"`
+	TLSAcme       bool   `json:"tls"`
+	RouteName     string `json:"route-name"`
+	EnableIngress bool   `json:"ingress-enabled"`
+	Path          string `json:"path"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/kubeless/v1beta1/http_trigger.go
+++ b/pkg/apis/kubeless/v1beta1/http_trigger.go
@@ -32,11 +32,12 @@ type HTTPTrigger struct {
 
 // HTTPTriggerSpec contains func specification
 type HTTPTriggerSpec struct {
-	FunctionName  string `json:"function-name"` // Name of the associated function
-	HostName      string `json:"host-name"`
-	TLSAcme       bool   `json:"tls"`
-	RouteName     string `json:"route-name"`
-	EnableIngress bool   `json:"ingress-enabled"`
+	FunctionName    string `json:"function-name"` // Name of the associated function
+	HostName        string `json:"host-name"`
+	TLSAcme         bool   `json:"tls"`
+	RouteName       string `json:"route-name"`
+	EnableIngress   bool   `json:"ingress-enabled"`
+	IngressPathName string `json:"path-name"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -484,7 +484,7 @@ func CreateIngress(client kubernetes.Interface, httpTriggerObj *kubelessApi.HTTP
 						HTTP: &v1beta1.HTTPIngressRuleValue{
 							Paths: []v1beta1.HTTPIngressPath{
 								{
-									Path: "/",
+									Path: httpTriggerObj.Spec.IngressPathName,
 									Backend: v1beta1.IngressBackend{
 										ServiceName: httpTriggerObj.ObjectMeta.Name,
 										ServicePort: funcSvc.Spec.Ports[0].TargetPort,

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -484,7 +484,7 @@ func CreateIngress(client kubernetes.Interface, httpTriggerObj *kubelessApi.HTTP
 						HTTP: &v1beta1.HTTPIngressRuleValue{
 							Paths: []v1beta1.HTTPIngressPath{
 								{
-									Path: httpTriggerObj.Spec.IngressPathName,
+									Path: httpTriggerObj.Spec.Path,
 									Backend: v1beta1.IngressBackend{
 										ServiceName: httpTriggerObj.ObjectMeta.Name,
 										ServicePort: funcSvc.Spec.Ports[0].TargetPort,


### PR DESCRIPTION
**Issue Ref**:  #638
 
**Description**: 
Allows to specify the path of an ingress-enabled http trigger.

**PR Description**
Enhances the http trigger crd specification with the additional property `Path`:
````
type HTTPTriggerSpec struct {
	FunctionName    string `json:"function-name"` // Name of the associated function
	HostName        string `json:"host-name"`
	TLSAcme         bool   `json:"tls"`
	RouteName       string `json:"route-name"`
	EnableIngress   bool   `json:"ingress-enabled"`
	Path            string `json:"path"`
}
````
Creating via kubeless cli will set the path of an ingress enabled http trigger to the default "/" like before.

**TODOs**:
 - [x] Ready to review
 - [ ] Automated Tests
 - [ ] Docs
