### PR TITLE
Added --from-url command line flag

### DIFF
--- a/cmd/kubeless/function/deploy.go
+++ b/cmd/kubeless/function/deploy.go
@@ -85,6 +85,11 @@ var deployCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
+		fromURL, err := cmd.Flags().GetString("from-url")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
 		file, err := cmd.Flags().GetString("from-file")
 		if err != nil {
 			logrus.Fatal(err)
@@ -163,7 +168,7 @@ var deployCmd = &cobra.Command{
 			"function":   funcName,
 		}
 
-		f, err := getFunctionDescription(cli, funcName, ns, handler, file, funcDeps, runtime, runtimeImage, mem, cpu, timeout, port, headless, envs, labels, secrets, defaultFunctionSpec)
+		f, err := getFunctionDescription(cli, funcName, ns, handler, fromURL, file, funcDeps, runtime, runtimeImage, mem, cpu, timeout, port, headless, envs, labels, secrets, defaultFunctionSpec)
 
 		if err != nil {
 			logrus.Fatal(err)
@@ -210,6 +215,7 @@ func init() {
 	deployCmd.Flags().StringP("runtime", "", "", "Specify runtime")
 	deployCmd.Flags().StringP("handler", "", "", "Specify handler")
 	deployCmd.Flags().StringP("from-file", "", "", "Specify code file")
+	deployCmd.Flags().StringP("from-url", "", "", "Specify a URL to the raw code file. For example, --from-url https://raw.githubusercontent.com/<USER>/<REPO>/<BRANCH>/<FILE>")
 	deployCmd.Flags().StringSliceP("label", "", []string{}, "Specify labels of the function. Both separator ':' and '=' are allowed. For example: --label foo1=bar1,foo2:bar2")
 	deployCmd.Flags().StringSliceP("secrets", "", []string{}, "Specify Secrets to be mounted to the functions container. For example: --secrets mySecret")
 	deployCmd.Flags().StringArrayP("env", "", []string{}, "Specify environment variable of the function. Both separator ':' and '=' are allowed. For example: --env foo1=bar1,foo2:bar2")

--- a/cmd/kubeless/function/update.go
+++ b/cmd/kubeless/function/update.go
@@ -59,6 +59,11 @@ var updateCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
+		fromURL, err := cmd.Flags().GetString("from-url")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
 		file, err := cmd.Flags().GetString("from-file")
 		if err != nil {
 			logrus.Fatal(err)
@@ -137,7 +142,7 @@ var updateCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
-		f, err := getFunctionDescription(cli, funcName, ns, handler, file, funcDeps, runtime, runtimeImage, mem, cpu, timeout, port, headless, envs, labels, secrets, previousFunction)
+		f, err := getFunctionDescription(cli, funcName, ns, handler, fromURL, file, funcDeps, runtime, runtimeImage, mem, cpu, timeout, port, headless, envs, labels, secrets, previousFunction)
 		if err != nil {
 			logrus.Fatal(err)
 		}
@@ -160,6 +165,7 @@ func init() {
 	updateCmd.Flags().StringP("runtime", "", "", "Specify runtime")
 	updateCmd.Flags().StringP("handler", "", "", "Specify handler")
 	updateCmd.Flags().StringP("from-file", "", "", "Specify code file")
+	updateCmd.Flags().StringP("from-url", "", "", "Specify a URL to the raw code file. For example, --from-url https://raw.githubusercontent.com/<USER>/<REPO>/<BRANCH>/<FILE>")
 	updateCmd.Flags().StringP("memory", "", "", "Request amount of memory for the function")
 	updateCmd.Flags().StringP("cpu", "", "", "Request amount of cpu for the function.")
 	updateCmd.Flags().StringSliceP("label", "", []string{}, "Specify labels of the function")


### PR DESCRIPTION
**Issue Ref**: [Issue 705](https://github.com/kubeless/kubeless/issues/705)
 
**Description**: 

This PR adds support for the --from-url command line flag which allows the user to specify a URL to a raw code file or zip file when calling `function deploy` or `function update`. For example:

`function deploy foo --runtime python2.7 --from-url https://raw.githubusercontent.com/<USER>/<REPO>/<BRANCH>/<FILE> --handler test.foobar`

Thanks. 

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 - [ ] Docs
