### PR TITLE
Add response object to function event

### DIFF
--- a/docker/runtime/golang/kubeless.tpl.go
+++ b/docker/runtime/golang/kubeless.tpl.go
@@ -126,6 +126,7 @@ func handler(w http.ResponseWriter, r *http.Request) {
 		EventNamespace: r.Header.Get("event-namespace"),
 		Extensions: functions.Extension{
 			Request: r,
+			Response: w,
 			Context: ctx,
 		},
 	}

--- a/docker/runtime/nodejs/kubeless.js
+++ b/docker/runtime/nodejs/kubeless.js
@@ -84,7 +84,7 @@ function modExecute(handler, req, res, end) {
             'event-time': req.get('event-time'),
             'event-namespace': req.get('event-namespace'),
             data,
-            'extensions': { request: req },
+            'extensions': { request: req, response: res },
         };
         Promise.resolve(func(event, context))
         // Finalize

--- a/docs/kubeless-functions.md
+++ b/docs/kubeless-functions.md
@@ -16,6 +16,7 @@ event:
   event-namespace: "kafkatriggers.kubeless.io"  # Event emitter
   extensions:                                   # Optional parameters
     request: ...                                # Reference to the request received 
+    response: ...                               # Reference to the response to send 
                                                 # (specific properties will depend on the function language)
 context:
     function-name: "pubsub-nodejs"

--- a/kubeless-non-rbac.jsonnet
+++ b/kubeless-non-rbac.jsonnet
@@ -106,13 +106,13 @@ local runtime_images ='[
       {
         "name": "node6",
         "version": "6",
-        "runtimeImage": "kubeless/nodejs@sha256:61c5a10aacb709c4575a09a4aa28f822b2d008c0dbf4aa0b124705ee9ca143f9",
+        "runtimeImage": "kubeless/nodejs@sha256:0a8a72af4cc3bfbfd4fe9bd309cbf486e7493d0dc32a691673b3f0d3fae07487",
         "initImage": "node:6.10"
       },
       {
         "name": "node8",
         "version": "8",
-        "runtimeImage": "kubeless/nodejs@sha256:fc1aa96e55116400ee13d664a655dfb2025ded91858ebfd5fc0c8f0d6b923eba",
+        "runtimeImage": "kubeless/nodejs@sha256:76ee28dc7e3613845fface2d1c56afc2e6e2c6d6392c724795a7ccc2f5e60582",
         "initImage": "node:8"
       }
     ],
@@ -140,7 +140,7 @@ local runtime_images ='[
       {
         "name": "php72",
         "version": "7.2",
-        "runtimeImage": "kubeless/php@sha256:4e44ab60f597e93097bf9f5ea91d58bd9c308bf206043db2a9809ec16a8ff2f4",
+        "runtimeImage": "kubeless/php@sha256:b605bb6b5ae3b1a2a93570939296618904259d7767a14002fa9733e66d59849b",
         "initImage": "composer:1.6"
       }
     ],
@@ -155,7 +155,7 @@ local runtime_images ='[
         "name": "go1.10",
         "version": "1.10",
         "runtimeImage": "kubeless/go@sha256:bf72622344a54e4360f31d3fea5eb9dca2c96fbedc6f0ad7c54f3eb8fb7bd353",
-        "initImage": "kubeless/go-init@sha256:e262f70639594b3a9e3481843171ecbbe82e84b786825ebe28bc1a3ae89310d3"
+        "initImage": "kubeless/go-init@sha256:d0812c4e8351bfd95d0574efd23613cff2664d6a57af4ed0a20ebc651382d476"
       }
     ],
     "depName": "Gopkg.toml",

--- a/pkg/functions/params.go
+++ b/pkg/functions/params.go
@@ -23,8 +23,9 @@ import (
 
 // Extension includes a reference to the Event request and its Context (to handle timeouts)
 type Extension struct {
-	Request *http.Request
-	Context context.Context
+	Request  *http.Request
+	Response http.ResponseWriter
+	Context  context.Context
 }
 
 // Event includes information about the event source


### PR DESCRIPTION
**Issue Ref**: Fixes #712
 
**Description**: 

Add response object to `event.extensions`. It allows function to customize response properties like the status code or headers.

It is not necessary to perform any change for Python and Ruby since it is already possible to return a `response` object for those frameworks.

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 - [x] Docs
