### PR TITLE
Add missing `cd` command to dev guide

### DIFF
--- a/docs/dev-guide.md
+++ b/docs/dev-guide.md
@@ -96,6 +96,7 @@ To regenerate the most updated k8s manifests file, run:
 cd $KUBELESS_WORKING_DIR
 export KUBECFG_JPATH=$PWD/ksonnet-lib
 git clone --depth=1 https://github.com/ksonnet/ksonnet-lib.git
+cd $KUBELESS_WORKING_DIR/kubeless
 make all-yaml
 ```
 


### PR DESCRIPTION
section `### Building k8s manifests file` is missing a `cd` before the `make all-yaml` command.

**Issue Ref**: N/A
 
**Description**: 

Simple doc update for the dev build build. I believe I'm following the directions properly and end up with a `$GOPATH/src/github.com/kubeless/kubeless` directory in which the kubeless repo is cloned, in that case we need to cd into it before running any `make` commands.

Looking at the other make commands (like `make binary-cross`) it appears this is the expected directory structure.

Caveat: my first go project.

**TODOs**:
 - [X] Ready to review
 - [ ] Automated Tests
 - [X] Docs
