### PR TITLE
[WIP] split out http and cronjob trigger controller from function controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -155,6 +155,8 @@ docker/kafka-controller/kafka-controller
 docker/function-image-builder/imbuilder
 docker/nats-controller/nats-controller
 docker/kinesis-controller/kinesis-controller
+docker/http-controller/http-controller
+docker/cronjob-controller/cronjob-controller
 ksonnet-lib/
 kubeless-openshift.yaml
 kubeless-non-rbac.yaml
@@ -163,3 +165,5 @@ kafka-zookeeper.yaml
 kafka-zookeeper-openshift.yaml
 nats.yaml
 kinesis.yaml
+http.yaml
+cronjob.yaml

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,8 @@ KUBECFG = kubecfg
 DOCKER = docker
 CONTROLLER_IMAGE = kubeless-controller-manager:latest
 FUNCTION_IMAGE_BUILDER = kubeless-function-image-builder:latest
+HTTP_CONTROLLER_IMAGE = http-trigger-controller:latest
+CRONJOB_CONTROLLER_IMAGE = cronjob-trigger-controller:latest
 KAFKA_CONTROLLER_IMAGE = kafka-trigger-controller:latest
 NATS_CONTROLLER_IMAGE = nats-trigger-controller:latest
 KINESIS_CONTROLLER_IMAGE = kinesis-trigger-controller:latest
@@ -39,7 +41,7 @@ binary-cross:
 	$(KUBECFG) show -o yaml $< > $@.tmp
 	mv $@.tmp $@
 
-all-yaml: kubeless.yaml kubeless-non-rbac.yaml kubeless-openshift.yaml kafka-zookeeper.yaml kafka-zookeeper-openshift.yaml nats.yaml kinesis.yaml
+all-yaml: kubeless.yaml kubeless-non-rbac.yaml kubeless-openshift.yaml kafka-zookeeper.yaml kafka-zookeeper-openshift.yaml nats.yaml kinesis.yaml http.yaml cronjob.yaml
 
 kubeless.yaml: kubeless.jsonnet
 
@@ -48,6 +50,10 @@ kubeless-non-rbac.yaml: kubeless-non-rbac.jsonnet
 kubeless-openshift.yaml: kubeless-openshift.jsonnet
 
 kafka-zookeeper.yaml: kafka-zookeeper.jsonnet
+
+cronjob.yaml: cronjob.jsonnet
+
+http.yaml: http.jsonnet
 
 nats.yaml: nats.jsonnet
 
@@ -79,6 +85,24 @@ kafka-controller-build:
 
 kafka-controller-image: docker/kafka-controller
 	$(DOCKER) build -t $(KAFKA_CONTROLLER_IMAGE) $<
+
+cronjob-controller-build:
+	./script/binary-controller -os=$(OS) -arch=$(ARCH) cronjob-controller github.com/kubeless/kubeless/cmd/cronjob-trigger-controller
+
+cronjob-controller-image: docker/cronjob-controller
+	$(DOCKER) build -t $(CRONJOB_CONTROLLER_IMAGE) $<
+
+docker/cronjob-controller: cronjob-controller-build
+	cp $(BUNDLES)/kubeless_$(OS)-$(ARCH)/cronjob-controller $@
+
+http-controller-build:
+	./script/binary-controller -os=$(OS) -arch=$(ARCH) http-controller github.com/kubeless/kubeless/cmd/http-trigger-controller
+
+http-controller-image: docker/http-controller
+	$(DOCKER) build -t $(HTTP_CONTROLLER_IMAGE) $<
+
+docker/http-controller: http-controller-build
+	cp $(BUNDLES)/kubeless_$(OS)-$(ARCH)/http-controller $@
 
 nats-controller-build:
 	./script/binary-controller -os=$(OS) -arch=$(ARCH) nats-controller github.com/kubeless/kubeless/cmd/nats-trigger-controller

--- a/cmd/http-trigger-controller/http-controller.go
+++ b/cmd/http-trigger-controller/http-controller.go
@@ -14,9 +14,6 @@ See the License for the specific language governing permissions and
 limitations under the License.
 */
 
