### PR TITLE
Show function statistics in CLI

### DIFF
--- a/cmd/kubeless/function/function.go
+++ b/cmd/kubeless/function/function.go
@@ -31,6 +31,7 @@ import (
 	"unicode/utf8"
 
 	kubelessApi "github.com/kubeless/kubeless/pkg/apis/kubeless/v1beta1"
+	"github.com/kubeless/kubeless/pkg/client/clientset/versioned"
 	"github.com/spf13/cobra"
 	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
@@ -366,4 +367,22 @@ func getDeploymentStatus(cli kubernetes.Interface, funcName, ns string) (string,
 		status += " NOT READY"
 	}
 	return status, nil
+}
+
+func getFunctions(kubelessClient versioned.Interface, namespace, functionName string) ([]*kubelessApi.Function, error) {
+	if functionName == "" {
+		f, err := kubelessClient.KubelessV1beta1().Functions(namespace).List(metav1.ListOptions{})
+		if err != nil {
+			return []*kubelessApi.Function{}, err
+		}
+		return f.Items, nil
+	}
+
+	f, err := kubelessClient.KubelessV1beta1().Functions(namespace).Get(functionName, metav1.GetOptions{})
+	if err != nil {
+		return []*kubelessApi.Function{}, err
+	}
+	return []*kubelessApi.Function{
+		f,
+	}, nil
 }

