### PR TITLE
<cmd>: add prometheus/pprof for main kubeless components

### DIFF
--- a/cmd/kubeless-controller-manager/kubeless-controller-manager.go
+++ b/cmd/kubeless-controller-manager/kubeless-controller-manager.go
@@ -22,9 +22,15 @@ package main
 import (
 	"fmt"
 	"os"
+	"net"
 	"os/signal"
 	"syscall"
+	"strconv"
+	"runtime"
+	"net/http"
+	"net/http/pprof"
 
+	"github.com/prometheus/client_golang/prometheus"
 	monitoringv1alpha1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
 	"github.com/kubeless/kubeless/pkg/client/informers/externalversions"
 	"github.com/kubeless/kubeless/pkg/controller"
@@ -78,6 +84,46 @@ var rootCmd = &cobra.Command{
 		httpTriggerController := controller.NewHTTPTriggerController(httpTriggerCfg, sharedInformerFactory)
 		cronJobTriggerController := controller.NewCronJobTriggerController(cronJobTriggerCfg, sharedInformerFactory)
 
+		port, err := cmd.Flags().GetUint16("port")
+		if err != nil {
+			logrus.Fatal("Invalid Server Port")
+		}
+
+		address, err := cmd.Flags().GetString("addresss")
+		if err != nil {
+			logrus.Fatal("Cannot get Server Address")
+		}
+
+		isEnableProfiling, err := cmd.Flags().GetBool("profiling")
+		if err != nil {
+			logrus.Fatal("Cannot get profiling")
+		}
+
+		isEnableContentionProfiling, err := cmd.Flags().GetBool("contention-profiling")
+		if err != nil {
+			logrus.Fatal("Cannot get contention-profiling")
+		}
+
+		go func() {
+			mux := http.NewServeMux()
+			if isEnableProfiling {
+				mux.HandleFunc("/debug/pprof/", pprof.Index)
+				mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+				mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+				mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+				if isEnableContentionProfiling {
+					runtime.SetBlockProfileRate(1)
+				}
+			}
+			mux.Handle("/metrics", prometheus.Handler())
+
+			server := &http.Server{
+				Addr:    net.JoinHostPort(address, strconv.Itoa(int(port))),
+				Handler: mux,
+			}
+			logrus.Fatal(server.ListenAndServe())
+		}()
+
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 
@@ -90,6 +136,13 @@ var rootCmd = &cobra.Command{
 		signal.Notify(sigterm, syscall.SIGINT)
 		<-sigterm
 	},
+}
+
+func init() {
+	rootCmd.Flags().StringP("address", "", "0.0.0.0", "The IP address to serve on (set to 0.0.0.0 for all interfaces)")
+	rootCmd.Flags().Uint16P("port", "", 10301, "The port that the controller-manager's http service runs on")
+	rootCmd.Flags().BoolP("profiling", "", false, "Enable profiling via web interface host:port/debug/pprof/")
+	rootCmd.Flags().BoolP("contention-profiling", "", false, "Enable lock contention profiling, if profiling is enabled")
 }
 
 func main() {

--- a/cmd/nats-trigger-controller/nats-controller.go
+++ b/cmd/nats-trigger-controller/nats-controller.go
@@ -19,14 +19,20 @@ package main
 import (
 	"fmt"
 	"os"
+	"net"
 	"os/signal"
 	"syscall"
+	"runtime"
+	"net/http"
+	"net/http/pprof"
 
+	"github.com/prometheus/client_golang/prometheus"
 	"github.com/kubeless/kubeless/pkg/controller"
 	"github.com/kubeless/kubeless/pkg/utils"
 	"github.com/kubeless/kubeless/pkg/version"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
+	"strconv"
 )
 
 var rootCmd = &cobra.Command{
@@ -48,6 +54,46 @@ var rootCmd = &cobra.Command{
 
 		natsTriggerController := controller.NewNatsTriggerController(natsTriggerCfg)
 
+				port, err := cmd.Flags().GetUint16("port")
+		if err != nil {
+			logrus.Fatal("Invalid Server Port")
+		}
+
+		address, err := cmd.Flags().GetString("addresss")
+		if err != nil {
+			logrus.Fatal("Cannot get Server Address")
+		}
+
+		isEnableProfiling, err := cmd.Flags().GetBool("profiling")
+		if err != nil {
+			logrus.Fatal("Cannot get profiling")
+		}
+
+		isEnableContentionProfiling, err := cmd.Flags().GetBool("contention-profiling")
+		if err != nil {
+			logrus.Fatal("Cannot get contention-profiling")
+		}
+
+		go func() {
+			mux := http.NewServeMux()
+			if isEnableProfiling {
+				mux.HandleFunc("/debug/pprof/", pprof.Index)
+				mux.HandleFunc("/debug/pprof/profile", pprof.Profile)
+				mux.HandleFunc("/debug/pprof/symbol", pprof.Symbol)
+				mux.HandleFunc("/debug/pprof/trace", pprof.Trace)
+				if isEnableContentionProfiling {
+					runtime.SetBlockProfileRate(1)
+				}
+			}
+			mux.Handle("/metrics", prometheus.Handler())
+
+			server := &http.Server{
+				Addr:    net.JoinHostPort(address, strconv.Itoa(int(port))),
+				Handler: mux,
+			}
+			logrus.Fatal(server.ListenAndServe())
+		}()
+
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 
@@ -58,6 +104,13 @@ var rootCmd = &cobra.Command{
 		signal.Notify(sigterm, syscall.SIGINT)
 		<-sigterm
 	},
+}
+
+func init() {
+	rootCmd.Flags().StringP("address", "", "0.0.0.0", "The IP address to serve on (set to 0.0.0.0 for all interfaces)")
+	rootCmd.Flags().Uint16P("port", "", 10302, "The port that the controller-manager's http service runs on")
+	rootCmd.Flags().BoolP("profiling", "", false, "Enable profiling via web interface host:port/debug/pprof/")
+	rootCmd.Flags().BoolP("contention-profiling", "", false, "Enable lock contention profiling, if profiling is enabled")
 }
 
 func main() {


### PR DESCRIPTION
when i read kubernetes code, i found kubeless components lack of pprof and prometheus.So i add both to kubeless. may their can be helpful for other developers.
ps: I want see this pr whether pass ci. Due to lack of test enviroment, I do few test.