### PR TITLE
Add import to allow OIDC auth

### DIFF
--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -48,8 +48,9 @@ import (
 
 	monitoringv1alpha1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
 
-	// Adding explicitely the GCP auth plugin
+	// Auth plugins
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
+	_ "k8s.io/client-go/plugin/pkg/client/auth/oidc"
 
 	"github.com/imdario/mergo"
 	"github.com/kubeless/kubeless/pkg/client/clientset/versioned"


### PR DESCRIPTION
**Issue Ref**: None
 
**Description**:  Fixes this error on the command line when authing to Kubernetes with
OIDC:

```
$ kubeless function ls
FATA[0000] Can not list functions: No Auth Provider found for name "oidc"
```

After the import:

```
$ kubeless function ls
NAME	NAMESPACE	HANDLER	RUNTIME	TYPE	TOPIC	DEPENDENCIES	STATUS
```
**TODOs**:
 - [X] Ready to review
