### PR TITLE
create a hostpath pv for kafka,then it can run locally

### DIFF
--- a/chart/kubeless/README.md
+++ b/chart/kubeless/README.md
@@ -7,3 +7,4 @@ It installs:
 * The Kubeless configuration
 * The UI
 * A single node Kafka and Zookeeper setup
+* A HostPath PersistentVolume for kafka, You can create a gce PersistentVolume to replace it.

--- a/chart/kubeless/templates/kafka-pv.yaml
+++ b/chart/kubeless/templates/kafka-pv.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolume
+metadata:
+  name: kafka-pv
+  labels:
+    kubeless: kafka
+spec:
+  capacity:
+    storage: 1Gi
+  accessModes:
+    - ReadWriteOnce
+  persistentVolumeReclaimPolicy: Retain
+  hostPath:
+    path: "/tmp"


### PR DESCRIPTION
Add a HostPath pv for kafka,then helm can install kubelss-kafka successfully.If user have no knowledge about kubernetes, he will be very confused.So i think make helm run ok is important.