### PR TITLE
Basic Authentication Support for HTTP Triggers

### DIFF
--- a/cmd/kubeless/trigger/http/create.go
+++ b/cmd/kubeless/trigger/http/create.go
@@ -104,6 +104,18 @@ var createCmd = &cobra.Command{
 		}
 		httpTrigger.Spec.HostName = hostName
 
+		gateway, err := cmd.Flags().GetString("gateway")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		httpTrigger.Spec.Gateway = gateway
+
+		basicAuthSecret, err := cmd.Flags().GetString("basic-auth-secret")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		httpTrigger.Spec.BasicAuthSecret = basicAuthSecret
+
 		err = utils.CreateHTTPTriggerCustomResource(kubelessClient, &httpTrigger)
 		if err != nil {
 			logrus.Fatalf("Failed to deploy HTTP trigger %s in namespace %s. Error: %s", triggerName, ns, err)
@@ -118,5 +130,7 @@ func init() {
 	createCmd.Flags().StringP("path", "", "", "Ingress path for the function")
 	createCmd.Flags().StringP("hostname", "", "", "Specify a valid hostname for the function")
 	createCmd.Flags().BoolP("enableTLSAcme", "", false, "If true, routing rule will be configured for use with kube-lego")
+	createCmd.Flags().StringP("gateway", "", "", "Specify a valid gateway for the Ingress")
+	createCmd.Flags().StringP("basic-auth-secret", "", "", "Specify an existing secret name for basic authentication")
 	createCmd.MarkFlagRequired("function-name")
 }

--- a/cmd/kubeless/trigger/http/update.go
+++ b/cmd/kubeless/trigger/http/update.go
@@ -83,6 +83,19 @@ var updateCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 		httpTrigger.Spec.TLSAcme = enableTLSAcme
+
+		gateway, err := cmd.Flags().GetString("gateway")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		httpTrigger.Spec.Gateway = gateway
+
+		basicAuthSecret, err := cmd.Flags().GetString("basic-auth-secret")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		httpTrigger.Spec.BasicAuthSecret = basicAuthSecret
+
 		err = utils.UpdateHTTPTriggerCustomResource(kubelessClient, httpTrigger)
 		if err != nil {
 			logrus.Fatalf("Failed to deploy HTTP trigger %s in namespace %s. Error: %s", triggerName, ns, err)
@@ -97,4 +110,7 @@ func init() {
 	updateCmd.Flags().StringP("path", "", "", "Ingress path for the function")
 	updateCmd.Flags().StringP("hostname", "", "", "Specify a valid hostname for the function")
 	updateCmd.Flags().BoolP("enableTLSAcme", "", false, "If true, routing rule will be configured for use with kube-lego")
+	updateCmd.Flags().StringP("gateway", "", "", "Specify a valid gateway for the Ingress")
+	updateCmd.Flags().StringP("basic-auth-secret", "", "", "Specify an existing secret name for basic authentication")
+
 }

--- a/docs/http-triggers.md
+++ b/docs/http-triggers.md
@@ -92,3 +92,24 @@ $ kubeless trigger http create get-python --function-name get-python --path get-
 ```
 
 Running the above command, Kubeless will automatically create a ingress object with annotation `kubernetes.io/tls-acme: 'true'` set which will be used by Kube-lego to configure the service certificate.
+
+## Enable Basic Authentication
+
+By default, Kubeless doesn't take care about securing its exposed functions, in example by basic authentication.
+You can do it manually depending on your Ingress controller, some examples are:
+* [Nginx](https://github.com/kubernetes/ingress-nginx/blob/master/docs/examples/auth/basic/README.md)
+* [Traefik](https://docs.traefik.io/user-guide/kubernetes/#basic-authentication)
+
+When you have a running Nginx or Traefik ingress controller, you can deploy function and create a basic authentication secured route as shown below:
+The Kubernetes secreted specified by `--basic-auth-secret` must exist and located within the same namespace as the http trigger.
+
+```console
+$ kubeless trigger http create get-python --function-name get-python --path get-python --basic-auth-secret get-python-secret --gateway nginx
+```
+
+Running the above command, Kubeless will automatically create an ingress object with annotations:
+* `kubernetes.io/ingress.class: nginx`
+* `ingress.kubernetes.io/auth-secret: get-python-secret`
+* `ingress.kubernetes.io/auth-type: basic`
+
+

--- a/docs/http-triggers.md
+++ b/docs/http-triggers.md
@@ -97,13 +97,13 @@ Running the above command, Kubeless will automatically create a ingress object w
 
 ## Enable Basic Authentication
 
-By default, Kubeless doesn't take care about securing its exposed functions, in example by basic authentication.
+By default, Kubeless doesn't take care about securing its exposed functions.
 You can do it manually depending on your Ingress controller, some examples are:
 * [Nginx](https://github.com/kubernetes/ingress-nginx/blob/master/docs/examples/auth/basic/README.md)
 * [Traefik](https://docs.traefik.io/user-guide/kubernetes/#basic-authentication)
 
 When you have a running Nginx or Traefik ingress controller, you can deploy function and create a basic authentication secured route as shown below:
-The Kubernetes secreted specified by `--basic-auth-secret` must exist and located within the same namespace as the http trigger.
+The Kubernetes secret specified by `--basic-auth-secret` must exist and located within the same namespace as the http trigger.
 
 ```console
 $ kubeless trigger http create get-python --function-name get-python --path get-python --basic-auth-secret get-python-secret --gateway nginx

--- a/docs/http-triggers.md
+++ b/docs/http-triggers.md
@@ -40,8 +40,10 @@ Usage:
   kubeless trigger http create <http_trigger_name> FLAG [flags]
 
 Flags:
+      --basic-auth-secret      Specify an existing secret name for basic authentication
       --enableTLSAcme          If true, routing rule will be configured for use with kube-lego
       --function-name string   Name of the function to be associated with trigger
+      --gateway                Specify a valid gateway for the Ingress
   -h, --help                   help for create
       --hostname string        Specify a valid hostname for the function
       --namespace string       Specify namespace for the function

--- a/pkg/apis/kubeless/v1beta1/http_trigger.go
+++ b/pkg/apis/kubeless/v1beta1/http_trigger.go
@@ -32,10 +32,12 @@ type HTTPTrigger struct {
 
 // HTTPTriggerSpec defines specification for HTTP trigger
 type HTTPTriggerSpec struct {
-	FunctionName string `json:"function-name"` // Name of the associated function
-	HostName     string `json:"host-name"`
-	TLSAcme      bool   `json:"tls"`
-	Path         string `json:"path"`
+	FunctionName    string `json:"function-name"` // Name of the associated function
+	HostName        string `json:"host-name"`
+	TLSAcme         bool   `json:"tls"`
+	Path            string `json:"path"`
+	BasicAuthSecret string `json:"basic-auth-secret"`
+	Gateway         string `json:"gateway"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -506,6 +506,21 @@ func CreateIngress(client kubernetes.Interface, httpTriggerObj *kubelessApi.HTTP
 	// to the path expected by the service
 	ingressAnnotations["nginx.ingress.kubernetes.io/rewrite-target"] = "/"
 
+	if len(httpTriggerObj.Spec.BasicAuthSecret) > 0 {
+		switch gateway := httpTriggerObj.Spec.Gateway; gateway {
+		case "nginx":
+			ingressAnnotations["kubernetes.io/ingress.class"] = "nginx"
+			ingressAnnotations["ingress.kubernetes.io/auth-secret"] = httpTriggerObj.Spec.BasicAuthSecret
+			ingressAnnotations["ingress.kubernetes.io/auth-type"] = "basic"
+			break
+		case "traefik":
+			ingressAnnotations["kubernetes.io/ingress.class"] = "traefik"
+			ingressAnnotations["ingress.kubernetes.io/auth-secret"] = httpTriggerObj.Spec.BasicAuthSecret
+			ingressAnnotations["ingress.kubernetes.io/auth-type"] = "basic"
+			break
+		}
+	}
+
 	// add annotations and TLS configuration for kube-lego
 	if httpTriggerObj.Spec.TLSAcme {
 		ingressAnnotations["kubernetes.io/tls-acme"] = "true"


### PR DESCRIPTION
**Issue Ref**: #635
 
**Description**: 
Enables basic authentication for kubeless HTTP Triggers.
[PR Description]
Introduce new properties to the HTTP Trigger spec:
* basic-auth-secret
* gateway

**TODOs**:
 - [x ] Ready to review
 - [x ] Automated Tests
 - [x] Docs
