### PR TITLE
Nodejs Runtime: Use bare minimum base image

### DIFF
--- a/docker/runtime/nodejs/Dockerfile.6
+++ b/docker/runtime/nodejs/Dockerfile.6
@@ -2,13 +2,14 @@ FROM node:6
 
 RUN apt-get update &&  apt-get install git
 
-ADD package.json /
+ADD package.json kubeless_rt/
+ADD lib/helper.js kubeless_rt/lib/
+ADD kubeless.js kubeless_rt/
+
+WORKDIR kubeless_rt/
 
 RUN npm install
 
-ADD lib/helper.js /lib/
-ADD kubeless.js /
-
 USER 1000
 
-CMD ["node", "/kubeless.js"]
+CMD ["node", "kubeless.js"]

--- a/docker/runtime/nodejs/Dockerfile.8.opt
+++ b/docker/runtime/nodejs/Dockerfile.8.opt
@@ -11,7 +11,7 @@ WORKDIR kubeless_rt/
 RUN npm install
 
 
-FROM gcr.io/distroless/nodejs
+FROM gcr.io/distroless/nodejs@sha256:91b207c7278667472dcd08d8e137ed98c99a3b92120f6a7ec977fc3f63323848
 COPY --from=build-env /kubeless_rt /kubeless_rt
 
 WORKDIR kubeless_rt/

--- a/docker/runtime/nodejs/Dockerfile.8.opt
+++ b/docker/runtime/nodejs/Dockerfile.8.opt
@@ -1,4 +1,4 @@
-FROM node:8
+FROM node:8 AS build-env
 
 RUN apt-get update &&  apt-get install git
 
@@ -10,6 +10,12 @@ WORKDIR kubeless_rt/
 
 RUN npm install
 
+
+FROM gcr.io/distroless/nodejs
+COPY --from=build-env /kubeless_rt /kubeless_rt
+
+WORKDIR kubeless_rt/
+
 USER 1000
 
-CMD ["node", "kubeless.js"]
+CMD ["kubeless.js"]

--- a/docker/runtime/nodejs/kubeless.js
+++ b/docker/runtime/nodejs/kubeless.js
@@ -23,7 +23,9 @@ const funcHandler = process.env.FUNC_HANDLER;
 const timeout = Number(process.env.FUNC_TIMEOUT || '180');
 const funcPort = Number(process.env.FUNC_PORT || '8080');
 
-const modRootPath = require.main.filename.replace('kubeless.js', 'kubeless');
+const modKubeless = require.main.filename;
+const modRootPath = path.join(modKubeless, '..', '..', 'kubeless');
+
 const modPath = path.join(modRootPath, `${modName}.js`);
 const libPath = path.join(modRootPath, 'node_modules');
 const pkgPath = path.join(modRootPath, 'package.json');

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -3,7 +3,7 @@
 By default Kubeless has support for the following runtimes:
 
  - Python: For the branches 2.7, 3.4 and 3.6
- - NodeJS: For the branches 6 and 8
+ - NodeJS: For the branches 6 and 8, as well as NodeJS [distroless](https://github.com/GoogleContainerTools/distroless) for the branch 8
  - Ruby: For the branch 2.4
  - PHP: For the branch 7.2
  - Golang: For the branch 1.10
@@ -50,6 +50,23 @@ $ kubeless function deploy myFunction --runtime nodejs6 \
 #### Server implementation
 
 For the Node.js runtime we start an [Express](http://expressjs.com) server and we include the routes for serving the health check and exposing the monitoring metrics. Apart from that we enable [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS) requests and [Morgan](https://github.com/expressjs/morgan) for handling the logging in the server. Monitoring is supported if the function is synchronous or if it uses promises.
+
+#### Distroless Variant
+
+There is the [distroless](https://github.com/GoogleContainerTools/distroless) variant of the Node.js 8 runtime.
+The distroless Node.js runtime contains only the kubeless function and its runtime dependencies.
+In particular, this variant does not contain package manager, shells or any other programs which are part of a standard Linux distribution. 
+
+The same example Node.js function from above can then be deployed:
+
+```console
+$ kubeless function deploy myFunction --runtime nodejs_distroless8 \
+                                --env NPM_REGISTRY=http://my-registry.com \
+                                --env NPM_SCOPE=@myorg \
+                                --dependencies package.json \
+                                --handler test.foobar \
+                                --from-file test.js
+```
 
 ### Python
 

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -792,3 +792,9 @@ get-java-deps:
 get-java-deps-verify:
 	kubeless function call get-java-deps --data '{"hello": "world"}'
 	kubectl logs -l function=get-java-deps | grep -q '.*Hello.*world! Current local time is:'
+
+get-nodejs-distroless:
+	kubeless function deploy get-nodejs-distroless --runtime nodejs_distroless8 --handler helloget.foo --from-file nodejs/helloget.js
+
+get-nodejs-distroless-verify:
+	kubeless function call get-nodejs-distroless |egrep hello.world

--- a/kubeless-non-rbac.jsonnet
+++ b/kubeless-non-rbac.jsonnet
@@ -120,6 +120,20 @@ local runtime_images ='[
     "fileNameSuffix": ".js"
   },
   {
+    "ID": "nodejs_distroless",
+    "compiled": false,
+    "versions": [
+      {
+        "name": "node8",
+        "version": "8",
+        "runtimeImage": "henrike42/kubeless/runtimes/nodejs/distroless:0.0.1",
+        "initImage": "node:8"
+      }
+    ],
+    "depName": "package.json",
+    "fileNameSuffix": ".js"
+  },
+  {
     "ID": "ruby",
     "compiled": false,
     "versions": [

--- a/kubeless-non-rbac.jsonnet
+++ b/kubeless-non-rbac.jsonnet
@@ -126,7 +126,7 @@ local runtime_images ='[
       {
         "name": "node8",
         "version": "8",
-        "runtimeImage": "henrike42/kubeless/runtimes/nodejs/distroless:0.0.1",
+        "runtimeImage": "henrike42/kubeless/runtimes/nodejs/distroless:0.0.2",
         "initImage": "node:8"
       }
     ],

--- a/tests/integration-tests.bats
+++ b/tests/integration-tests.bats
@@ -50,6 +50,7 @@ load ../script/libtest
   deploy_function get-java
   deploy_function post-java
   deploy_function get-java-deps
+  deploy_function get-nodejs-distroless
 }
 @test "Test function: get-python" {
   verify_function get-python
@@ -198,6 +199,9 @@ load ../script/libtest
 }
 @test "Test function: get-java-deps" {
   verify_function get-java-deps
+}
+@test "Test function: get-nodejs-distroless" {
+  verify_function get-nodejs-distroless
 }
 @test "Test no-errors" {
   if kubectl logs -n kubeless -l kubeless=controller | grep "level=error"; then


### PR DESCRIPTION
**Issue Ref**:  #750 
 
**Description**: 
Provide a bare minimum docker image for nodejs using distroless.

[PR Description]
An additional Dockerfile Dockerfile.8.opt is added which provides a bare minimum nodejs 8 runtime using the distroless images.
One refactoring is required. All kubeless related files need to be put within a sub folder.
This affects all nodejs dockerfiles and the kubeless.js file.
Currently, this sub folder is named <b>kubeless_rt</b>.
Before, in example the lib folder has been copied to the root directory and conflicts with an existing folder within the distroless base image.
I have tested the refactored nodejs docker images Dockerfile.8 and Dockerfile.8.opt.
The additional image is not yet integrated in the overall make/build process.

**TODOs**:
 - [x] Ready to review
 - [x] Automated Tests
 - [x] Docs
