### PR TITLE
Update Proxy URL format for k8s v1.10

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -125,7 +125,7 @@ $ kubectl proxy -p 8080 &
 
 $ curl -L --data '{"Another": "Echo"}' \
   --header "Content-Type:application/json" \
-  localhost:8080/api/v1/proxy/namespaces/default/services/get-python:http-function-port/
+  localhost:8080/api/v1/namespaces/default/services/get-python:http-function-port/proxy/
 {"Another": "Echo"}
 ```
 


### PR DESCRIPTION
The URL format when using the proxy has changed (https://github.com/kubernetes/kubernetes/pull/59884/files). This updates the quickstart guide to match.

This structure has been in place since v1.3. v1.10 removed it.