-// Kubeless controller binary.
-//
-// See github.com/kubeless/kubeless/pkg/controller
 package main
 
 import (
@@ -25,50 +22,36 @@ import (
 	"os/signal"
 	"syscall"
 
-	monitoringv1alpha1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
+	"github.com/kubeless/kubeless/pkg/client/informers/externalversions"
 	"github.com/kubeless/kubeless/pkg/controller"
 	"github.com/kubeless/kubeless/pkg/utils"
 	"github.com/kubeless/kubeless/pkg/version"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-	"k8s.io/client-go/rest"
-)
-
-const (
-	globalUsage = `` //TODO: adding explanation
 )
 
 var rootCmd = &cobra.Command{
-	Use:   "kubeless-controller",
-	Short: "Kubeless controller",
-	Long:  globalUsage,
+	Use:   "http-trigger-controller",
+	Short: "Kubeless HTTP trigger controller",
+	Long:  "Kubeless HTTP trigger controller",
 	Run: func(cmd *cobra.Command, args []string) {
 		kubelessClient, err := utils.GetFunctionClientInCluster()
 		if err != nil {
 			logrus.Fatalf("Cannot get kubeless client: %v", err)
 		}
 
-		functionCfg := controller.Config{
-			KubeCli:        utils.GetClient(),
-			FunctionClient: kubelessClient,
+		httpTriggerCfg := controller.HTTPTriggerConfig{
+			KubeCli:       utils.GetClient(),
+			TriggerClient: kubelessClient,
 		}
 
-		restCfg, err := rest.InClusterConfig()
-		if err != nil {
-			logrus.Fatalf("Cannot get REST client: %v", err)
-		}
-		// ServiceMonitor client is needed for handling monitoring resources
-		smclient, err := monitoringv1alpha1.NewForConfig(restCfg)
-		if err != nil {
-			logrus.Fatal(err)
-		}
-
-		functionController := controller.NewFunctionController(functionCfg, smclient)
+		sharedInformerFactory := externalversions.NewSharedInformerFactory(kubelessClient, 0)
+		httpTriggerController := controller.NewHTTPTriggerController(httpTriggerCfg, sharedInformerFactory)
 
 		stopCh := make(chan struct{})
 		defer close(stopCh)
 
-		go functionController.Run(stopCh)
+		go httpTriggerController.Run(stopCh)
 
 		sigterm := make(chan os.Signal, 1)
 		signal.Notify(sigterm, syscall.SIGTERM)
@@ -78,7 +61,7 @@ var rootCmd = &cobra.Command{
 }
 
 func main() {
-	logrus.Infof("Running Kubeless controller manager version: %v", version.Version)
+	logrus.Infof("Running Kubeless HTTP trigger controller version: %v", version.Version)
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
 		os.Exit(1)

--- a/cronjob.jsonnet
+++ b/cronjob.jsonnet
@@ -1,0 +1,77 @@
+local k = import "ksonnet.beta.1/k.libsonnet";
+local container = k.core.v1.container;
+
+local deployment = k.apps.v1beta1.deployment;
+local serviceAccount = k.core.v1.serviceAccount;
+local objectMeta = k.core.v1.objectMeta;
+
+local namespace = "kubeless";
+local controller_account_name = "controller-acct";
+
+local crd = [
+  {
+    apiVersion: "apiextensions.k8s.io/v1beta1",
+    kind: "CustomResourceDefinition",
+    metadata: objectMeta.name("cronjobtriggers.kubeless.io"),
+    spec: {group: "kubeless.io", version: "v1beta1", scope: "Namespaced", names: {plural: "cronjobtriggers", singular: "cronjobtrigger", kind: "CronJobTrigger"}},
+    description: "CRD object for HTTP trigger type",
+  },
+];
+
+local controllerContainer =
+  container.default("cronjob-trigger-controller", "bitnami/cronjob-trigger-controller:latest") +
+  container.imagePullPolicy("IfNotPresent");
+
+local kubelessLabel = {kubeless: "cronjob-trigger-controller"};
+
+local controllerAccount =
+  serviceAccount.default(controller_account_name, namespace);
+
+local controllerDeployment =
+  deployment.default("cronjob-trigger-controller", controllerContainer, namespace) +
+  {metadata+:{labels: kubelessLabel}} +
+  {spec+: {selector: {matchLabels: kubelessLabel}}} +
+  {spec+: {template+: {spec+: {serviceAccountName: controllerAccount.metadata.name}}}} +
+  {spec+: {template+: {metadata: {labels: kubelessLabel}}}};
+
+local controller_roles = [
+  {
+    apiGroups: [""],
+    resources: ["services", "configmaps"],
+    verbs: ["get", "list"],
+  },
+  {
+    apiGroups: ["kubeless.io"],
+    resources: ["functions", "cronjobtriggers"],
+    verbs: ["get", "list", "watch", "update", "delete"],
+  },
+];
+
+local clusterRole(name, rules) = {
+    apiVersion: "rbac.authorization.k8s.io/v1beta1",
+    kind: "ClusterRole",
+    metadata: objectMeta.name(name),
+    rules: rules,
+};
+
+local clusterRoleBinding(name, role, subjects) = {
+    apiVersion: "rbac.authorization.k8s.io/v1beta1",
+    kind: "ClusterRoleBinding",
+    metadata: objectMeta.name(name),
+    subjects: [{kind: s.kind, namespace: s.metadata.namespace, name: s.metadata.name} for s in subjects],
+    roleRef: {kind: role.kind, apiGroup: "rbac.authorization.k8s.io", name: role.metadata.name},
+};
+
+local controllerClusterRole = clusterRole(
+  "http-controller-deployer", controller_roles);
+
+local controllerClusterRoleBinding = clusterRoleBinding(
+  "http-controller-deployer", controllerClusterRole, [controllerAccount]
+);
+
+{
+  controller: k.util.prune(controllerDeployment),
+  crd: k.util.prune(crd),
+  controllerClusterRole: k.util.prune(controllerClusterRole),
+  controllerClusterRoleBinding: k.util.prune(controllerClusterRoleBinding),
+}

--- a/docker/cronjob-controller/Dockerfile
+++ b/docker/cronjob-controller/Dockerfile
@@ -1,0 +1,5 @@
+FROM bitnami/minideb:jessie
+
+ADD cronjob-controller /cronjob-controller
+
+ENTRYPOINT ["/cronjob-controller"]

--- a/docker/http-controller/Dockerfile
+++ b/docker/http-controller/Dockerfile
@@ -1,0 +1,7 @@
+FROM bitnami/minideb:jessie
+
+ADD http-controller /http-controller
+
+RUN install_packages ca-certificates
+
+ENTRYPOINT ["/http-controller"]

--- a/http.jsonnet
+++ b/http.jsonnet
@@ -1,0 +1,77 @@
+local k = import "ksonnet.beta.1/k.libsonnet";
+local container = k.core.v1.container;
+
+local deployment = k.apps.v1beta1.deployment;
+local serviceAccount = k.core.v1.serviceAccount;
+local objectMeta = k.core.v1.objectMeta;
+
+local namespace = "kubeless";
+local controller_account_name = "controller-acct";
+
+local crd = [
+  {
+    apiVersion: "apiextensions.k8s.io/v1beta1",
+    kind: "CustomResourceDefinition",
+    metadata: objectMeta.name("httptriggers.kubeless.io"),
+    spec: {group: "kubeless.io", version: "v1beta1", scope: "Namespaced", names: {plural: "httptriggers", singular: "httptrigger", kind: "HTTPTrigger"}},
+    description: "CRD object for HTTP trigger type",
+  },
+];
+
+local controllerContainer =
+  container.default("http-trigger-controller", "bitnami/http-trigger-controller:latest") +
+  container.imagePullPolicy("IfNotPresent");
+
+local kubelessLabel = {kubeless: "http-trigger-controller"};
+
+local controllerAccount =
+  serviceAccount.default(controller_account_name, namespace);
+
+local controllerDeployment =
+  deployment.default("http-trigger-controller", controllerContainer, namespace) +
+  {metadata+:{labels: kubelessLabel}} +
+  {spec+: {selector: {matchLabels: kubelessLabel}}} +
+  {spec+: {template+: {spec+: {serviceAccountName: controllerAccount.metadata.name}}}} +
+  {spec+: {template+: {metadata: {labels: kubelessLabel}}}};
+
+local controller_roles = [
+  {
+    apiGroups: [""],
+    resources: ["services", "configmaps"],
+    verbs: ["get", "list"],
+  },
+  {
+    apiGroups: ["kubeless.io"],
+    resources: ["functions", "httptriggers"],
+    verbs: ["get", "list", "watch", "update", "delete"],
+  },
+];
+
+local clusterRole(name, rules) = {
+    apiVersion: "rbac.authorization.k8s.io/v1beta1",
+    kind: "ClusterRole",
+    metadata: objectMeta.name(name),
+    rules: rules,
+};
+
+local clusterRoleBinding(name, role, subjects) = {
+    apiVersion: "rbac.authorization.k8s.io/v1beta1",
+    kind: "ClusterRoleBinding",
+    metadata: objectMeta.name(name),
+    subjects: [{kind: s.kind, namespace: s.metadata.namespace, name: s.metadata.name} for s in subjects],
+    roleRef: {kind: role.kind, apiGroup: "rbac.authorization.k8s.io", name: role.metadata.name},
+};
+
+local controllerClusterRole = clusterRole(
+  "http-controller-deployer", controller_roles);
+
+local controllerClusterRoleBinding = clusterRoleBinding(
+  "http-controller-deployer", controllerClusterRole, [controllerAccount]
+);
+
+{
+  controller: k.util.prune(controllerDeployment),
+  crd: k.util.prune(crd),
+  controllerClusterRole: k.util.prune(controllerClusterRole),
+  controllerClusterRoleBinding: k.util.prune(controllerClusterRoleBinding),
+}

--- a/kubeless-non-rbac.jsonnet
+++ b/kubeless-non-rbac.jsonnet
@@ -53,20 +53,6 @@ local crd = [
     metadata: objectMeta.name("functions.kubeless.io"),
     spec: {group: "kubeless.io", version: "v1beta1", scope: "Namespaced", names: {plural: "functions", singular: "function", kind: "Function"}},
     description: "Kubernetes Native Serverless Framework",
-  },
-  {
-    apiVersion: "apiextensions.k8s.io/v1beta1",
-    kind: "CustomResourceDefinition",
-    metadata: objectMeta.name("httptriggers.kubeless.io"),
-    spec: {group: "kubeless.io", version: "v1beta1", scope: "Namespaced", names: {plural: "httptriggers", singular: "httptrigger", kind: "HTTPTrigger"}},
-    description: "CRD object for HTTP trigger type",
-  },
-  {
-    apiVersion: "apiextensions.k8s.io/v1beta1",
-    kind: "CustomResourceDefinition",
-    metadata: objectMeta.name("cronjobtriggers.kubeless.io"),
-    spec: {group: "kubeless.io", version: "v1beta1", scope: "Namespaced", names: {plural: "cronjobtriggers", singular: "cronjobtrigger", kind: "CronJobTrigger"}},
-    description: "CRD object for HTTP trigger type",
   }
 ];
 

--- a/kubeless.jsonnet
+++ b/kubeless.jsonnet
@@ -28,11 +28,6 @@ local controller_roles = [
     verbs: ["get"],
   },
   {
-    apiGroups: ["kubeless.io"],
-    resources: ["functions", "httptriggers", "cronjobtriggers"],
-    verbs: ["get", "list", "watch", "update", "delete"],
-  },
-  {
     apiGroups: ["batch"],
     resources: ["cronjobs", "jobs"],
     verbs: ["create", "get", "delete", "deletecollection", "list", "update", "patch"],

--- a/script/binary
+++ b/script/binary
@@ -26,6 +26,8 @@ rm -f ${GOPATH%%:*}/bin/kubeless
 rm -f ${GOPATH%%:*}/bin/kafka-trigger-controller
 rm -f ${GOPATH%%:*}/bin/kubeless-controller-manager
 rm -f ${GOPATH%%:*}/bin/nats-trigger-controller
+rm -f ${GOPATH%%:*}/bin/http-trigger-controller
+rm -f ${GOPATH%%:*}/bin/cronjob-trigger-controller
 
 echo "Build Kubeless Components binaries"
 # Build binary


### PR DESCRIPTION
**Issue Ref**: #785 
 
**Description**: 

As a first step in preparation for #695 seperate out both cronjob and http trigger controllers out of main kubeless-controler-manager.

Also rename kubeless-controler-manager to kubeless-function-controller to make its functionality more clear

[PR Description]

**TODOs**:
 - [ ] Ready to review
 - [ ] Automated Tests
 - [ ] Docs