### PR TITLE
760 make healthcheck configurable

### DIFF
--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -416,3 +416,25 @@ hello world
 Note that it is possible to specify `--dependencies` as well when using custom images and install them using an Init container but that is only possible for the supported runtimes. You can get the list of supported runtimes executing `kubeless get-server-config`.
 
 When using a runtime not supported your function will be stored as `/kubeless/function` without extension. For example, injecting a file `my-function.jar` would result in the file being mounted as `/kubeless/my-fuction`).
+
+## Use a custom livenessProbe
+
+One can use kubeless-config to override the default liveness probe. By default, the liveness probe is `http-get` this can be overriden by providing the livenessprobe info in `kubeless-confg` under `runtime-images`. It has been implemented in such a way that each runtime can have its own liveness probe info. To use custom liveness probe paste the following info in `runtime-images`:
+
+```json
+"version": [],
+"livenessProbeInfo": {
+  "exec": {
+    "command": [
+      "curl",
+      "-f",
+      "http://localhost:8080/healthz"
+    ],
+  },
+  "initialDelaySeconds": 5,
+  "periodSeconds": 5,
+  "failureThreshold": 3,
+  "timeoutSeconds": 30
+},
+"depname": ""
+```

--- a/pkg/langruntime/langruntime.go
+++ b/pkg/langruntime/langruntime.go
@@ -33,14 +33,29 @@ type ImageSecret struct {
 	ImageSecret string `yaml:"imageSecret,omitempty"`
 }
 
+// ExecInfo contains the information about the commands to be executed for healthcheck
+type ExecInfo struct {
+	Command []string `yaml:"command"`
+}
+
+// LivenessProbe consists of complete struct info about the livenessProbe
+type LivenessProbe struct {
+	Exec                ExecInfo `yaml:"exec"`
+	InitialDelaySeconds int      `yaml:"initialDelaySeconds,omitempty"`
+	PeriodSeconds       int      `yaml:"periodSeconds,omitempty"`
+	TimeoutSeconds      int      `yaml:"timeoutSeconds,omitempty"`
+	FailureThreshold    int      `yaml:"failureThreshold,omitempty"`
+}
+
 // RuntimeInfo describe the runtime specifics (typical file suffix and dependency file name)
 // and the supported versions
 type RuntimeInfo struct {
-	ID             string           `yaml:"ID"`
-	Compiled       bool             `yaml:"compiled"`
-	Versions       []RuntimeVersion `yaml:"versions"`
-	DepName        string           `yaml:"depName"`
-	FileNameSuffix string           `yaml:"fileNameSuffix"`
+	ID                string           `yaml:"ID"`
+	Compiled          bool             `yaml:"compiled"`
+	Versions          []RuntimeVersion `yaml:"versions"`
+	LivenessProbeInfo LivenessProbe    `yaml:"livenessProbeInfo,omitempty"`
+	DepName           string           `yaml:"depName"`
+	FileNameSuffix    string           `yaml:"fileNameSuffix"`
 }
 
 // New initializes a langruntime object
@@ -111,6 +126,17 @@ func (l *Langruntimes) GetRuntimeInfo(runtime string) (RuntimeInfo, error) {
 		}
 	}
 	return RuntimeInfo{}, fmt.Errorf("Unable to find %s as runtime", runtime)
