### PR TITLE
Minor refactor for cronjobtrigger. Add some tests

### DIFF
--- a/kubeless-rbac.jsonnet
+++ b/kubeless-rbac.jsonnet
@@ -24,7 +24,7 @@ local controller_roles = [
   {
     apiGroups: ["kubeless.io"],
     resources: ["functions", "kafkatriggers", "httptriggers", "cronjobtriggers"],
-    verbs: ["get", "list", "watch", "update"],
+    verbs: ["get", "list", "watch", "update", "delete"],
   },
   {
     apiGroups: ["batch"],

--- a/pkg/controller/cronjob_trigger_controller.go
+++ b/pkg/controller/cronjob_trigger_controller.go
@@ -239,7 +239,7 @@ func (c *CronJobTriggerController) syncCronJobTrigger(key string) error {
 		c.logger.Errorf("Unable to find the function %s in the namespace %s. Received %s: ", cronJobtriggerObj.Spec.FunctionName, ns, err)
 		return err
 	}
-	err = utils.EnsureCronJob(c.clientset, functionObj, cronJobtriggerObj, or)
+	err = utils.EnsureCronJob(c.clientset, functionObj, cronJobtriggerObj.Spec.Schedule, or)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/cronjob_trigger_controller_test.go
+++ b/pkg/controller/cronjob_trigger_controller_test.go
@@ -109,22 +109,22 @@ func TestCronJobTriggerObjChanged(t *testing.T) {
 		Time: time.Now(),
 	}
 	testObjs := []testObj{
-		testObj{
+		{
 			old:             &kubelessApi.CronJobTrigger{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 			new:             &kubelessApi.CronJobTrigger{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
 			expectedChanged: false,
 		},
-		testObj{
+		{
 			old:             &kubelessApi.CronJobTrigger{ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &t1}},
 			new:             &kubelessApi.CronJobTrigger{ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &t2}},
 			expectedChanged: true,
 		},
-		testObj{
+		{
 			old:             &kubelessApi.CronJobTrigger{Spec: kubelessApi.CronJobTriggerSpec{Schedule: "* * * * *"}},
 			new:             &kubelessApi.CronJobTrigger{Spec: kubelessApi.CronJobTriggerSpec{Schedule: "* * * * *"}},
 			expectedChanged: false,
 		},
-		testObj{
+		{
 			old:             &kubelessApi.CronJobTrigger{Spec: kubelessApi.CronJobTriggerSpec{Schedule: "*/10 * * * *"}},
 			new:             &kubelessApi.CronJobTrigger{Spec: kubelessApi.CronJobTriggerSpec{Schedule: "* * * * *"}},
 			expectedChanged: true,

--- a/pkg/controller/cronjob_trigger_controller_test.go
+++ b/pkg/controller/cronjob_trigger_controller_test.go
@@ -1,0 +1,139 @@
+package controller
+
+import (
+	"testing"
+	"time"
+
+	kubelessApi "github.com/kubeless/kubeless/pkg/apis/kubeless/v1beta1"
+	kubelessFake "github.com/kubeless/kubeless/pkg/client/clientset/versioned/fake"
+	"github.com/sirupsen/logrus"
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+func TestFunctionAddedUpdated(t *testing.T) {
+	myNsFoo := metav1.ObjectMeta{
+		Namespace: "myns",
+		Name:      "foo",
+	}
+
+	f := kubelessApi.Function{
+		ObjectMeta: myNsFoo,
+	}
+
+	cjtrigger := kubelessApi.CronJobTrigger{
+		ObjectMeta: myNsFoo,
+	}
+
+	triggerClientset := kubelessFake.NewSimpleClientset(&f, &cjtrigger)
+
+	cronjob := batchv1beta1.CronJob{
+		ObjectMeta: myNsFoo,
+	}
+	clientset := fake.NewSimpleClientset(&cronjob)
+
+	controller := CronJobTriggerController{
+		clientset:      clientset,
+		kubelessclient: triggerClientset,
+		logger:         logrus.WithField("controller", "cronjob-trigger-controller"),
+	}
+
+	// no-op for when the function is not deleted
+	err := controller.functionAddedDeletedUpdated(&f, false)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	list, err := controller.kubelessclient.KubelessV1beta1().CronJobTriggers("myns").List(metav1.ListOptions{})
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(list.Items) != 1 || list.Items[0].ObjectMeta.Name != "foo" {
+		t.Errorf("Missing trigger in list: %v", list.Items)
+	}
+}
+
+func TestFunctionDeleted(t *testing.T) {
+	myNsFoo := metav1.ObjectMeta{
+		Namespace: "myns",
+		Name:      "foo",
+	}
+
+	f := kubelessApi.Function{
+		ObjectMeta: myNsFoo,
+	}
+
+	cjtrigger := kubelessApi.CronJobTrigger{
+		ObjectMeta: myNsFoo,
+	}
+
+	triggerClientset := kubelessFake.NewSimpleClientset(&f, &cjtrigger)
+
+	cronjob := batchv1beta1.CronJob{
+		ObjectMeta: myNsFoo,
+	}
+	clientset := fake.NewSimpleClientset(&cronjob)
+
+	controller := CronJobTriggerController{
+		clientset:      clientset,
+		kubelessclient: triggerClientset,
+		logger:         logrus.WithField("controller", "cronjob-trigger-controller"),
+	}
+
+	// no-op for when the function is not deleted
+	err := controller.functionAddedDeletedUpdated(&f, true)
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+
+	list, err := controller.kubelessclient.KubelessV1beta1().CronJobTriggers("myns").List(metav1.ListOptions{})
+	if err != nil {
+		t.Errorf("Unexpected error: %v", err)
+	}
+	if len(list.Items) != 0 {
+		t.Errorf("Trigger should be deleted from list: %v", list.Items)
+	}
+}
+
+func TestCronJobTriggerObjChanged(t *testing.T) {
+	type testObj struct {
+		old             *kubelessApi.CronJobTrigger
+		new             *kubelessApi.CronJobTrigger
+		expectedChanged bool
+	}
+	t1 := metav1.Time{
+		Time: time.Now(),
+	}
+	t2 := metav1.Time{
+		Time: time.Now(),
+	}
+	testObjs := []testObj{
+		testObj{
+			old:             &kubelessApi.CronJobTrigger{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+			new:             &kubelessApi.CronJobTrigger{ObjectMeta: metav1.ObjectMeta{Name: "foo"}},
+			expectedChanged: false,
+		},
+		testObj{
+			old:             &kubelessApi.CronJobTrigger{ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &t1}},
+			new:             &kubelessApi.CronJobTrigger{ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &t2}},
+			expectedChanged: true,
+		},
+		testObj{
+			old:             &kubelessApi.CronJobTrigger{Spec: kubelessApi.CronJobTriggerSpec{Schedule: "* * * * *"}},
+			new:             &kubelessApi.CronJobTrigger{Spec: kubelessApi.CronJobTriggerSpec{Schedule: "* * * * *"}},
+			expectedChanged: false,
+		},
+		testObj{
+			old:             &kubelessApi.CronJobTrigger{Spec: kubelessApi.CronJobTriggerSpec{Schedule: "*/10 * * * *"}},
+			new:             &kubelessApi.CronJobTrigger{Spec: kubelessApi.CronJobTriggerSpec{Schedule: "* * * * *"}},
+			expectedChanged: true,
+		},
+	}
+	for _, to := range testObjs {
+		changed := cronJobTriggerObjChanged(to.old, to.new)
+		if changed != to.expectedChanged {
+			t.Errorf("%v != %v expected to be %v", to.old, to.new, to.expectedChanged)
+		}
+	}
+}

--- a/pkg/controller/cronjob_trigger_controller_test.go
+++ b/pkg/controller/cronjob_trigger_controller_test.go
@@ -65,7 +65,13 @@ func TestFunctionDeleted(t *testing.T) {
 	}
 
 	cjtrigger := kubelessApi.CronJobTrigger{
-		ObjectMeta: myNsFoo,
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "myns",
+			Name:      "foo-trigger",
+		},
+		Spec: kubelessApi.CronJobTriggerSpec{
+			FunctionName: "foo",
+		},
 	}
 
 	triggerClientset := kubelessFake.NewSimpleClientset(&f, &cjtrigger)
@@ -117,6 +123,11 @@ func TestCronJobTriggerObjChanged(t *testing.T) {
 		{
 			old:             &kubelessApi.CronJobTrigger{ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &t1}},
 			new:             &kubelessApi.CronJobTrigger{ObjectMeta: metav1.ObjectMeta{DeletionTimestamp: &t2}},
+			expectedChanged: true,
+		},
+		{
+			old:             &kubelessApi.CronJobTrigger{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "1"}},
+			new:             &kubelessApi.CronJobTrigger{ObjectMeta: metav1.ObjectMeta{ResourceVersion: "2"}},
 			expectedChanged: true,
 		},
 		{

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -960,7 +960,7 @@ func doRESTReq(restIface rest.Interface, groupVersion, verb, resource, elem, nam
 }
 
 // EnsureCronJob creates/updates a function cron job
-func EnsureCronJob(client kubernetes.Interface, funcObj *kubelessApi.Function, cronJobObj *kubelessApi.CronJobTrigger, or []metav1.OwnerReference) error {
+func EnsureCronJob(client kubernetes.Interface, funcObj *kubelessApi.Function, schedule string, or []metav1.OwnerReference) error {
 	var maxSucccessfulHist, maxFailedHist int32
 	maxSucccessfulHist = 3
 	maxFailedHist = 1
@@ -994,7 +994,7 @@ func EnsureCronJob(client kubernetes.Interface, funcObj *kubelessApi.Function, c
 			OwnerReferences: or,
 		},
 		Spec: batchv1beta1.CronJobSpec{
-			Schedule:                   cronJobObj.Spec.Schedule,
+			Schedule:                   schedule,
 			SuccessfulJobsHistoryLimit: &maxSucccessfulHist,
 			FailedJobsHistoryLimit:     &maxFailedHist,
 			JobTemplate: batchv1beta1.JobTemplateSpec{

--- a/pkg/utils/k8sutil_test.go
+++ b/pkg/utils/k8sutil_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/kubeless/kubeless/pkg/langruntime"
 
 	v2beta1 "k8s.io/api/autoscaling/v2beta1"
-	batchv2alpha1 "k8s.io/api/batch/v2alpha1"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	xv1beta1 "k8s.io/api/extensions/v1beta1"
@@ -26,7 +25,6 @@ import (
 	"k8s.io/apimachinery/pkg/apimachinery"
 	"k8s.io/apimachinery/pkg/apimachinery/registered"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
@@ -560,145 +558,55 @@ func TestEnsureCronJob(t *testing.T) {
 			Timeout: "120",
 		},
 	}
-	c := &kubelessApi.CronJobTrigger{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      f1Name,
-			Namespace: ns,
-		},
-		Spec: kubelessApi.CronJobTriggerSpec{
-			Schedule:     "*/10 * * * *",
-			FunctionName: f1Name,
-		},
-	}
 	expectedMeta := metav1.ObjectMeta{
 		Name:            "trigger-" + f1Name,
 		Namespace:       ns,
 		OwnerReferences: or,
 	}
 
-	client := fakeRESTClient(func(req *http.Request) (*http.Response, error) {
-		header := http.Header{}
-		header.Set("Content-Type", runtime.ContentTypeJSON)
-		listObj := batchv2alpha1.CronJobList{}
-		if req.Method == "POST" {
-			reqCronJobBytes, err := ioutil.ReadAll(req.Body)
-			if err != nil {
-				t.Fatal(err)
-			}
-			cronJob := batchv2alpha1.CronJob{}
-			err = json.Unmarshal(reqCronJobBytes, &cronJob)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if !reflect.DeepEqual(expectedMeta, cronJob.ObjectMeta) {
-				t.Errorf("Unexpected metadata metadata. Expecting\n%+v \nReceived:\n%+v", expectedMeta, cronJob.ObjectMeta)
-			}
-			if *cronJob.Spec.SuccessfulJobsHistoryLimit != int32(3) {
-				t.Errorf("Unexpected SuccessfulJobsHistoryLimit: %d", *cronJob.Spec.SuccessfulJobsHistoryLimit)
-			}
-			if *cronJob.Spec.FailedJobsHistoryLimit != int32(1) {
-				t.Errorf("Unexpected FailedJobsHistoryLimit: %d", *cronJob.Spec.FailedJobsHistoryLimit)
-			}
-			if *cronJob.Spec.JobTemplate.Spec.ActiveDeadlineSeconds != int64(120) {
-				t.Errorf("Unexpected ActiveDeadlineSeconds: %d", *cronJob.Spec.JobTemplate.Spec.ActiveDeadlineSeconds)
-			}
-			expectedCommand := []string{"curl", "-Lv", fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", f1Name, ns)}
-			args := cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args
-			// skip event headers data (i.e  -H "event-id: cronjob-controller-2018-03-05T05:55:41.990784027Z" etc)
-			foundCommand := []string{args[0], args[1], args[len(args)-1]}
-			if !reflect.DeepEqual(foundCommand, expectedCommand) {
-				t.Errorf("Unexpected command %s expexted %s", foundCommand, expectedCommand)
-			}
-		} else {
-			t.Fatalf("unexpected verb %s", req.Method)
-		}
-		switch req.URL.Path {
-		case "/apis/batch/v2alpha1/namespaces/default/cronjobs":
-			return &http.Response{
-				StatusCode: 200,
-				Header:     header,
-				Body:       objBody(&listObj),
-			}, nil
-		default:
-			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
-			return nil, nil
-		}
-	})
-	err := EnsureCronJob(client, f1, c, or, "batch/v2alpha1")
+	clientset := fake.NewSimpleClientset()
+
+	err := EnsureCronJob(clientset, f1, "* * * * *", or)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
+	}
+	cronJob, err := clientset.BatchV1beta1().CronJobs(ns).Get(fmt.Sprintf("trigger-%s", f1.Name), metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
+	}
+	if !reflect.DeepEqual(expectedMeta, cronJob.ObjectMeta) {
+		t.Errorf("Unexpected metadata metadata. Expecting\n%+v \nReceived:\n%+v", expectedMeta, cronJob.ObjectMeta)
+	}
+	if *cronJob.Spec.SuccessfulJobsHistoryLimit != int32(3) {
+		t.Errorf("Unexpected SuccessfulJobsHistoryLimit: %d", *cronJob.Spec.SuccessfulJobsHistoryLimit)
+	}
+	if *cronJob.Spec.FailedJobsHistoryLimit != int32(1) {
+		t.Errorf("Unexpected FailedJobsHistoryLimit: %d", *cronJob.Spec.FailedJobsHistoryLimit)
+	}
+	if *cronJob.Spec.JobTemplate.Spec.ActiveDeadlineSeconds != int64(120) {
+		t.Errorf("Unexpected ActiveDeadlineSeconds: %d", *cronJob.Spec.JobTemplate.Spec.ActiveDeadlineSeconds)
+	}
+	expectedCommand := []string{"curl", "-Lv", fmt.Sprintf("http://%s.%s.svc.cluster.local:8080", f1Name, ns)}
+	args := cronJob.Spec.JobTemplate.Spec.Template.Spec.Containers[0].Args
+	// skip event headers data (i.e  -H "event-id: cronjob-controller-2018-03-05T05:55:41.990784027Z" etc)
+	foundCommand := []string{args[0], args[1], args[len(args)-1]}
+	if !reflect.DeepEqual(foundCommand, expectedCommand) {
+		t.Errorf("Unexpected command %s expexted %s", foundCommand, expectedCommand)
 	}
 
 	// It should update the existing cronJob if it is already created
-	updateCalled := false
-	client = fakeRESTClient(func(req *http.Request) (*http.Response, error) {
-		header := http.Header{}
-		header.Set("Content-Type", runtime.ContentTypeJSON)
-		switch req.Method {
-		case "POST":
-			return &http.Response{
-				StatusCode: http.StatusConflict,
-				Header:     header,
-				Body:       objBody(nil),
-			}, nil
-		case "GET":
-			previousCronJob := batchv2alpha1.CronJob{
-				ObjectMeta: metav1.ObjectMeta{
-					ResourceVersion: "123456",
-				},
-			}
-			return &http.Response{
-				StatusCode: 200,
-				Header:     header,
-				Body:       objBody(&previousCronJob),
-			}, nil
-		case "PUT":
-			updateCalled = true
-			reqCronJobBytes, err := ioutil.ReadAll(req.Body)
-			if err != nil {
-				t.Fatal(err)
-			}
-			cronJob := batchv2alpha1.CronJob{}
-			err = json.Unmarshal(reqCronJobBytes, &cronJob)
-			if err != nil {
-				t.Fatal(err)
-			}
-			if cronJob.ObjectMeta.ResourceVersion != "123456" {
-				t.Error("Expecting that the object to update contains the previous information")
-			}
-			listObj := batchv2alpha1.CronJobList{}
-			return &http.Response{
-				StatusCode: 200,
-				Header:     header,
-				Body:       objBody(&listObj),
-			}, nil
-		default:
-			t.Fatalf("unexpected request: %#v\n%#v", req.URL, req)
-			return nil, nil
-		}
-	})
-	err = EnsureCronJob(client, f1, c, or, "batch/v2alpha1")
+	newSchedule := "*/10 * * * *"
+	err = EnsureCronJob(clientset, f1, newSchedule, or)
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
-	if !updateCalled {
-		t.Errorf("Expect the update method to be called")
+	updatedCronJob, err := clientset.BatchV1beta1().CronJobs(ns).Get(fmt.Sprintf("trigger-%s", f1.Name), metav1.GetOptions{})
+	if err != nil {
+		t.Errorf("Unexpected error: %s", err)
 	}
-
-	// IT should change the endpoint
-	client = fakeRESTClient(func(req *http.Request) (*http.Response, error) {
-		header := http.Header{}
-		header.Set("Content-Type", runtime.ContentTypeJSON)
-		if req.URL.Path != "/apis/batch/v1beta1/namespaces/default/cronjobs" {
-			t.Errorf("Unexpected URL %s", req.URL.Path)
-		}
-		return &http.Response{
-			StatusCode: 200,
-			Header:     header,
-			Body:       objBody(nil),
-		}, nil
-	})
-	err = EnsureCronJob(client, f1, c, or, "batch/v1beta1")
+	if updatedCronJob.Spec.Schedule != newSchedule {
+		t.Errorf("Unexpected schedule %s expecting %s", updatedCronJob.Spec.Schedule, newSchedule)
+	}
 }
 
 func doesNotContain(envs []v1.EnvVar, env v1.EnvVar) bool {

--- a/script/libtest.bash
+++ b/script/libtest.bash
@@ -335,4 +335,15 @@ sts_restart() {
     k8s_wait_for_uniq_pod -l kubeless=kafka -n kubeless
     wait_for_kubeless_kafka_server_ready
 }
+verify_clean_object() {
+    local type=${1:?}; shift
+    local name=${1:?}; shift
+    echo_info "Checking if "${type}" exists for function "${name}"... "
+    local -i cnt=${TEST_MAX_WAIT_SEC:?}
+    until [[ ! $(kubectl get ${type} | grep ${name}) ]]; do
+        ((cnt=cnt-1)) || return 1
+        sleep 1
+    done
+    echo_info "${type}/${name} is gone"
+}
 # vim: sw=4 ts=4 et si

--- a/script/libtest.bash
+++ b/script/libtest.bash
@@ -340,9 +340,10 @@ verify_clean_object() {
     local name=${1:?}; shift
     echo_info "Checking if "${type}" exists for function "${name}"... "
     local -i cnt=${TEST_MAX_WAIT_SEC:?}
-    until [[ ! $(kubectl get ${type} | grep ${name}) ]]; do
+    until [[ ! $(kubectl get ${type} 2>&1 | grep ${name}) ]]; do
         ((cnt=cnt-1)) || return 1
         sleep 1
+        echo_info "$(kubectl get ${type} 2>&1 | grep ${name})"
     done
     echo_info "${type}/${name} is gone"
 }

--- a/tests/integration-tests.bats
+++ b/tests/integration-tests.bats
@@ -161,6 +161,8 @@ load ../script/libtest
   # without having to wait
   verify_function scheduled-get-python
   kubeless_function_delete scheduled-get-python
+  verify_clean_object cronjobtrigger scheduled-get-python
+  verify_clean_object cronjob trigger-scheduled-get-python
 }
 @test "Test no-errors" {
   if kubectl logs -n kubeless -l kubeless=controller | grep "level=error"; then


### PR DESCRIPTION
**Issue Ref**: None
 
**Description**: 

Minor refactor of the CronjobTrigger. It removes the `groupVersion` discovery that we were doing for supporting Kubernetes 1.7 and 1.9 which means that this PR will fail until the version 1.7 is deprecated.

Now when deleting a function, if it has a cronjobtrigger associated it will be deleted instead of just deleting the cronjob object.

It also includes unit/integration tests for checking that the trigger is removed when the function is deleted and that it properly detect changes in the cronjobtrigger.

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 ~~- [ ] Docs~~