--- a/cmd/kubeless/function/function.go
+++ b/cmd/kubeless/function/function.go
@@ -57,6 +57,7 @@ func init() {
 	FunctionCmd.AddCommand(logsCmd)
 	FunctionCmd.AddCommand(describeCmd)
 	FunctionCmd.AddCommand(updateCmd)
+	FunctionCmd.AddCommand(topCmd)
 }
 
 func getKV(input string) (string, string) {

--- a/cmd/kubeless/function/top.go
+++ b/cmd/kubeless/function/top.go
@@ -17,6 +17,7 @@ limitations under the License.
 package function
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"sort"
@@ -24,6 +25,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ghodss/yaml"
 	"github.com/gosuri/uitable"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -38,8 +40,7 @@ import (
 )
 
 // TODO - testing
-// TODO - wide view
-// TODO - add timing information to the display - how long it took to query/parse the stats
+// TODO - yaml, json
 
 var topCmd = &cobra.Command{
 	Use:     "top",
@@ -58,11 +59,16 @@ var topCmd = &cobra.Command{
 		if ns == "" {
 			ns = utils.GetDefaultNamespace()
 		}
+		output, err := cmd.Flags().GetString("out")
+		if err != nil {
+			logrus.Fatal(err.Error())
+		}
 
 		apiV1Client := utils.GetClientOutOfCluster()
 		kubelessClient, err := utils.GetKubelessClientOutCluster()
+		handler := &PrometheusMetricsHandler{metricsPath: "/metrics"}
 
-		err = doTop(cmd.OutOrStdout(), kubelessClient, apiV1Client, ns, functionName, args)
+		err = doTop(cmd.OutOrStdout(), kubelessClient, apiV1Client, handler, ns, functionName, output)
 		if err != nil {
 			logrus.Fatal(err.Error())
 		}
@@ -70,16 +76,27 @@ var topCmd = &cobra.Command{
 }
 
 type functionMetrics struct {
-	functionName       string
-	namespace          string
-	functionRawMetrics string
+	FunctionName       string `json:"function_name,omitempty"`
+	Namespace          string `json:"namespace,omitempty"`
+	FunctionRawMetrics string `json:"function_raw_metrics,omitempty"`
 	// map[METHOD][METRIC_NAME]
-	metricsMap map[string]map[string]float64
+	MetricsMap map[string]map[string]float64 `json:",omitempty"`
 }
 
 func init() {
 	topCmd.Flags().StringP("namespace", "n", "", "Specify namespace for the function")
 	topCmd.Flags().StringP("function", "f", "", "Specify the function")
+	topCmd.Flags().StringP("out", "o", "", "Output format. One of: json|yaml")
+}
+
+// MetricsRetriever is an interface for retreiving metrics from an endpoint
+type MetricsRetriever interface {
+	getMetrics(kubernetes.Interface, string, string, string) ([]byte, error)
+}
+
+// PrometheusMetricsHandler is a handler for retreiving metrics from Prometheus
+type PrometheusMetricsHandler struct {
+	metricsPath string
 }
 
 func getFunctions(kubelessClient versioned.Interface, namespace, functionName string) ([]*kubelessApi.Function, error) {
@@ -104,23 +121,25 @@ func getFunctions(kubelessClient versioned.Interface, namespace, functionName st
 
 func parseMetrics(metrics *functionMetrics) error {
 	parser := expfmt.TextParser{}
-	parsedData, err := parser.TextToMetricFamilies(strings.NewReader(metrics.functionRawMetrics))
+	parsedData, err := parser.TextToMetricFamilies(strings.NewReader(metrics.FunctionRawMetrics))
 	if err != nil {
+		fmt.Printf("error while parsing metrics ", err)
 		return err
 	}
 
 	metricsOfInterest := []string{"function_duration_seconds", "function_calls_total", "function_failures_total"}
 	for _, m := range metricsOfInterest {
 		for _, metric := range parsedData[m].GetMetric() {
+			// a function can have metrics for each method (GET, POST, etc.) - group metrics by method and show a single line per method
 			for _, label := range metric.GetLabel() {
 				if label.GetName() == "method" {
-					if metrics.metricsMap[label.GetValue()] == nil {
-						metrics.metricsMap[label.GetValue()] = make(map[string]float64)
+					if metrics.MetricsMap[label.GetValue()] == nil {
+						metrics.MetricsMap[label.GetValue()] = make(map[string]float64)
 					}
 					if m == "function_duration_seconds" {
-						metrics.metricsMap[label.GetValue()][m] = metric.GetHistogram().GetSampleSum()
+						metrics.MetricsMap[label.GetValue()][m] = metric.GetHistogram().GetSampleSum()
 					} else {
-						metrics.metricsMap[label.GetValue()][m] = metric.GetCounter().GetValue()
+						metrics.MetricsMap[label.GetValue()][m] = metric.GetCounter().GetValue()
 					}
 				}
 			}
@@ -130,38 +149,50 @@ func parseMetrics(metrics *functionMetrics) error {
 }
 
 func calculateMetrics(metrics *functionMetrics) {
-	for _, v := range metrics.metricsMap {
+	for _, v := range metrics.MetricsMap {
 		if v["function_calls_total"] > 0 {
 			v["function_average_duration_seconds"] = v["function_duration_seconds"] / v["function_calls_total"]
 		}
 	}
 }
 
-func getFunctionMetrics(apiV1Client kubernetes.Interface, namespace, functionName string, responseChan chan functionMetrics) {
-	metrics := functionMetrics{}
-	metrics.functionName = functionName
-	metrics.namespace = namespace
-	metrics.metricsMap = make(map[string]map[string]float64)
-	svc, err := apiV1Client.CoreV1().Services(namespace).Get(functionName, metav1.GetOptions{})
-	if err != nil {
-		responseChan <- metrics
-		return
-	}
-	port := strconv.Itoa(int(svc.Spec.Ports[0].Port))
-	req := apiV1Client.CoreV1().RESTClient().Get().Namespace(namespace).Resource("services").SubResource("proxy").Name(functionName + ":" + port).Suffix("/metrics")
+func (h *PrometheusMetricsHandler) getMetrics(apiV1Client kubernetes.Interface, namespace, functionName, port string) ([]byte, error) {
+	req := apiV1Client.CoreV1().RESTClient().Get().Namespace(namespace).Resource("services").SubResource("proxy").Name(functionName + ":" + port).Suffix(h.metricsPath)
 	res, err := req.Do().Raw()
 	if err != nil {
-		responseChan <- metrics
-		return
+		return []byte{}, err
 	}
-	metrics.functionRawMetrics = string(res)
-
-	_ = parseMetrics(&metrics)
-	calculateMetrics(&metrics)
-	responseChan <- metrics
+	return res, nil
 }
 
-func doTop(w io.Writer, kubelessClient versioned.Interface, apiV1Client kubernetes.Interface, ns, functionName string, args []string) error {
+func getFunctionMetrics(apiV1Client kubernetes.Interface, h MetricsRetriever, namespace, functionName string) functionMetrics {
+	metrics := functionMetrics{}
+	metrics.FunctionName = functionName
+	metrics.Namespace = namespace
+	metrics.MetricsMap = make(map[string]map[string]float64)
+	svc, err := apiV1Client.CoreV1().Services(namespace).Get(functionName, metav1.GetOptions{})
+	if err != nil {
+		return metrics
+	}
+
+	port := strconv.Itoa(int(svc.Spec.Ports[0].Port))
+	if svc.Spec.Ports[0].Name != "" {
+		port = svc.Spec.Ports[0].Name
+	}
+	res, err := h.getMetrics(apiV1Client, namespace, functionName, port)
+
+	if err != nil {
+		return metrics
+	}
+	metrics.FunctionRawMetrics = string(res)
+
+	// swallow the error if metrics parsing fails - display will show the function name but no metrics
+	_ = parseMetrics(&metrics)
+	calculateMetrics(&metrics)
+	return metrics
+}
+
+func doTop(w io.Writer, kubelessClient versioned.Interface, apiV1Client kubernetes.Interface, handler MetricsRetriever, ns, functionName, output string) error {
 	functions, err := getFunctions(kubelessClient, ns, functionName)
 	if err != nil {
 		return fmt.Errorf("Error listing functions: %v", err)
@@ -170,44 +201,67 @@ func doTop(w io.Writer, kubelessClient versioned.Interface, apiV1Client kubernet
 	var metrics []functionMetrics
 	ch := make(chan functionMetrics, len(functions))
 	for _, f := range functions {
-		go getFunctionMetrics(apiV1Client, ns, f.ObjectMeta.Name, ch)
+		go func(f *kubelessApi.Function) {
+			ch <- getFunctionMetrics(apiV1Client, handler, ns, f.ObjectMeta.Name)
+		}(f)
 	}
 
-loop:
+metricsLoop:
 	for len(metrics) < len(functions) {
 		select {
 		case r := <-ch:
 			metrics = append(metrics, r)
+		// timeout all go routines after 5 seconds to avoid hanging at the cmd line
 		case <-time.After(5 * time.Second):
-			break loop
+			break metricsLoop
 		}
 	}
 
-	sort.Slice(metrics, func(i, j int) bool { return metrics[i].functionName < metrics[j].functionName })
-	return printTop(w, metrics, apiV1Client)
+	// sort the results - useful when using 'watch kubeless function top'
+	sort.Slice(metrics, func(i, j int) bool { return metrics[i].FunctionName < metrics[j].FunctionName })
+	return printTop(w, metrics, apiV1Client, output)
 }
 
-func printTop(w io.Writer, metrics []functionMetrics, cli kubernetes.Interface) error {
-	table := uitable.New()
-	table.MaxColWidth = 50
-	table.Wrap = true
-	table.AddRow("NAME", "NAMESPACE", "METHOD", "TOTAL_CALLS", "TOTAL_FAILURES", "DURATION_SECONDS", "AVG_DURATION_SECONDS")
-	for _, f := range metrics {
-		n := f.functionName
-		ns := f.namespace
-		if len(f.metricsMap) > 0 {
-			for k, metrics := range f.metricsMap {
-				method := k
-				totalCalls := strconv.FormatFloat(metrics["function_calls_total"], 'f', -1, 32)
-				durationSeconds := strconv.FormatFloat(metrics["function_duration_seconds"], 'f', -1, 32)
-				totalFailures := strconv.FormatFloat(metrics["function_failures_total"], 'f', -1, 32)
-				avgDuration := strconv.FormatFloat(metrics["function_average_duration_seconds"], 'f', -1, 32)
-				table.AddRow(n, ns, method, totalCalls, totalFailures, durationSeconds, avgDuration)
+func printTop(w io.Writer, metrics []functionMetrics, cli kubernetes.Interface, output string) error {
+	if output == "" {
+		table := uitable.New()
+		table.MaxColWidth = 50
+		table.Wrap = true
+		table.AddRow("NAME", "NAMESPACE", "METHOD", "TOTAL_CALLS", "TOTAL_FAILURES", "TOTAL_DURATION_SECONDS", "AVG_DURATION_SECONDS")
+		for _, f := range metrics {
+			n := f.FunctionName
+			ns := f.Namespace
+			if len(f.MetricsMap) > 0 {
+				for k, metrics := range f.MetricsMap {
+					method := k
+					totalCalls := strconv.FormatFloat(metrics["function_calls_total"], 'f', -1, 32)
+					durationSeconds := strconv.FormatFloat(metrics["function_duration_seconds"], 'f', -1, 32)
+					totalFailures := strconv.FormatFloat(metrics["function_failures_total"], 'f', -1, 32)
+					avgDuration := strconv.FormatFloat(metrics["function_average_duration_seconds"], 'f', -1, 32)
+					table.AddRow(n, ns, method, totalCalls, totalFailures, durationSeconds, avgDuration)
+				}
+			} else {
+				table.AddRow(n, ns)
 			}
-		} else {
-			table.AddRow(n, ns)
+		}
+		fmt.Fprintln(w, table)
+	} else {
+		switch output {
+		case "json":
+			b, err := json.MarshalIndent(metrics, "", "  ")
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(w, string(b))
+		case "yaml":
+			b, err := yaml.Marshal(metrics)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(w, string(b))
+		default:
+			return fmt.Errorf("Wrong output format. Please use only json|yaml")
 		}
 	}
-	fmt.Fprintln(w, table)
 	return nil
 }

--- a/cmd/kubeless/function/top.go
+++ b/cmd/kubeless/function/top.go
@@ -1,0 +1,213 @@
+/*
+Copyright (c) 2016-2017 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package function
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/gosuri/uitable"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes"
+
+	kubelessApi "github.com/kubeless/kubeless/pkg/apis/kubeless/v1beta1"
+	"github.com/kubeless/kubeless/pkg/client/clientset/versioned"
+	"github.com/kubeless/kubeless/pkg/utils"
+
+	"github.com/prometheus/common/expfmt"
+)
+
+// TODO - testing
+// TODO - wide view
+// TODO - add timing information to the display - how long it took to query/parse the stats
+
+var topCmd = &cobra.Command{
+	Use:     "top",
+	Aliases: []string{"stats"},
+	Short:   "display function metrics",
+	Long:    `display function metrics`,
+	Run: func(cmd *cobra.Command, args []string) {
+		functionName, err := cmd.Flags().GetString("function")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		ns, err := cmd.Flags().GetString("namespace")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		if ns == "" {
+			ns = utils.GetDefaultNamespace()
+		}
+
+		apiV1Client := utils.GetClientOutOfCluster()
+		kubelessClient, err := utils.GetKubelessClientOutCluster()
+
+		err = doTop(cmd.OutOrStdout(), kubelessClient, apiV1Client, ns, functionName, args)
+		if err != nil {
+			logrus.Fatal(err.Error())
+		}
+	},
+}
+
+type functionMetrics struct {
+	functionName       string
+	namespace          string
+	functionRawMetrics string
+	// map[METHOD][METRIC_NAME]
+	metricsMap map[string]map[string]float64
+}
+
+func init() {
+	topCmd.Flags().StringP("namespace", "n", "", "Specify namespace for the function")
+	topCmd.Flags().StringP("function", "f", "", "Specify the function")
+}
+
+func getFunctions(kubelessClient versioned.Interface, namespace, functionName string) ([]*kubelessApi.Function, error) {
+	var functionList *kubelessApi.FunctionList
+	var f *kubelessApi.Function
+	var err error
+	if functionName == "" {
+		functionList, err = kubelessClient.KubelessV1beta1().Functions(namespace).List(metav1.ListOptions{})
+	} else {
+		f, err = kubelessClient.KubelessV1beta1().Functions(namespace).Get(functionName, metav1.GetOptions{})
+		functionList = &kubelessApi.FunctionList{
+			Items: []*kubelessApi.Function{
+				f,
+			},
+		}
+	}
+	if err != nil {
+		return []*kubelessApi.Function{}, err
+	}
+	return functionList.Items, nil
+}
+
+func parseMetrics(metrics *functionMetrics) error {
+	parser := expfmt.TextParser{}
+	parsedData, err := parser.TextToMetricFamilies(strings.NewReader(metrics.functionRawMetrics))
+	if err != nil {
+		return err
+	}
+
+	metricsOfInterest := []string{"function_duration_seconds", "function_calls_total", "function_failures_total"}
+	for _, m := range metricsOfInterest {
+		for _, metric := range parsedData[m].GetMetric() {
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == "method" {
+					if metrics.metricsMap[label.GetValue()] == nil {
+						metrics.metricsMap[label.GetValue()] = make(map[string]float64)
+					}
+					if m == "function_duration_seconds" {
+						metrics.metricsMap[label.GetValue()][m] = metric.GetHistogram().GetSampleSum()
+					} else {
+						metrics.metricsMap[label.GetValue()][m] = metric.GetCounter().GetValue()
+					}
+				}
+			}
+		}
+	}
+	return nil
+}
+
+func calculateMetrics(metrics *functionMetrics) {
+	for _, v := range metrics.metricsMap {
+		if v["function_calls_total"] > 0 {
+			v["function_average_duration_seconds"] = v["function_duration_seconds"] / v["function_calls_total"]
+		}
+	}
+}
+
+func getFunctionMetrics(apiV1Client kubernetes.Interface, namespace, functionName string, responseChan chan functionMetrics) {
+	metrics := functionMetrics{}
+	metrics.functionName = functionName
+	metrics.namespace = namespace
+	metrics.metricsMap = make(map[string]map[string]float64)
+	svc, err := apiV1Client.CoreV1().Services(namespace).Get(functionName, metav1.GetOptions{})
+	if err != nil {
+		responseChan <- metrics
+		return
+	}
+	port := strconv.Itoa(int(svc.Spec.Ports[0].Port))
+	req := apiV1Client.CoreV1().RESTClient().Get().Namespace(namespace).Resource("services").SubResource("proxy").Name(functionName + ":" + port).Suffix("/metrics")
+	res, err := req.Do().Raw()
+	if err != nil {
+		responseChan <- metrics
+		return
+	}
+	metrics.functionRawMetrics = string(res)
+
+	_ = parseMetrics(&metrics)
+	calculateMetrics(&metrics)
+	responseChan <- metrics
+}
+
+func doTop(w io.Writer, kubelessClient versioned.Interface, apiV1Client kubernetes.Interface, ns, functionName string, args []string) error {
+	functions, err := getFunctions(kubelessClient, ns, functionName)
+	if err != nil {
+		return fmt.Errorf("Error listing functions: %v", err)
+	}
+
+	var metrics []functionMetrics
+	ch := make(chan functionMetrics, len(functions))
+	for _, f := range functions {
+		go getFunctionMetrics(apiV1Client, ns, f.ObjectMeta.Name, ch)
+	}
+
+loop:
+	for len(metrics) < len(functions) {
+		select {
+		case r := <-ch:
+			metrics = append(metrics, r)
+		case <-time.After(5 * time.Second):
+			break loop
+		}
+	}
+
+	sort.Slice(metrics, func(i, j int) bool { return metrics[i].functionName < metrics[j].functionName })
+	return printTop(w, metrics, apiV1Client)
+}
+
+func printTop(w io.Writer, metrics []functionMetrics, cli kubernetes.Interface) error {
+	table := uitable.New()
+	table.MaxColWidth = 50
+	table.Wrap = true
+	table.AddRow("NAME", "NAMESPACE", "METHOD", "TOTAL_CALLS", "TOTAL_FAILURES", "DURATION_SECONDS", "AVG_DURATION_SECONDS")
+	for _, f := range metrics {
+		n := f.functionName
+		ns := f.namespace
+		if len(f.metricsMap) > 0 {
+			for k, metrics := range f.metricsMap {
+				method := k
+				totalCalls := strconv.FormatFloat(metrics["function_calls_total"], 'f', -1, 32)
+				durationSeconds := strconv.FormatFloat(metrics["function_duration_seconds"], 'f', -1, 32)
+				totalFailures := strconv.FormatFloat(metrics["function_failures_total"], 'f', -1, 32)
+				avgDuration := strconv.FormatFloat(metrics["function_average_duration_seconds"], 'f', -1, 32)
+				table.AddRow(n, ns, method, totalCalls, totalFailures, durationSeconds, avgDuration)
+			}
+		} else {
+			table.AddRow(n, ns)
+		}
+	}
+	fmt.Fprintln(w, table)
+	return nil
+}

--- a/cmd/kubeless/function/top_test.go
+++ b/cmd/kubeless/function/top_test.go
@@ -1,0 +1,449 @@
+/*
+Copyright (c) 2016-2017 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package function
+
+import (
+	"bytes"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"k8s.io/api/core/v1"
+	"k8s.io/api/extensions/v1beta1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
+
+	kubelessApi "github.com/kubeless/kubeless/pkg/apis/kubeless/v1beta1"
+	"github.com/kubeless/kubeless/pkg/client/clientset/versioned"
+	fFake "github.com/kubeless/kubeless/pkg/client/clientset/versioned/fake"
+)
+
+type testMetricsHandler struct{}
+
+// handler used for testing purposes only
+// satisfies the MetricsRetriever interface, gets metrics from the test http server (URL to test http server stored in svc.SelfLink field)
+func (h *testMetricsHandler) getMetrics(apiClient kubernetes.Interface, namespace, functionName, _ string) ([]byte, error) {
+	svc, err := apiClient.CoreV1().Services(namespace).Get(functionName, metav1.GetOptions{})
+	if err != nil {
+		return []byte{}, err
+	}
+	b, err := http.Get(svc.SelfLink)
+	if err != nil {
+		return nil, err
+	}
+	defer b.Body.Close()
+	body, err := ioutil.ReadAll(b.Body)
+	return body, nil
+}
+
+func topOutput(t *testing.T, client versioned.Interface, apiV1Client kubernetes.Interface, h MetricsRetriever, ns, functionName, output string) string {
+	var buf bytes.Buffer
+
+	if err := doTop(&buf, client, apiV1Client, h, ns, functionName, output); err != nil {
+		t.Fatalf("doTop returned error: %v", err)
+	}
+
+	return buf.String()
+}
+
+// DONE - multiple methods
+// DONE - multiple functions
+// DONE - single function
+// different namespace
+// DONE - json/yaml
+
+func TestTop(t *testing.T) {
+
+	// setup test server to serve the /metrics endpoint
+	ts2 := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w,
+			`# HELP go_gc_duration_seconds A summary of the GC invocation durations.
+			# TYPE go_gc_duration_seconds summary
+			go_gc_duration_seconds{quantile="0"} 1.6846e-05
+			go_gc_duration_seconds{quantile="0.25"} 3.9124e-05
+			go_gc_duration_seconds{quantile="0.5"} 0.000147183
+			go_gc_duration_seconds{quantile="0.75"} 0.000958419
+			go_gc_duration_seconds{quantile="1"} 0.00796035
+			go_gc_duration_seconds_sum 2.50781303
+			go_gc_duration_seconds_count 3424
+			# HELP go_goroutines Number of goroutines that currently exist.
+			# TYPE go_goroutines gauge
+			go_goroutines 7
+			# HELP go_info Information about the Go environment.
+			# TYPE go_info gauge
+			go_info{version="go1.10.2"} 1
+			# HELP go_memstats_alloc_bytes Number of bytes allocated and still in use.
+			# TYPE go_memstats_alloc_bytes gauge
+			go_memstats_alloc_bytes 2.28336e+06
+			# HELP go_memstats_alloc_bytes_total Total number of bytes allocated, even if freed.
+			# TYPE go_memstats_alloc_bytes_total counter
+			go_memstats_alloc_bytes_total 9.9682544e+09
+			# HELP go_memstats_buck_hash_sys_bytes Number of bytes used by the profiling bucket hash table.
+			# TYPE go_memstats_buck_hash_sys_bytes gauge
+			go_memstats_buck_hash_sys_bytes 1.500081e+06
+			# HELP go_memstats_frees_total Total number of frees.
+			# TYPE go_memstats_frees_total counter
+			go_memstats_frees_total 1.2698678e+07
+			# HELP go_memstats_gc_cpu_fraction The fraction of this program's available CPU time used by the GC since the program started.
+			# TYPE go_memstats_gc_cpu_fraction gauge
+			go_memstats_gc_cpu_fraction 0.0001214506861340198
+			# HELP go_memstats_gc_sys_bytes Number of bytes used for garbage collection system metadata.
+			# TYPE go_memstats_gc_sys_bytes gauge
+			go_memstats_gc_sys_bytes 405504
+			# HELP go_memstats_heap_alloc_bytes Number of heap bytes allocated and still in use.
+			# TYPE go_memstats_heap_alloc_bytes gauge
+			go_memstats_heap_alloc_bytes 2.28336e+06
+			# HELP go_memstats_heap_idle_bytes Number of heap bytes waiting to be used.
+			# TYPE go_memstats_heap_idle_bytes gauge
+			go_memstats_heap_idle_bytes 2.6624e+06
+			# HELP go_memstats_heap_inuse_bytes Number of heap bytes that are in use.
+			# TYPE go_memstats_heap_inuse_bytes gauge
+			go_memstats_heap_inuse_bytes 3.072e+06
+			# HELP go_memstats_heap_objects Number of allocated objects.
+			# TYPE go_memstats_heap_objects gauge
+			go_memstats_heap_objects 6280
+			# HELP go_memstats_heap_released_bytes Number of heap bytes released to OS.
+			# TYPE go_memstats_heap_released_bytes gauge
+			go_memstats_heap_released_bytes 0
+			# HELP go_memstats_heap_sys_bytes Number of heap bytes obtained from system.
+			# TYPE go_memstats_heap_sys_bytes gauge
+			go_memstats_heap_sys_bytes 5.7344e+06
+			# HELP go_memstats_last_gc_time_seconds Number of seconds since 1970 of last garbage collection.
+			# TYPE go_memstats_last_gc_time_seconds gauge
+			go_memstats_last_gc_time_seconds 1.528573398809276e+09
+			# HELP go_memstats_lookups_total Total number of pointer lookups.
+			# TYPE go_memstats_lookups_total counter
+			go_memstats_lookups_total 88701
+			# HELP go_memstats_mallocs_total Total number of mallocs.
+			# TYPE go_memstats_mallocs_total counter
+			go_memstats_mallocs_total 1.2704958e+07
+			# HELP go_memstats_mcache_inuse_bytes Number of bytes in use by mcache structures.
+			# TYPE go_memstats_mcache_inuse_bytes gauge
+			go_memstats_mcache_inuse_bytes 3472
+			# HELP go_memstats_mcache_sys_bytes Number of bytes used for mcache structures obtained from system.
+			# TYPE go_memstats_mcache_sys_bytes gauge
+			go_memstats_mcache_sys_bytes 16384
+			# HELP go_memstats_mspan_inuse_bytes Number of bytes in use by mspan structures.
+			# TYPE go_memstats_mspan_inuse_bytes gauge
+			go_memstats_mspan_inuse_bytes 25688
+			# HELP go_memstats_mspan_sys_bytes Number of bytes used for mspan structures obtained from system.
+			# TYPE go_memstats_mspan_sys_bytes gauge
+			go_memstats_mspan_sys_bytes 32768
+			# HELP go_memstats_next_gc_bytes Number of heap bytes when next garbage collection will take place.
+			# TYPE go_memstats_next_gc_bytes gauge
+			go_memstats_next_gc_bytes 4.194304e+06
+			# HELP go_memstats_other_sys_bytes Number of bytes used for other system allocations.
+			# TYPE go_memstats_other_sys_bytes gauge
+			go_memstats_other_sys_bytes 738631
+			# HELP go_memstats_stack_inuse_bytes Number of bytes in use by the stack allocator.
+			# TYPE go_memstats_stack_inuse_bytes gauge
+			go_memstats_stack_inuse_bytes 557056
+			# HELP go_memstats_stack_sys_bytes Number of bytes obtained from system for stack allocator.
+			# TYPE go_memstats_stack_sys_bytes gauge
+			go_memstats_stack_sys_bytes 557056
+			# HELP go_memstats_sys_bytes Number of bytes obtained from system.
+			# TYPE go_memstats_sys_bytes gauge
+			go_memstats_sys_bytes 8.984824e+06
+			# HELP go_threads Number of OS threads created.
+			# TYPE go_threads gauge
+			go_threads 10
+			# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+			# TYPE process_cpu_seconds_total counter
+			process_cpu_seconds_total 25.88
+			# HELP process_max_fds Maximum number of open file descriptors.
+			# TYPE process_max_fds gauge
+			process_max_fds 1.048576e+06
+			# HELP process_open_fds Number of open file descriptors.
+			# TYPE process_open_fds gauge
+			process_open_fds 8
+			# HELP process_resident_memory_bytes Resident memory size in bytes.
+			# TYPE process_resident_memory_bytes gauge
+			process_resident_memory_bytes 1.3942784e+07
+			# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+			# TYPE process_start_time_seconds gauge
+			process_start_time_seconds 1.52853941225e+09
+			# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+			# TYPE process_virtual_memory_bytes gauge
+			process_virtual_memory_bytes 1.57294592e+08
+			# HELP promhttp_metric_handler_requests_in_flight Current number of scrapes being served.
+			# TYPE promhttp_metric_handler_requests_in_flight gauge
+			promhttp_metric_handler_requests_in_flight 1
+			# HELP promhttp_metric_handler_requests_total Total number of scrapes by HTTP status code.
+			# TYPE promhttp_metric_handler_requests_total counter
+			promhttp_metric_handler_requests_total{code="200"} 10798
+			promhttp_metric_handler_requests_total{code="500"} 0
+			promhttp_metric_handler_requests_total{code="503"} 0			
+
+`)
+	}))
+	defer ts2.Close()
+
+	// setup test server to serve the /metrics endpoint
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fmt.Fprint(w,
+			`# HELP process_virtual_memory_bytes Virtual memory size in bytes.
+			# TYPE process_virtual_memory_bytes gauge
+			process_virtual_memory_bytes 815255552.0
+			# HELP process_resident_memory_bytes Resident memory size in bytes.
+			# TYPE process_resident_memory_bytes gauge
+			process_resident_memory_bytes 25001984.0
+			# HELP process_start_time_seconds Start time of the process since unix epoch in seconds.
+			# TYPE process_start_time_seconds gauge
+			process_start_time_seconds 1528507334.03
+			# HELP process_cpu_seconds_total Total user and system CPU time spent in seconds.
+			# TYPE process_cpu_seconds_total counter
+			process_cpu_seconds_total 54.72
+			# HELP process_open_fds Number of open file descriptors.
+			# TYPE process_open_fds gauge
+			process_open_fds 8.0
+			# HELP process_max_fds Maximum number of open file descriptors.
+			# TYPE process_max_fds gauge
+			process_max_fds 1048576.0
+			# HELP python_info Python platform information
+			# TYPE python_info gauge
+			python_info{implementation="CPython",major="2",minor="7",patchlevel="9",version="2.7.9"} 1.0
+			# HELP function_failures_total Number of exceptions in user function
+			# TYPE function_failures_total counter
+			function_failures_total{method="GET"} 0.0
+			function_failures_total{method="POST"} 0.0
+			# HELP function_calls_total Number of calls to user function
+			# TYPE function_calls_total counter
+			function_calls_total{method="GET"} 254.0
+			function_calls_total{method="POST"} 296.0
+			# HELP function_duration_seconds Duration of user function in seconds
+			# TYPE function_duration_seconds histogram
+			function_duration_seconds_bucket{le="0.005",method="GET"} 8.0
+			function_duration_seconds_bucket{le="0.01",method="GET"} 191.0
+			function_duration_seconds_bucket{le="0.025",method="GET"} 248.0
+			function_duration_seconds_bucket{le="0.05",method="GET"} 253.0
+			function_duration_seconds_bucket{le="0.075",method="GET"} 253.0
+			function_duration_seconds_bucket{le="0.1",method="GET"} 253.0
+			function_duration_seconds_bucket{le="0.25",method="GET"} 254.0
+			function_duration_seconds_bucket{le="0.5",method="GET"} 254.0
+			function_duration_seconds_bucket{le="0.75",method="GET"} 254.0
+			function_duration_seconds_bucket{le="1.0",method="GET"} 254.0
+			function_duration_seconds_bucket{le="2.5",method="GET"} 254.0
+			function_duration_seconds_bucket{le="5.0",method="GET"} 254.0
+			function_duration_seconds_bucket{le="7.5",method="GET"} 254.0
+			function_duration_seconds_bucket{le="10.0",method="GET"} 254.0
+			function_duration_seconds_bucket{le="+Inf",method="GET"} 254.0
+			function_duration_seconds_count{method="GET"} 254.0
+			function_duration_seconds_sum{method="GET"} 2.863368272781372
+			function_duration_seconds_bucket{le="0.005",method="POST"} 1.0
+			function_duration_seconds_bucket{le="0.01",method="POST"} 157.0
+			function_duration_seconds_bucket{le="0.025",method="POST"} 296.0
+			function_duration_seconds_bucket{le="0.05",method="POST"} 296.0
+			function_duration_seconds_bucket{le="0.075",method="POST"} 296.0
+			function_duration_seconds_bucket{le="0.1",method="POST"} 296.0
+			function_duration_seconds_bucket{le="0.25",method="POST"} 296.0
+			function_duration_seconds_bucket{le="0.5",method="POST"} 296.0
+			function_duration_seconds_bucket{le="0.75",method="POST"} 296.0
+			function_duration_seconds_bucket{le="1.0",method="POST"} 296.0
+			function_duration_seconds_bucket{le="2.5",method="POST"} 296.0
+			function_duration_seconds_bucket{le="5.0",method="POST"} 296.0
+			function_duration_seconds_bucket{le="7.5",method="POST"} 296.0
+			function_duration_seconds_bucket{le="10.0",method="POST"} 296.0
+			function_duration_seconds_bucket{le="+Inf",method="POST"} 296.0
+			function_duration_seconds_count{method="POST"} 296.0
+			function_duration_seconds_sum{method="POST"} 3.4116291999816895
+
+`)
+	}))
+	defer ts.Close()
+
+	function1Name := "pyFunc"
+	function2Name := "goFunc"
+	namespace := "myns"
+
+	listObj := kubelessApi.FunctionList{
+		Items: []*kubelessApi.Function{
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      function1Name,
+					Namespace: namespace,
+				},
+				Spec: kubelessApi.FunctionSpec{
+					Handler:  "fhandler",
+					Function: function1Name,
+					Runtime:  "pyruntime",
+					Deps:     "pydeps",
+					Deployment: v1beta1.Deployment{
+						Spec: v1beta1.DeploymentSpec{
+							Template: v1.PodTemplateSpec{
+								Spec: v1.PodSpec{
+									Containers: []v1.Container{{}},
+								},
+							},
+						},
+					},
+				},
+			},
+			{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      function2Name,
+					Namespace: namespace,
+				},
+				Spec: kubelessApi.FunctionSpec{
+					Handler:  "gohandler",
+					Function: function2Name,
+					Runtime:  "goruntime",
+					Deps:     "godeps",
+					Deployment: v1beta1.Deployment{
+						Spec: v1beta1.DeploymentSpec{
+							Template: v1.PodTemplateSpec{
+								Spec: v1.PodSpec{
+									Containers: []v1.Container{{}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	client := fFake.NewSimpleClientset(listObj.Items[0], listObj.Items[1])
+
+	deploymentPy := v1beta1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      function1Name,
+			Namespace: namespace,
+		},
+		Status: v1beta1.DeploymentStatus{
+			Replicas:      int32(1),
+			ReadyReplicas: int32(1),
+		},
+	}
+	deploymentGo := v1beta1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      function2Name,
+			Namespace: namespace,
+		},
+		Status: v1beta1.DeploymentStatus{
+			Replicas:      int32(1),
+			ReadyReplicas: int32(1),
+		},
+	}
+	serviceGo := v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      function2Name,
+			Namespace: namespace,
+			SelfLink:  ts2.URL,
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				v1.ServicePort{
+					Name:       "p1",
+					Port:       int32(8080),
+					TargetPort: intstr.FromInt(8080),
+					NodePort:   0,
+					Protocol:   v1.ProtocolTCP,
+				},
+			},
+		},
+	}
+	servicePy := v1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      function1Name,
+			Namespace: namespace,
+			SelfLink:  ts.URL,
+		},
+		Spec: v1.ServiceSpec{
+			Ports: []v1.ServicePort{
+				v1.ServicePort{
+					Name:       "p1",
+					Port:       int32(8080),
+					TargetPort: intstr.FromInt(8080),
+					NodePort:   0,
+					Protocol:   v1.ProtocolTCP,
+				},
+			},
+		},
+	}
+
+	apiV1Client := fake.NewSimpleClientset(&deploymentPy, &servicePy, &deploymentGo, &serviceGo)
+
+	handler := &testMetricsHandler{}
+
+	// List multiple functions
+	output := topOutput(t, client, apiV1Client, handler, namespace, "", "")
+	t.Log("output is", output)
+
+	if !strings.Contains(output, function1Name) || !strings.Contains(output, function2Name) || !strings.Contains(output, namespace) {
+		t.Errorf("table output didn't match FUNCTION or NAMESPACE")
+	}
+	if !strings.Contains(output, "GET") || !strings.Contains(output, "POST") {
+		t.Errorf("table output didn't match on METHOD")
+	}
+	if !strings.Contains(output, "2.86336") || !strings.Contains(output, "3.41162") {
+		t.Errorf("table output didn't match on TOTAL_DURATION_SECONDS")
+	}
+	// verify calculated fields
+	if !strings.Contains(output, "0.0112731") || !strings.Contains(output, "0.0115257") {
+		t.Errorf("table output didn't match on AVG_DURATION_SECONDS")
+	}
+
+	// Get single function
+	output = topOutput(t, client, apiV1Client, handler, namespace, function2Name, "")
+	t.Log("output is", output)
+
+	if strings.Contains(output, function1Name) || !strings.Contains(output, function2Name) || !strings.Contains(output, namespace) {
+		t.Errorf("table output didn't match FUNCTION or NAMESPACE")
+	}
+
+	// json output
+	output = topOutput(t, client, apiV1Client, handler, namespace, "", "json")
+	t.Log("output is", output)
+
+	if !strings.Contains(output, function1Name) || !strings.Contains(output, function2Name) || !strings.Contains(output, namespace) {
+		t.Errorf("table output didn't match FUNCTION or NAMESPACE")
+	}
+	if !strings.Contains(output, "GET") || !strings.Contains(output, "POST") {
+		t.Errorf("table output didn't match on METHOD")
+	}
+	if !strings.Contains(output, "2.86336") || !strings.Contains(output, "3.41162") {
+		t.Errorf("table output didn't match on TOTAL_DURATION_SECONDS")
+	}
+	// verify calculated fields
+	if !strings.Contains(output, "0.0112731") || !strings.Contains(output, "0.0115257") {
+		t.Errorf("table output didn't match on AVG_DURATION_SECONDS")
+	}
+
+	// yaml output
+	output = topOutput(t, client, apiV1Client, handler, namespace, "", "yaml")
+	t.Log("output is", output)
+
+	if !strings.Contains(output, function1Name) || !strings.Contains(output, function2Name) || !strings.Contains(output, namespace) {
+		t.Errorf("table output didn't match FUNCTION or NAMESPACE")
+	}
+	if !strings.Contains(output, "GET") || !strings.Contains(output, "POST") {
+		t.Errorf("table output didn't match on METHOD")
+	}
+	if !strings.Contains(output, "2.86336") || !strings.Contains(output, "3.41162") {
+		t.Errorf("table output didn't match on TOTAL_DURATION_SECONDS")
+	}
+	// verify calculated fields
+	if !strings.Contains(output, "0.0112731") || !strings.Contains(output, "0.0115257") {
+		t.Errorf("table output didn't match on AVG_DURATION_SECONDS")
+	}
+
+}

--- a/cmd/kubeless/function/top_test.go
+++ b/cmd/kubeless/function/top_test.go
@@ -41,7 +41,7 @@ type testMetricsHandler struct{}
 
 // handler used for testing purposes only
 // satisfies the MetricsRetriever interface, gets metrics from the test http server (URL to test http server stored in svc.SelfLink field)
-func (h *testMetricsHandler) getMetrics(apiClient kubernetes.Interface, namespace, functionName, _ string) ([]byte, error) {
+func (h *testMetricsHandler) getRawMetrics(apiClient kubernetes.Interface, namespace, functionName string) ([]byte, error) {
 	svc, err := apiClient.CoreV1().Services(namespace).Get(functionName, metav1.GetOptions{})
 	if err != nil {
 		return []byte{}, err
@@ -51,8 +51,7 @@ func (h *testMetricsHandler) getMetrics(apiClient kubernetes.Interface, namespac
 		return nil, err
 	}
 	defer b.Body.Close()
-	body, err := ioutil.ReadAll(b.Body)
-	return body, nil
+	return ioutil.ReadAll(b.Body)
 }
 
 func topOutput(t *testing.T, client versioned.Interface, apiV1Client kubernetes.Interface, h MetricsRetriever, ns, functionName, output string) string {
@@ -64,12 +63,6 @@ func topOutput(t *testing.T, client versioned.Interface, apiV1Client kubernetes.
 
 	return buf.String()
 }
-
-// DONE - multiple methods
-// DONE - multiple functions
-// DONE - single function
-// different namespace
-// DONE - json/yaml
 
 func TestTop(t *testing.T) {
 
@@ -191,7 +184,7 @@ func TestTop(t *testing.T) {
 			# TYPE promhttp_metric_handler_requests_total counter
 			promhttp_metric_handler_requests_total{code="200"} 10798
 			promhttp_metric_handler_requests_total{code="500"} 0
-			promhttp_metric_handler_requests_total{code="503"} 0			
+			promhttp_metric_handler_requests_total{code="503"} 0
 
 `)
 	}))
@@ -351,7 +344,7 @@ func TestTop(t *testing.T) {
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
-				v1.ServicePort{
+				{
 					Name:       "p1",
 					Port:       int32(8080),
 					TargetPort: intstr.FromInt(8080),
@@ -369,7 +362,7 @@ func TestTop(t *testing.T) {
 		},
 		Spec: v1.ServiceSpec{
 			Ports: []v1.ServicePort{
-				v1.ServicePort{
+				{
 					Name:       "p1",
 					Port:       int32(8080),
 					TargetPort: intstr.FromInt(8080),

--- a/cmd/kubeless/function/top_test.go
+++ b/cmd/kubeless/function/top_test.go
@@ -35,13 +35,14 @@ import (
 	kubelessApi "github.com/kubeless/kubeless/pkg/apis/kubeless/v1beta1"
 	"github.com/kubeless/kubeless/pkg/client/clientset/versioned"
 	fFake "github.com/kubeless/kubeless/pkg/client/clientset/versioned/fake"
+	"github.com/kubeless/kubeless/pkg/utils"
 )
 
 type testMetricsHandler struct{}
 
 // handler used for testing purposes only
 // satisfies the MetricsRetriever interface, gets metrics from the test http server (URL to test http server stored in svc.SelfLink field)
-func (h *testMetricsHandler) getRawMetrics(apiClient kubernetes.Interface, namespace, functionName string) ([]byte, error) {
+func (h *testMetricsHandler) GetRawMetrics(apiClient kubernetes.Interface, namespace, functionName string) ([]byte, error) {
 	svc, err := apiClient.CoreV1().Services(namespace).Get(functionName, metav1.GetOptions{})
 	if err != nil {
 		return []byte{}, err
@@ -54,7 +55,7 @@ func (h *testMetricsHandler) getRawMetrics(apiClient kubernetes.Interface, names
 	return ioutil.ReadAll(b.Body)
 }
 
-func topOutput(t *testing.T, client versioned.Interface, apiV1Client kubernetes.Interface, h MetricsRetriever, ns, functionName, output string) string {
+func topOutput(t *testing.T, client versioned.Interface, apiV1Client kubernetes.Interface, h utils.MetricsRetriever, ns, functionName, output string) string {
 	var buf bytes.Buffer
 
 	if err := doTop(&buf, client, apiV1Client, h, ns, functionName, output); err != nil {

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -3,7 +3,7 @@ get-python:
 
 get-python-verify:
 	kubeless function call get-python |egrep hello.world
-	kubeless function top --function get-python --out yaml | egrep total_calls.1
+	kubeless function top --function get-python --out yaml |egrep total_calls.*[1-100000]
 
 get-python-update:
 	$(eval TMPDIR := $(shell mktemp -d))

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -3,7 +3,7 @@ get-python:
 
 get-python-verify:
 	kubeless function call get-python |egrep hello.world
-	kubeless function top --function get-python | egrep function_calls_total.*1
+	kubeless function top --function get-python --out yaml | egrep total_calls.1
 
 get-python-update:
 	$(eval TMPDIR := $(shell mktemp -d))

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -3,6 +3,7 @@ get-python:
 
 get-python-verify:
 	kubeless function call get-python |egrep hello.world
+	kubeless function top --function get-python | egrep function_calls_total.*1
 
 get-python-update:
 	$(eval TMPDIR := $(shell mktemp -d))

--- a/pkg/utils/event_sender.go
+++ b/pkg/utils/event_sender.go
@@ -35,13 +35,23 @@ func IsJSON(s string) bool {
 
 }
 
+// GetFunctionPort returns the port for a function service
+func GetFunctionPort(clientset kubernetes.Interface, namespace, functionName string) (string, error) {
+	svc, err := clientset.CoreV1().Services(namespace).Get(functionName, metav1.GetOptions{})
+	if err != nil {
+		return "", fmt.Errorf("Unable to find the service for function %s", functionName)
+	}
+	return strconv.Itoa(int(svc.Spec.Ports[0].Port)), nil
+}
+
 // GetHTTPReq returns the http request object that can be used to send a event with payload to function service
 func GetHTTPReq(clientset kubernetes.Interface, funcName, namespace, eventNamespace, method, body string) (*http.Request, error) {
-	svc, err := clientset.CoreV1().Services(namespace).Get(funcName, metav1.GetOptions{})
+
+	funcPort, err := GetFunctionPort(clientset, namespace, funcName)
 	if err != nil {
-		return nil, fmt.Errorf("Unable to find the service for function %s", funcName)
+		return nil, err
 	}
-	funcPort := strconv.Itoa(int(svc.Spec.Ports[0].Port))
+
 	req, err := http.NewRequest(method, fmt.Sprintf("http://%s.%s.svc.cluster.local:%s", funcName, namespace, funcPort), strings.NewReader(body))
 	if err != nil {
 		return nil, fmt.Errorf("Unable to create request %v", err)

--- a/pkg/utils/metrics.go
+++ b/pkg/utils/metrics.go
@@ -1,0 +1,127 @@
+/*
+Copyright (c) 2016-2017 Bitnami
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package utils
+
+import (
+	"bytes"
+
+	"k8s.io/client-go/kubernetes"
+
+	"github.com/prometheus/common/expfmt"
+)
+
+// Metric contains metrics for a functions
+type Metric struct {
+	FunctionName         string  `json:"function,omitempty"`
+	Namespace            string  `json:"namespace,omitempty"`
+	Method               string  `json:"method,omitempty"`
+	TotalCalls           float64 `json:"total_calls,omitempty"`
+	TotalFailures        float64 `json:"total_failures,omitempty"`
+	TotalDurationSeconds float64 `json:"total_duration_seconds,omitempty"`
+	AvgDurationSeconds   float64 `json:"avg_duration_seconds,omitempty"`
+}
+
+// MetricsRetriever is an interface for retreiving metrics from an endpoint
+type MetricsRetriever interface {
+	GetRawMetrics(kubernetes.Interface, string, string) ([]byte, error)
+}
+
+// PrometheusMetricsHandler is a handler for retreiving metrics from Prometheus
+type PrometheusMetricsHandler struct{}
+
+func parseMetrics(namespace, functionName string, rawMetrics []byte) ([]*Metric, error) {
+	parser := expfmt.TextParser{}
+	parsedData, err := parser.TextToMetricFamilies(bytes.NewReader(rawMetrics))
+	if err != nil {
+		return nil, err
+	}
+
+	tmp := map[string]*Metric{}
+	var parsedMetrics []*Metric
+
+	metricsOfInterest := []string{"function_duration_seconds", "function_calls_total", "function_failures_total"}
+	for _, m := range metricsOfInterest {
+		for _, metric := range parsedData[m].GetMetric() {
+			// a function can have metrics for multiple methods (GET, POST, etc.)
+			// method names can be values other than GET/POST/PUT/DELETE
+			for _, label := range metric.GetLabel() {
+				if label.GetName() == "method" {
+					if _, ok := tmp[label.GetValue()]; !ok {
+						tmp[label.GetValue()] = &Metric{
+							FunctionName: functionName,
+							Namespace:    namespace,
+							Method:       label.GetValue(),
+						}
+					}
+					if m == "function_failures_total" {
+						tmp[label.GetValue()].TotalFailures = metric.GetCounter().GetValue()
+					}
+					if m == "function_duration_seconds" {
+						tmp[label.GetValue()].TotalDurationSeconds = metric.GetHistogram().GetSampleSum()
+					}
+					if m == "function_calls_total" {
+						tmp[label.GetValue()].TotalCalls = metric.GetCounter().GetValue()
+						if tmp[label.GetValue()].TotalCalls > 0 {
+							tmp[label.GetValue()].AvgDurationSeconds = float64(tmp[label.GetValue()].TotalDurationSeconds) / tmp[label.GetValue()].TotalCalls
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// if the funciton hasn't been invoked, add an item to the list so the function displays in the output
+	if len(tmp) == 0 {
+		tmp[""] = &Metric{
+			FunctionName: functionName,
+			Namespace:    namespace,
+		}
+	}
+
+	for _, v := range tmp {
+		parsedMetrics = append(parsedMetrics, v)
+	}
+
+	return parsedMetrics, nil
+}
+
+// GetRawMetrics returns the raw metrics for a Prometheus endpoint
+func (h *PrometheusMetricsHandler) GetRawMetrics(apiV1Client kubernetes.Interface, namespace, functionName string) ([]byte, error) {
+
+	port, err := GetFunctionPort(apiV1Client, namespace, functionName)
+	if err != nil {
+		return []byte{}, err
+	}
+
+	req := apiV1Client.CoreV1().RESTClient().Get().Namespace(namespace).Resource("services").SubResource("proxy").Name(functionName + ":" + port).Suffix("/metrics")
+	return req.Do().Raw()
+}
+
+// GetFunctionMetrics returns Prometheus metrics as a slice of *Metrics
+func GetFunctionMetrics(apiV1Client kubernetes.Interface, h MetricsRetriever, namespace, functionName string) []*Metric {
+
+	res, err := h.GetRawMetrics(apiV1Client, namespace, functionName)
+	if err != nil {
+		return []*Metric{}
+	}
+
+	metrics, err := parseMetrics(namespace, functionName, res)
+	if err != nil {
+		return []*Metric{}
+	}
+	return metrics
+}


### PR DESCRIPTION
**Issue Ref**: 
Fixes #375 
 
**Description**: 
Added the `top` (`stats` can also be used) command to the kubeless CLI for retrieving function statistics from Prometheus.
```
kubeless function top 
kubeless function stats --function get-python --namespace default --out json
```

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 - [ ] Docs
