### PR TITLE
HTTP trigger: TLS with existing certificates

### DIFF
--- a/cmd/kubeless/trigger/http/create.go
+++ b/cmd/kubeless/trigger/http/create.go
@@ -88,6 +88,15 @@ var createCmd = &cobra.Command{
 		}
 		httpTrigger.Spec.TLSAcme = enableTLSAcme
 
+		tlsSecret, err := cmd.Flags().GetString("tls-secret")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		if enableTLSAcme && len(tlsSecret) > 0 {
+			logrus.Fatalf("Either --enableTLSAcme or --tls-secret must be specified ")
+		}
+		httpTrigger.Spec.TLSSecret = tlsSecret
+
 		hostName, err := cmd.Flags().GetString("hostname")
 		if err != nil {
 			logrus.Fatal(err)
@@ -132,5 +141,6 @@ func init() {
 	createCmd.Flags().BoolP("enableTLSAcme", "", false, "If true, routing rule will be configured for use with kube-lego")
 	createCmd.Flags().StringP("gateway", "", "", "Specify a valid gateway for the Ingress")
 	createCmd.Flags().StringP("basic-auth-secret", "", "", "Specify an existing secret name for basic authentication")
+	createCmd.Flags().StringP("tls-secret", "", "", "Specify an existing secret that contains a TLS private key and certificate to secure ingress")
 	createCmd.MarkFlagRequired("function-name")
 }

--- a/cmd/kubeless/trigger/http/create.go
+++ b/cmd/kubeless/trigger/http/create.go
@@ -93,7 +93,7 @@ var createCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 		if enableTLSAcme && len(tlsSecret) > 0 {
-			logrus.Fatalf("Either --enableTLSAcme or --tls-secret must be specified ")
+			logrus.Fatalf("Cannot specify both --enableTLSAcme and --tls-secret")
 		}
 		httpTrigger.Spec.TLSSecret = tlsSecret
 

--- a/cmd/kubeless/trigger/http/update.go
+++ b/cmd/kubeless/trigger/http/update.go
@@ -84,6 +84,15 @@ var updateCmd = &cobra.Command{
 		}
 		httpTrigger.Spec.TLSAcme = enableTLSAcme
 
+		tlsSecret, err := cmd.Flags().GetString("tls-secret")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		if enableTLSAcme && len(tlsSecret) > 0 {
+			logrus.Fatalf("Either --enableTLSAcme or --tls-secret must be specified ")
+		}
+		httpTrigger.Spec.TLSSecret = tlsSecret
+
 		gateway, err := cmd.Flags().GetString("gateway")
 		if err != nil {
 			logrus.Fatal(err)
@@ -112,5 +121,5 @@ func init() {
 	updateCmd.Flags().BoolP("enableTLSAcme", "", false, "If true, routing rule will be configured for use with kube-lego")
 	updateCmd.Flags().StringP("gateway", "", "", "Specify a valid gateway for the Ingress")
 	updateCmd.Flags().StringP("basic-auth-secret", "", "", "Specify an existing secret name for basic authentication")
-
+	updateCmd.Flags().StringP("tls-secret", "", "", "Specify an existing secret that contains a TLS private key and certificate to secure ingress")
 }

--- a/cmd/kubeless/trigger/http/update.go
+++ b/cmd/kubeless/trigger/http/update.go
@@ -89,7 +89,7 @@ var updateCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 		if enableTLSAcme && len(tlsSecret) > 0 {
-			logrus.Fatalf("Either --enableTLSAcme or --tls-secret must be specified ")
+			logrus.Fatalf("Cannot specify both --enableTLSAcme and --tls-secret")
 		}
 		httpTrigger.Spec.TLSSecret = tlsSecret
 

--- a/docs/http-triggers.md
+++ b/docs/http-triggers.md
@@ -87,13 +87,25 @@ $ curl --data '{"Another": "Echo"}' \
 
 ## Enable TLS
 
-By default, Kubeless doesn't take care of setting up TLS for its functions. You can do it manually by following the [standard procedure](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) of securing ingress. There is also a [general guideline](https://docs.bitnami.com/kubernetes/how-to/secure-kubernetes-services-with-ingress-tls-letsencrypt/) to enable TLS for your Kubernetes services using LetsEncrypt and Kube-lego written by Bitnami folks. When you have running Kube-lego, you can deploy function and create route with flag `--enableTLSAcme` enabled as below:
+By default, Kubeless doesn't take care of setting up TLS for its functions. You can do it manually by following the [standard procedure](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls) of securing ingress. There is also a [general guideline](https://docs.bitnami.com/kubernetes/how-to/secure-kubernetes-services-with-ingress-tls-letsencrypt/) to enable TLS for your Kubernetes services using LetsEncrypt and Kube-lego written by Bitnami folks.
+
+### Using Let’s Encrypt’s CA
+
+When you have running Kube-lego, you can deploy function and create route with flag `--enableTLSAcme` enabled as below:
 
 ```console
 $ kubeless trigger http create get-python --function-name get-python --path get-python --enableTLSAcme
 ```
 
 Running the above command, Kubeless will automatically create a ingress object with annotation `kubernetes.io/tls-acme: 'true'` set which will be used by Kube-lego to configure the service certificate.
+
+### Using existing Certificate and Private Key
+
+If you have existing certificate, you can use them to setup TLS for ingress, there by securing functions. You need to create a [secret](https://kubernetes.io/docs/concepts/configuration/secret/) using the TLS private key and certificate as per Kubernetes ingress TLS [guideline](https://kubernetes.io/docs/concepts/services-networking/ingress/#tls). You can use created secret with kubeless CLI as below.
+
+```console
+kubeless trigger http create get-python --function-name get-python --path get-python --tls-secret secret-name
+```
 
 ## Enable Basic Authentication
 

--- a/pkg/apis/kubeless/v1beta1/http_trigger.go
+++ b/pkg/apis/kubeless/v1beta1/http_trigger.go
@@ -35,6 +35,7 @@ type HTTPTriggerSpec struct {
 	FunctionName    string `json:"function-name"` // Name of the associated function
 	HostName        string `json:"host-name"`
 	TLSAcme         bool   `json:"tls"`
+	TLSSecret       string `json:"tls-secret"`
 	Path            string `json:"path"`
 	BasicAuthSecret string `json:"basic-auth-secret"`
 	Gateway         string `json:"gateway"`

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -522,6 +522,20 @@ func CreateIngress(client kubernetes.Interface, httpTriggerObj *kubelessApi.HTTP
 		}
 	}
 
+	if len(httpTriggerObj.Spec.TLSSecret) > 0 && httpTriggerObj.Spec.TLSAcme {
+		return fmt.Errorf("Can not create ingress object from HTTP trigger spec with both TLSSecret and IngressTLS specified")
+	}
+
+	//  secure an Ingress by specified secret that contains a TLS private key and certificate
+	if len(httpTriggerObj.Spec.TLSSecret) > 0 {
+		ingress.Spec.TLS = []v1beta1.IngressTLS{
+			{
+				SecretName: httpTriggerObj.Spec.TLSSecret,
+				Hosts:      []string{httpTriggerObj.Spec.HostName},
+			},
+		}
+	}
+
 	// add annotations and TLS configuration for kube-lego
 	if httpTriggerObj.Spec.TLSAcme {
 		ingressAnnotations["kubernetes.io/tls-acme"] = "true"

--- a/tests/integration-tests-http.bats
+++ b/tests/integration-tests-http.bats
@@ -42,6 +42,17 @@ load ../script/libtest
     verify_clean_object ingress ing-get-python
 }
 
+@test "Create HTTP Trigger with TLS private key and certificate" {
+    deploy_function get-python
+    verify_function get-python
+    create_tls_secret_from_key_cert foo-secret
+    create_http_trigger_with_tls_secret get-python "foo.bar.com" "get-python" "foo-secret"
+    verify_https_trigger get-python $(minikube ip) "hello.*world" "foo.bar.com" "get-python"
+    delete_http_trigger get-python
+    verify_clean_object httptrigger ing-get-python
+    verify_clean_object ingress ing-get-python
+}
+
 @test "Create HTTP Trigger with basic auth" {
     deploy_function get-python
     verify_function get-python


### PR DESCRIPTION
**Issue Ref**: https://github.com/kubeless/kubeless/issues/649
 
**Description**: 

Fixes #649

This PR provides an option for function user to use existing certificate for TLS igress.
https://kubernetes.io/docs/concepts/services-networking/ingress/#tls


**TODOs**:
 - [x] Ready to review
 - [x] Automated Tests
 - [x] Docs