### PR TITLE
[WIP] Support of CloudEvents 0.1

### DIFF
--- a/docker/runtime/nodejs/kubeless.js
+++ b/docker/runtime/nodejs/kubeless.js
@@ -88,14 +88,18 @@ function modExecute(handler, req, res, end) {
             else {
                 event = {
                     'eventType': req.get('CE-EventType'),
+                    'eventTypeVersion': req.get('CE-EventTypeVersion'),
                     'eventID': req.get('CE-EventID'),
                     'eventTime': req.get('CE-EventTime'),
-                    'eventSource': req.get('CE-EventSource'),
+                    'source': req.get('CE-EventSource'),
+                    'schemaURL': req.get('CE-SchemaURL'),
                     'cloudEventsVersion' : req.get('CE-CloudEventsVersion'),
-                    'contentType': cType.toString(),
-                    'extensions': { request: req },
+                    'contentType': req.get('content-type'),
+                    'extensions': { request: req, response: res },
                 };
-
+                Object.keys(req.headers).forEach(key => {
+                    if (key.match(/^ce-x-+/)) event.extensions[key.substring(5)] = req.headers[key];
+                })
                 if (cType.type === 'application/json' || cType.type.endsWith('+json')) {
                     event.data = JSON.parse(req.body.toString('utf-8'));
                 }

--- a/docker/runtime/nodejs/kubeless.js
+++ b/docker/runtime/nodejs/kubeless.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const fs = require('fs');
+const http = require('http');
 const vm = require('vm');
 const path = require('path');
 const Module = require('module');
@@ -81,7 +82,7 @@ function modExecute(handler, req, res, end) {
                     console.log('Event: '+req.body.toString());
                 }
                 else {
-//  We only support +json right now. Throw an error?
+                    handleError(new Error(`Content-type ${cType.type} not supported`));
                 }
             }
             else {
@@ -96,7 +97,7 @@ function modExecute(handler, req, res, end) {
                 };
 
                 if (cType.type === 'application/json' || cType.type.endsWith('+json')) {
-                    event.data = JSON.parse(req.body.toString('utf-8'))
+                    event.data = JSON.parse(req.body.toString('utf-8'));
                 }
                 else{
                     event.data = req.body;
@@ -129,9 +130,9 @@ function modFinalize(result, res, end) {
     end();
 }
 
-function handleError(err, res, label, end) {
+function handleError(err, res, label, end, code=500) {
     errorsCounter.labels(label).inc();
-    res.status(500).send('Internal Server Error');
+    res.status(code).send(http.STATUS_CODES[code]);
     console.error(`Function failed to execute: ${err.stack}`);
     end();
 }

--- a/docker/runtime/nodejs/kubeless.js
+++ b/docker/runtime/nodejs/kubeless.js
@@ -13,19 +13,26 @@ const express = require('express');
 const helper = require('./lib/helper');
 const morgan = require('morgan');
 
+const bodySizeLimit = Number(process.env.REQ_MB_LIMIT || '1');
+
 const app = express();
 app.use(morgan('combined'));
 const bodParserOptions = {
-    type: '*/*'
+    type: '*/*',
+    limit: `${bodySizeLimit}mb`,
 };
 app.use(bodyParser.raw(bodParserOptions));
+app.use(bodyParser.json({ limit: `${bodySizeLimit}mb` }));
+app.use(bodyParser.urlencoded({ limit: `${bodySizeLimit}mb`, extended: true }));
 
 const modName = process.env.MOD_NAME;
 const funcHandler = process.env.FUNC_HANDLER;
 const timeout = Number(process.env.FUNC_TIMEOUT || '180');
 const funcPort = Number(process.env.FUNC_PORT || '8080');
 
-const modRootPath = require.main.filename.replace('kubeless.js', 'kubeless');
+const modKubeless = require.main.filename;
+const modRootPath = path.join(modKubeless, '..', '..', 'kubeless');
+
 const modPath = path.join(modRootPath, `${modName}.js`);
 const libPath = path.join(modRootPath, 'node_modules');
 const pkgPath = path.join(modRootPath, 'package.json');
@@ -121,12 +128,15 @@ function modExecute(handler, req, res, end) {
 }
 
 function modFinalize(result, res, end) {
-    switch(typeof result) {
+    if (!res.finished) switch(typeof result) {
         case 'string':
             res.end(result);
             break;
         case 'object':
-            res.json(result);
+            res.json(result); // includes res.end(), null also handled
+            break;
+        case 'undefined':
+            res.end();
             break;
         default:
             res.end(JSON.stringify(result));

--- a/docker/runtime/nodejs/package.json
+++ b/docker/runtime/nodejs/package.json
@@ -12,6 +12,7 @@
     "body-parser": "^1.17.2",
     "express": "^4.15.3",
     "morgan": "^1.8.2",
-    "prom-client": "^10.0.2"
+    "prom-client": "^10.0.2",
+    "content-type": "^1.0.4",
   }
 }


### PR DESCRIPTION
These are the changes I had to do to make the interop demo at KubeCon work. I just changed the nodejs runtime, and it isn't finished, yet. Some go coding that is being used by the triggers and the CLI still need to be adjusted, too.
Before we can actually merge this request, we have to check, if we can avoid breaking changes or at least minimize them. There is no clear concept for handling http requests that do not cary a CloudEvents. 