+}
+
+// GetLivenessProbeInfo returs the liveness probe info regarding a runtime
+func (l *Langruntimes) GetLivenessProbeInfo(runtime string) (LivenessProbe, error) {
+	runtimeID := regexp.MustCompile("^[a-zA-Z]+").FindString(runtime)
+	for _, runtimeInf := range l.AvailableRuntimes {
+		if runtimeInf.ID == runtimeID {
+			return runtimeInf.LivenessProbeInfo, nil
+		}
+	}
+	return LivenessProbe{}, fmt.Errorf("Unable to find LivenessProbe for %s runtime", runtime)
 }
 
 func (l *Langruntimes) findRuntimeVersion(runtimeWithVersion string) (RuntimeVersion, error) {

--- a/pkg/langruntime/langruntime.go
+++ b/pkg/langruntime/langruntime.go
@@ -33,27 +33,13 @@ type ImageSecret struct {
 	ImageSecret string `yaml:"imageSecret,omitempty"`
 }
 
-// ExecInfo contains the information about the commands to be executed for healthcheck
-type ExecInfo struct {
-	Command []string `yaml:"command"`
-}
-
-// LivenessProbe consists of complete struct info about the livenessProbe
-type LivenessProbe struct {
-	Exec                ExecInfo `yaml:"exec"`
-	InitialDelaySeconds int      `yaml:"initialDelaySeconds,omitempty"`
-	PeriodSeconds       int      `yaml:"periodSeconds,omitempty"`
-	TimeoutSeconds      int      `yaml:"timeoutSeconds,omitempty"`
-	FailureThreshold    int      `yaml:"failureThreshold,omitempty"`
-}
-
 // RuntimeInfo describe the runtime specifics (typical file suffix and dependency file name)
 // and the supported versions
 type RuntimeInfo struct {
 	ID                string           `yaml:"ID"`
 	Compiled          bool             `yaml:"compiled"`
 	Versions          []RuntimeVersion `yaml:"versions"`
-	LivenessProbeInfo LivenessProbe    `yaml:"livenessProbeInfo,omitempty"`
+	LivenessProbeInfo *v1.Probe        `yaml:"livenessProbeInfo,omitempty"`
 	DepName           string           `yaml:"depName"`
 	FileNameSuffix    string           `yaml:"fileNameSuffix"`
 }
@@ -125,18 +111,19 @@ func (l *Langruntimes) GetRuntimeInfo(runtime string) (RuntimeInfo, error) {
 			return runtimeInf, nil
 		}
 	}
+
 	return RuntimeInfo{}, fmt.Errorf("Unable to find %s as runtime", runtime)
 }
 
 // GetLivenessProbeInfo returs the liveness probe info regarding a runtime
