### PR TITLE
Avoid to overwrite existing resources

### DIFF
--- a/pkg/utils/kubelessutil_test.go
+++ b/pkg/utils/kubelessutil_test.go
@@ -10,6 +10,7 @@ import (
 	kubelessApi "github.com/kubeless/kubeless/pkg/apis/kubeless/v1beta1"
 	"github.com/kubeless/kubeless/pkg/langruntime"
 
+	batchv1beta1 "k8s.io/api/batch/v1beta1"
 	"k8s.io/api/core/v1"
 	"k8s.io/api/extensions/v1beta1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
@@ -158,6 +159,22 @@ func TestEnsureFuncMapWithoutDeps(t *testing.T) {
 	}
 }
 
+func TestAvoidConfigMapOverwrite(t *testing.T) {
+	f1Name := "f1"
+	clientset, or, ns, lr := prepareDeploymentTest(f1Name)
+	clientset.CoreV1().ConfigMaps(ns).Create(&v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      f1Name,
+			Namespace: ns,
+		},
+	})
+	f1 := getDefaultFunc(f1Name, ns)
+	err := EnsureFuncConfigMap(clientset, f1, or, lr)
+	if err == nil && strings.Contains(err.Error(), "conflicting object") {
+		t.Errorf("It should fail because a conflict")
+	}
+}
+
 func TestEnsureService(t *testing.T) {
 	fakeSvc := v1.Service{
 		ObjectMeta: metav1.ObjectMeta{
@@ -278,6 +295,29 @@ func TestUpdateFuncSvc(t *testing.T) {
 	}
 	if reflect.DeepEqual(svc.Spec.Selector, newLabels) {
 		t.Error("It should not update the selector")
+	}
+}
+
+func TestAvoidServiceOverwrite(t *testing.T) {
+	f1Name := "f1"
+	ns := "default"
+	or := []metav1.OwnerReference{
+		{
+			Kind:       "Function",
+			APIVersion: "kubeless.io/v1beta1",
+		},
+	}
+	clientset := fake.NewSimpleClientset()
+	clientset.CoreV1().Services(ns).Create(&v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      f1Name,
+			Namespace: ns,
+		},
+	})
+	f1 := getDefaultFunc(f1Name, ns)
+	err := EnsureFuncService(clientset, f1, or)
+	if err == nil && strings.Contains(err.Error(), "conflicting object") {
+		t.Errorf("It should fail because a conflict")
 	}
 }
 
@@ -438,7 +478,7 @@ func TestEnsureDeployment(t *testing.T) {
 	expectedObjectMeta := metav1.ObjectMeta{
 		Name:            f1Name,
 		Namespace:       ns,
-		Labels:          funcLabels,
+		Labels:          addDefaultLabel(funcLabels),
 		OwnerReferences: or,
 		Annotations:     funcAnno,
 	}
@@ -622,6 +662,22 @@ func TestEnsureUpdateDeployment(t *testing.T) {
 	// ignores PATCH actions: https://github.com/kubernetes/client-go/issues/364
 }
 
+func TestAvoidDeploymentOverwrite(t *testing.T) {
+	f1Name := "f1"
+	clientset, or, ns, lr := prepareDeploymentTest(f1Name)
+	clientset.ExtensionsV1beta1().Deployments(ns).Create(&v1beta1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      f1Name,
+			Namespace: ns,
+		},
+	})
+	f1 := getDefaultFunc(f1Name, ns)
+	err := EnsureFuncDeployment(clientset, f1, or, lr, "", "unzip", []v1.LocalObjectReference{})
+	if err == nil && strings.Contains(err.Error(), "conflicting object") {
+		t.Errorf("It should fail because a conflict")
+	}
+}
+
 func TestDeploymentWithUnsupportedRuntime(t *testing.T) {
 	funcName := "func"
 	clientset, or, ns, lr := prepareDeploymentTest(funcName)
@@ -731,6 +787,7 @@ func TestEnsureCronJob(t *testing.T) {
 		Name:            "trigger-" + f1Name,
 		Namespace:       ns,
 		OwnerReferences: or,
+		Labels:          addDefaultLabel(map[string]string{}),
 	}
 
 	clientset := fake.NewSimpleClientset()
@@ -782,6 +839,28 @@ func TestEnsureCronJob(t *testing.T) {
 	}
 	if updatedCronJob.Spec.Schedule != newSchedule {
 		t.Errorf("Unexpected schedule %s expecting %s", updatedCronJob.Spec.Schedule, newSchedule)
+	}
+}
+
+func TestAvoidCronjobOverwrite(t *testing.T) {
+	or := []metav1.OwnerReference{}
+	ns := "default"
+	f1Name := "func1"
+	f1 := &kubelessApi.Function{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      f1Name,
+			Namespace: ns,
+		},
+		Spec: kubelessApi.FunctionSpec{},
+	}
+	clientset := fake.NewSimpleClientset()
+
+	clientset.BatchV1beta1().CronJobs(ns).Create(&batchv1beta1.CronJob{
+		ObjectMeta: metav1.ObjectMeta{Name: fmt.Sprintf("trigger-%s", f1.Name)},
+	})
+	err := EnsureCronJob(clientset, f1, "* * * * *", "unzip", or, []v1.LocalObjectReference{})
+	if err == nil && strings.Contains(err.Error(), "conflicting object") {
+		t.Errorf("It should fail because a conflict")
 	}
 }
 
@@ -983,9 +1062,9 @@ func TestUpdateIngressResource(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Namespace: "myns",
 			Name:      "foo",
-			Labels: map[string]string{
+			Labels: addDefaultLabel(map[string]string{
 				"test": "foo",
-			},
+			}),
 		},
 	}
 	clientset := fake.NewSimpleClientset(&fakeSvc, &fakeIngress)
@@ -1020,6 +1099,47 @@ func TestUpdateIngressResource(t *testing.T) {
 	}
 	if newIngress.Spec.Rules[0].Host != "test.domain" {
 		t.Errorf("Unexpected hostname: %s", newIngress.Spec.Rules[0].Host)
+	}
+}
+
+func TestAvoidIngressOverwrite(t *testing.T) {
+	fakeSvc := v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "myns",
+			Name:      "foo",
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				{TargetPort: intstr.FromInt(8080)},
+			},
+		},
+	}
+	clientset := fake.NewSimpleClientset(&fakeSvc)
+	f1 := &kubelessApi.Function{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "myns",
+		},
+		Spec: kubelessApi.FunctionSpec{},
+	}
+	httpTrigger := &kubelessApi.HTTPTrigger{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "myns",
+		},
+		Spec: kubelessApi.HTTPTriggerSpec{
+			FunctionName: f1.Name,
+		},
+	}
+	or := []metav1.OwnerReference{}
+	clientset.ExtensionsV1beta1().Ingresses("myns").Create(&v1beta1.Ingress{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "myns",
+		},
+	})
+	if err := CreateIngress(clientset, httpTrigger, or); err == nil {
+		t.Errorf("It should fail because a conflict")
 	}
 }
 


### PR DESCRIPTION
**Issue Ref**: Fixes #810
 
**Description**: 

Avoid to overwrite a resource if it doesn't contain the label `created-by: kubeless`. Ensure that all the resources created by kubeless contain that label.

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 ~~- [ ] Docs~~