### PR TITLE
added bash completion commands. modified kubeless.go to include compl…

### DIFF
--- a/cmd/kubeless/completion/bash.go
+++ b/cmd/kubeless/completion/bash.go
@@ -25,7 +25,7 @@ import (
 )
 
 var (
-	completion_shells = map[string]func(out io.Writer, cmd *cobra.Command) error{
+	completionShells = map[string]func(out io.Writer, cmd *cobra.Command) error{
 		"bash": runCompletionBash,
 	}
 )
@@ -41,7 +41,7 @@ var bashCmd = &cobra.Command{
 			logrus.Fatalf("Too many arguments. Expected only the shell type.")
 		}
 
-		run, found := completion_shells[cmd.Name()]
+		run, found := completionShells[cmd.Name()]
 		if !found {
 			logrus.Fatalf("Unsupported shell type.")
 		}

--- a/cmd/kubeless/completion/bash.go
+++ b/cmd/kubeless/completion/bash.go
@@ -1,0 +1,55 @@
+/*
+Copyright (c) 2016-2017 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package completion
+
+import (
+	"io"
+	"os"
+
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var (
+	completion_shells = map[string]func(out io.Writer, cmd *cobra.Command) error{
+		"bash": runCompletionBash,
+	}
+)
+
+var bashCmd = &cobra.Command{
+
+	Use:   "bash",
+	Short: "output shell completion code for bash",
+	Long:  `output shell completion code for bash`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		if len(args) > 0 {
+			logrus.Fatalf("Too many arguments. Expected only the shell type.")
+		}
+
+		run, found := completion_shells[cmd.Name()]
+		if !found {
+			logrus.Fatalf("Unsupported shell type.")
+		}
+
+		run(os.Stdout, cmd.Parent().Parent())
+	},
+}
+
+func runCompletionBash(out io.Writer, cmd *cobra.Command) error {
+	return cmd.GenBashCompletion(out)
+}

--- a/cmd/kubeless/completion/completion.go
+++ b/cmd/kubeless/completion/completion.go
@@ -1,0 +1,33 @@
+/*
+Copyright (c) 2016-2017 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package completion
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var CompletionCmd = &cobra.Command{
+	Use:   "completion [shell]",
+	Short: "Output shell completion code for the specified shell.",
+	Long: `Output shell completion code for the specified shell. For bash, load the completion code into the current shell: 
+	
+	source <(kubeless completion bash)`,
+}
+
+func init() {
+	CompletionCmd.AddCommand(bashCmd)
+}

--- a/cmd/kubeless/completion/completion.go
+++ b/cmd/kubeless/completion/completion.go
@@ -20,6 +20,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+//CompletionCmd contains first-class command for completion
 var CompletionCmd = &cobra.Command{
 	Use:   "completion [shell]",
 	Short: "Output shell completion code for the specified shell.",

--- a/cmd/kubeless/kubeless.go
+++ b/cmd/kubeless/kubeless.go
@@ -21,6 +21,7 @@ import (
 	"os"
 
 	"github.com/kubeless/kubeless/cmd/kubeless/autoscale"
+	"github.com/kubeless/kubeless/cmd/kubeless/completion"
 	"github.com/kubeless/kubeless/cmd/kubeless/function"
 	"github.com/kubeless/kubeless/cmd/kubeless/getserverconfig"
 	"github.com/kubeless/kubeless/cmd/kubeless/topic"
@@ -38,7 +39,7 @@ func newRootCmd() *cobra.Command {
 		Long:  globalUsage,
 	}
 
-	cmd.AddCommand(function.FunctionCmd, topic.TopicCmd, version.VersionCmd, autoscale.AutoscaleCmd, getserverconfig.GetServerConfigCmd, trigger.TriggerCmd)
+	cmd.AddCommand(function.FunctionCmd, topic.TopicCmd, version.VersionCmd, autoscale.AutoscaleCmd, getserverconfig.GetServerConfigCmd, trigger.TriggerCmd, completion.CompletionCmd)
 	return cmd
 }
 


### PR DESCRIPTION
**Issue Ref**: [#15](https://github.com/kubeless/kubeless/issues/15)
 
**Description**: 

This PR adds support for bash completion for kubeless subcommands. It is based on the kubectl bash completion implementation. To load the completion functions into the current shell: source <(kubeless completion bash)

Thanks.

**TODOs**:
 - [X] Ready to review
 - [ ] Automated Tests
 - [ ] Docs