-func (l *Langruntimes) GetLivenessProbeInfo(runtime string) (LivenessProbe, error) {
+func (l *Langruntimes) GetLivenessProbeInfo(runtime string) *v1.Probe {
 	runtimeID := regexp.MustCompile("^[a-zA-Z]+").FindString(runtime)
 	for _, runtimeInf := range l.AvailableRuntimes {
 		if runtimeInf.ID == runtimeID {
-			return runtimeInf.LivenessProbeInfo, nil
+			return runtimeInf.LivenessProbeInfo
 		}
 	}
-	return LivenessProbe{}, fmt.Errorf("Unable to find LivenessProbe for %s runtime", runtime)
+	return nil
 }
 
 func (l *Langruntimes) findRuntimeVersion(runtimeWithVersion string) (RuntimeVersion, error) {

--- a/pkg/langruntime/langruntime_test.go
+++ b/pkg/langruntime/langruntime_test.go
@@ -80,6 +80,36 @@ func TestGetFunctionImage(t *testing.T) {
 	os.Unsetenv("RUBY2.4_RUNTIME")
 }
 
+func TestGetLivenessProbe(t *testing.T) {
+	lr := SetupLangRuntime(clientset)
+	lr.ReadConfigMap()
+	livenessProbe, err := lr.GetLivenessProbeInfo("nodejs")
+	if err != nil {
+		t.Fatalf("Unable to get the livenessProbe")
+	}
+
+	expectedLivenessProbe := LivenessProbe{
+		Exec: ExecInfo{
+			Command: []string{"curl", "https://localhost"},
+		},
+		InitialDelaySeconds: 5,
+		PeriodSeconds:       5,
+	}
+
+	if !reflect.DeepEqual(livenessProbe, expectedLivenessProbe) {
+		t.Fatalf("Expected livenessProbeInfo to be %v, but found %v", expectedLivenessProbe, livenessProbe)
+	}
+
+	if livenessProbe.InitialDelaySeconds != 5 {
+		t.Fatalf("Expected InitialDelaySeconds to be '5' but got %v", livenessProbe.InitialDelaySeconds)
+	}
+
+	if livenessProbe.PeriodSeconds != 5 {
+		t.Fatalf("Expected PeriodSeconds to be '5' but got %v", livenessProbe.PeriodSeconds)
+	}
+
+}
+
 func TestGetRuntimes(t *testing.T) {
 	lr := SetupLangRuntime(clientset)
 	lr.ReadConfigMap()

--- a/pkg/langruntime/langruntime_test.go
+++ b/pkg/langruntime/langruntime_test.go
@@ -38,17 +38,12 @@ func TestGetFunctionFileNames(t *testing.T) {
 
 	expectedValues := []string{"requirements.txt", "test.py"}
 	check(clientset, lr, "python2.7", "test", expectedValues, t)
-	check(clientset, lr, "python3.4", "test", expectedValues, t)
 
 	expectedValues = []string{"package.json", "test.js"}
 	check(clientset, lr, "nodejs6", "test", expectedValues, t)
-	check(clientset, lr, "nodejs8", "test", expectedValues, t)
 
 	expectedValues = []string{"Gemfile", "test.rb"}
 	check(clientset, lr, "ruby2.4", "test", expectedValues, t)
-
-	expectedValues = []string{"requirements.xml", "test.cs"}
-	check(clientset, lr, "dotnetcore2.0", "test", expectedValues, t)
 }
 
 func TestGetFunctionImage(t *testing.T) {
@@ -83,7 +78,7 @@ func TestGetFunctionImage(t *testing.T) {
 func TestGetLivenessProbe(t *testing.T) {
 	lr := SetupLangRuntime(clientset)
 	lr.ReadConfigMap()
-	livenessProbe := lr.GetLivenessProbeInfo("nodejs")
+	livenessProbe := lr.GetLivenessProbeInfo("nodejs", 8080)
 
 	expectedLivenessProbe := &v1.Probe{
 		InitialDelaySeconds: int32(5),
@@ -105,7 +100,7 @@ func TestGetRuntimes(t *testing.T) {
 	lr.ReadConfigMap()
 
 	runtimes := strings.Join(lr.GetRuntimes(), ", ")
-	expectedRuntimes := "python2.7, python3.4, python3.6, nodejs6, nodejs8, ruby2.4, dotnetcore2.0, php7.2"
+	expectedRuntimes := "python2.7, nodejs6, ruby2.4"
 	if runtimes != expectedRuntimes {
 		t.Errorf("Expected %s but got %s", expectedRuntimes, runtimes)
 	}

--- a/pkg/langruntime/langruntime_test.go
+++ b/pkg/langruntime/langruntime_test.go
@@ -83,31 +83,21 @@ func TestGetFunctionImage(t *testing.T) {
 func TestGetLivenessProbe(t *testing.T) {
 	lr := SetupLangRuntime(clientset)
 	lr.ReadConfigMap()
-	livenessProbe, err := lr.GetLivenessProbeInfo("nodejs")
-	if err != nil {
-		t.Fatalf("Unable to get the livenessProbe")
-	}
+	livenessProbe := lr.GetLivenessProbeInfo("nodejs")
 
-	expectedLivenessProbe := LivenessProbe{
-		Exec: ExecInfo{
-			Command: []string{"curl", "https://localhost"},
+	expectedLivenessProbe := &v1.Probe{
+		InitialDelaySeconds: int32(5),
+		PeriodSeconds:       int32(10),
+		Handler: v1.Handler{
+			Exec: &v1.ExecAction{
+				Command: []string{"curl", "-f", "http://localhost:8080/healthz"},
+			},
 		},
-		InitialDelaySeconds: 5,
-		PeriodSeconds:       5,
 	}
 
 	if !reflect.DeepEqual(livenessProbe, expectedLivenessProbe) {
 		t.Fatalf("Expected livenessProbeInfo to be %v, but found %v", expectedLivenessProbe, livenessProbe)
 	}
-
-	if livenessProbe.InitialDelaySeconds != 5 {
-		t.Fatalf("Expected InitialDelaySeconds to be '5' but got %v", livenessProbe.InitialDelaySeconds)
-	}
-
-	if livenessProbe.PeriodSeconds != 5 {
-		t.Fatalf("Expected PeriodSeconds to be '5' but got %v", livenessProbe.PeriodSeconds)
-	}
-
 }
 
 func TestGetRuntimes(t *testing.T) {

--- a/pkg/langruntime/langruntimetestutils.go
+++ b/pkg/langruntime/langruntimetestutils.go
@@ -43,6 +43,13 @@ func AddFakeConfig(clientset *fake.Clientset) {
 	}, {ID: "nodejs",
 		DepName:        "package.json",
 		FileNameSuffix: ".js",
+		LivenessProbeInfo: LivenessProbe{
+			Exec: ExecInfo{
+				Command: []string{"curl", "https://localhost"},
+			},
+			InitialDelaySeconds: 5,
+			PeriodSeconds:       5,
+		},
 		Versions: []RuntimeVersion{
 			{
 				Name:      "nodejs6",

--- a/pkg/langruntime/langruntimetestutils.go
+++ b/pkg/langruntime/langruntimetestutils.go
@@ -4,7 +4,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/sirupsen/logrus"
-	yaml "gopkg.in/yaml.v2"
 	"k8s.io/api/core/v1"
 	"k8s.io/client-go/kubernetes/fake"
 )
@@ -12,104 +11,99 @@ import (
 // AddFakeConfig initializes configmap for unit tests with fake configuration.
 func AddFakeConfig(clientset *fake.Clientset) {
 
-	var runtimeImages = []RuntimeInfo{{
-		ID:             "python",
-		DepName:        "requirements.txt",
-		FileNameSuffix: ".py",
-		Versions: []RuntimeVersion{
-			{
-				Name:         "python27",
-				Version:      "2.7",
-				InitImage:    "tuna/python-pillow:2.7.11-alpine",
-				RuntimeImage: "kubeless/python@sha256:0f3b64b654df5326198e481cd26e73ecccd905aae60810fc9baea4dcbb61f697",
-
-				ImagePullSecrets: []ImageSecret{
-					{ImageSecret: "p1"}, {ImageSecret: "p2"},
+	runtimeImages := `[
+		{
+			"ID": "python",
+			"depName": "requirements.txt",
+			"versions": [
+				{
+					"name": "python27",
+					"version": "2.7",
+					"initImage": "tuna/python-pillow:2.7.11-alpine",
+					"runtimeImage": "kubeless/python@sha256:0f3b64b654df5326198e481cd26e73ecccd905aae60810fc9baea4dcbb61f697",
+					"imagePullSecrets": [{"ImageSecret": "p1"}, {"ImageSecret": "p2"}]
 				},
-			}, {
-				Name:    "python34",
-				Version: "3.4",
-				ImagePullSecrets: []ImageSecret{
-					{ImageSecret: "p1"}, {ImageSecret: "p2"},
+				{
+					"name": "python34",
+					"version": "3.4",
+					"imagePullSecrets": [{"ImageSecret": "p1"}, {"ImageSecret": "p2"}]
 				},
-			}, {
-				Name:    "python36",
-				Version: "3.6",
-				ImagePullSecrets: []ImageSecret{
-					{ImageSecret: "p1"}, {ImageSecret: "p2"},
-				},
-			},
+				{
+					"name": "python36",
+					"version": "3.6",
+					"imagePullSecrets": [{"ImageSecret": "p1"}, {"ImageSecret": "p2"}]
+				}
+			],
+			"fileNameSuffix": ".py"
 		},
-	}, {ID: "nodejs",
-		DepName:        "package.json",
-		FileNameSuffix: ".js",
-		LivenessProbeInfo: LivenessProbe{
-			Exec: ExecInfo{
-				Command: []string{"curl", "https://localhost"},
-			},
-			InitialDelaySeconds: 5,
-			PeriodSeconds:       5,
-		},
-		Versions: []RuntimeVersion{
-			{
-				Name:      "nodejs6",
-				Version:   "6",
-				InitImage: "node:6.10",
-				ImagePullSecrets: []ImageSecret{
-					{ImageSecret: "p1"}, {ImageSecret: "p2"},
+		{
+			"ID": "nodejs",
+			"depName": "package.json",
+			"livenessProbeInfo": {
+				"exec": {
+					"command": [
+						"curl",
+						"-f",
+						"http://localhost:8080/healthz"
+					]
 				},
-			}, {
-				Name:    "nodejs8",
-				Version: "8",
-				ImagePullSecrets: []ImageSecret{
-					{ImageSecret: "p1"}, {ImageSecret: "p2"},
-				},
+				"initialDelaySeconds": 5,
+				"periodseconds": 10
 			},
-		},
-	}, {ID: "ruby",
-		DepName:        "Gemfile",
-		FileNameSuffix: ".rb",
-		Versions: []RuntimeVersion{
-			{
-				Name:      "ruby24",
-				Version:   "2.4",
-				InitImage: "bitnami/ruby:2.4",
-				ImagePullSecrets: []ImageSecret{
-					{ImageSecret: "p1"}, {ImageSecret: "p2"},
+			"versions": [
+				{
+					"name": "nodejs6",
+					"version": "6",
+					"initImage": "node:6.10",
+					"imagePullSecrets": [{"ImageSecret": "p1"}, {"ImageSecret": "p2"}]
 				},
-			},
+				{
+					"name": "nodejs8",
+					"version": "8",
+					"imagePullSecrets": [{"ImageSecret": "p1"}, {"ImageSecret": "p2"}]
+				}
+			],
+			"fileNameSuffix": ".js"
 		},
-	}, {ID: "dotnetcore",
-		DepName:        "requirements.xml",
-		FileNameSuffix: ".cs",
-		Versions: []RuntimeVersion{
-			{
-				Name:    "dotnetcore2.0",
-				Version: "2.0",
-				ImagePullSecrets: []ImageSecret{
-					{ImageSecret: "p1"}, {ImageSecret: "p2"},
+		{
+			"ID": "ruby",
+			"depName": "Gemfile",
+			"versions": [
+				{
+					"name": "ruby24",
+					"version": "2.4",
+					InitImage: "bitnami/ruby:2.4",
+					"imagePullSecrets": [{"ImageSecret": "p1"}, {"ImageSecret": "p2"}]
 				},
-			},
+			],
+			"fileNameSuffix": ".rb"
 		},
-	}, {ID: "php",
-		DepName:        "composer.json",
-		FileNameSuffix: ".php",
-		Versions: []RuntimeVersion{
-			{
-				Name:      "php7.2",
-				Version:   "7.2",
-				InitImage: "composer:1.6",
-				ImagePullSecrets: []ImageSecret{
-					{ImageSecret: "p1"}, {ImageSecret: "p2"},
+		{
+			"ID": "dotnetcore",
+			"depName": "requirements.xml",
+			"versions": [
+				{
+					"name": "dotnetcore2.0",
+					"version": "2.0",
+					"imagePullSecrets": [{"ImageSecret": "p1"}, {"ImageSecret": "p2"}]
 				},
-			},
+			],
+			"fileNameSuffix": ".cs"
 		},
-	}}
-
-	out, err := yaml.Marshal(runtimeImages)
-	if err != nil {
-		logrus.Fatal("Canot Marshall runtimeimage")
-	}
+		{
+			"ID": "php",
+			"depName": "composer.json",
+			"versions": [
+				{
+					"name": "php7.2",
+					"version": "7.2",
+					InitImage: "composer:1.6",
+					"imagePullSecrets": [{"ImageSecret": "p1"}, {"ImageSecret": "p2"}]
+				},
+			],
+			"fileNameSuffix": ".php"
+		},
+	]`
 
 	cm := v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
@@ -117,11 +111,11 @@ func AddFakeConfig(clientset *fake.Clientset) {
 			Namespace: "kubeless",
 		},
 		Data: map[string]string{
-			"runtime-images": string(out),
+			"runtime-images": runtimeImages,
 		},
 	}
 
-	_, err = clientset.CoreV1().ConfigMaps("kubeless").Create(&cm)
+	_, err := clientset.CoreV1().ConfigMaps("kubeless").Create(&cm)
 	if err != nil {
 		logrus.Fatal("Unable to create configmap")
 	}

--- a/pkg/langruntime/langruntimetestutils.go
+++ b/pkg/langruntime/langruntimetestutils.go
@@ -23,16 +23,6 @@ func AddFakeConfig(clientset *fake.Clientset) {
 					"runtimeImage": "kubeless/python@sha256:0f3b64b654df5326198e481cd26e73ecccd905aae60810fc9baea4dcbb61f697",
 					"imagePullSecrets": [{"ImageSecret": "p1"}, {"ImageSecret": "p2"}]
 				},
-				{
-					"name": "python34",
-					"version": "3.4",
-					"imagePullSecrets": [{"ImageSecret": "p1"}, {"ImageSecret": "p2"}]
-				},
-				{
-					"name": "python36",
-					"version": "3.6",
-					"imagePullSecrets": [{"ImageSecret": "p1"}, {"ImageSecret": "p2"}]
-				}
 			],
 			"fileNameSuffix": ".py"
 		},
@@ -56,11 +46,6 @@ func AddFakeConfig(clientset *fake.Clientset) {
 					"version": "6",
 					"initImage": "node:6.10",
 					"imagePullSecrets": [{"ImageSecret": "p1"}, {"ImageSecret": "p2"}]
-				},
-				{
-					"name": "nodejs8",
-					"version": "8",
-					"imagePullSecrets": [{"ImageSecret": "p1"}, {"ImageSecret": "p2"}]
 				}
 			],
 			"fileNameSuffix": ".js"
@@ -77,31 +62,6 @@ func AddFakeConfig(clientset *fake.Clientset) {
 				},
 			],
 			"fileNameSuffix": ".rb"
-		},
-		{
-			"ID": "dotnetcore",
-			"depName": "requirements.xml",
-			"versions": [
-				{
-					"name": "dotnetcore2.0",
-					"version": "2.0",
-					"imagePullSecrets": [{"ImageSecret": "p1"}, {"ImageSecret": "p2"}]
-				},
-			],
-			"fileNameSuffix": ".cs"
-		},
-		{
-			"ID": "php",
-			"depName": "composer.json",
-			"versions": [
-				{
-					"name": "php7.2",
-					"version": "7.2",
-					InitImage: "composer:1.6",
-					"imagePullSecrets": [{"ImageSecret": "p1"}, {"ImageSecret": "p2"}]
-				},
-			],
-			"fileNameSuffix": ".php"
 		},
 	]`
 

--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -728,21 +728,11 @@ func EnsureFuncDeployment(client kubernetes.Interface, funcObj *kubelessApi.Func
 	// update deployment for loading dependencies
 	lr.UpdateDeployment(dpm, runtimeVolumeMount.MountPath, funcObj.Spec.Runtime)
 
-	livenessProbeInfo, err := lr.GetLivenessProbeInfo(funcObj.Spec.Runtime)
+	livenessProbeInfo := lr.GetLivenessProbeInfo(funcObj.Spec.Runtime)
 	livenessProbe := &v1.Probe{}
 
-	if len(livenessProbeInfo.Exec.Command) != 0 {
-		livenessProbe = &v1.Probe{
-			InitialDelaySeconds: int32(livenessProbeInfo.InitialDelaySeconds),
-			PeriodSeconds:       int32(livenessProbeInfo.PeriodSeconds),
-			FailureThreshold:    int32(livenessProbeInfo.FailureThreshold),
-			TimeoutSeconds:      int32(livenessProbeInfo.TimeoutSeconds),
-			Handler: v1.Handler{
-				Exec: &v1.ExecAction{
-					Command: livenessProbeInfo.Exec.Command,
-				},
-			},
-		}
+	if livenessProbeInfo != nil {
+		livenessProbe = livenessProbeInfo
 	} else {
 		livenessProbe = &v1.Probe{
 			InitialDelaySeconds: int32(3),

--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -728,25 +728,10 @@ func EnsureFuncDeployment(client kubernetes.Interface, funcObj *kubelessApi.Func
 	// update deployment for loading dependencies
 	lr.UpdateDeployment(dpm, runtimeVolumeMount.MountPath, funcObj.Spec.Runtime)
 
-	livenessProbeInfo := lr.GetLivenessProbeInfo(funcObj.Spec.Runtime)
-	livenessProbe := &v1.Probe{}
+	livenessProbeInfo := lr.GetLivenessProbeInfo(funcObj.Spec.Runtime, int(svcPort(funcObj)))
 
-	if livenessProbeInfo != nil {
-		livenessProbe = livenessProbeInfo
-	} else {
-		livenessProbe = &v1.Probe{
-			InitialDelaySeconds: int32(3),
-			PeriodSeconds:       int32(30),
-			Handler: v1.Handler{
-				HTTPGet: &v1.HTTPGetAction{
-					Path: "/healthz",
-					Port: intstr.FromInt(int(svcPort(funcObj))),
-				},
-			},
-		}
-	}
 	if dpm.Spec.Template.Spec.Containers[0].LivenessProbe == nil {
-		dpm.Spec.Template.Spec.Containers[0].LivenessProbe = livenessProbe
+		dpm.Spec.Template.Spec.Containers[0].LivenessProbe = livenessProbeInfo
 	}
 
 	// Add security context


### PR DESCRIPTION
**Issue Ref**: [#760]
 
**Description**: 

This PR allows user to override default `httpGet` health checks. This is necessary for the case when we are using kubeless with Istio. Where `httpGet` based health checks are not possible. 

**TODOs**:
 - [x] Ready to review
 - [x] Automated Tests
 - [x] Docs
