### PR TITLE
Fix spurious errors in CI

### DIFF
--- a/examples/Makefile
+++ b/examples/Makefile
@@ -33,10 +33,9 @@ get-python-deps-update:
 	rm -rf $(TMPDIR)
 
 get-python-deps-update-verify:
-	$(eval pod := $(shell kubectl get pod -l function=get-python-deps -o go-template -o custom-columns=:metadata.name --no-headers=true))
-	echo "Checking updated deps of $(pod)"
-	kubectl exec -it $(pod) pip freeze
-	kubectl exec -it $(pod) pip freeze | grep -q "twitter=="
+	pod=`kubectl get pod -l function=get-python-deps -o go-template -o custom-columns=:metadata.name --no-headers=true`; \
+	echo "Checking updated deps of $$pod"; \
+	kubectl exec -it $$pod pip freeze | grep -q "twitter=="
 
 get-python-34:
 	kubeless function deploy get-python --runtime python3.4 --handler helloget.foo --from-file python/helloget.py


### PR DESCRIPTION
**Issue Ref**: None
 
**Description**: 

Fixes two spurious errors that appears sometimes in the CI:

1. It is trying to get the python dependencies while there are two pods for the function:
```
not ok 6 Test function update: get-python-deps
...
# Checking updated deps of get-python-deps-67774954c5-k72dp get-python-deps-67774954c5-mtslr
...
# command terminated with exit code 126
# make: *** [get-python-deps-update-verify] Error 126
```

2. It is trying to deploy a function when it has not been deleted yet:
```
not ok 5 Create HTTP Trigger with basic auth
...
# time="2018-04-10T11:03:38Z" level=fatal msg="Failed to deploy get-python. Received:\nobject is being deleted: functions.kubeless.io \"get-python\" already exists"
# make: *** [get-python] Error 1
```

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 ~~- [ ] Docs~~