### PR TITLE
Nodejs: make maximum request size configurable

### DIFF
--- a/docker/runtime/nodejs/kubeless.js
+++ b/docker/runtime/nodejs/kubeless.js
@@ -11,12 +11,17 @@ const express = require('express');
 const helper = require('./lib/helper');
 const morgan = require('morgan');
 
+const bodySizeLimit = Number(process.env.REQ_MB_LIMIT || '1');
+
 const app = express();
 app.use(morgan('combined'));
 const bodParserOptions = {
-    type: '*/*'
+    type: '*/*',
+    limit: `${bodySizeLimit}mb`,
 };
 app.use(bodyParser.raw(bodParserOptions));
+app.use(bodyParser.json({ limit: `${bodySizeLimit}mb` }));
+app.use(bodyParser.urlencoded({ limit: `${bodySizeLimit}mb`, extended: true }));
 
 const modName = process.env.MOD_NAME;
 const funcHandler = process.env.FUNC_HANDLER;

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -48,6 +48,15 @@ $ kubeless function deploy myFunction --runtime nodejs6 \
                                 --from-file test.js
 ```
 
+Depending on the size of the payload sent to the NodeJS function it is possible to find the error `413 PayloadTooLargeError`. It is possible to increase this limit setting the environment variable `REQ_MB_LIMIT`. This will define the maximum size in MB that the function will accept:
+
+```console
+$ kubeless function deploy myFunction --runtime nodejs6 \
+                                --env REQ_MB_LIMIT=50 \
+                                --handler test.foobar \
+                                --from-file test.js
+```
+
 #### Server implementation
 
 For the Node.js runtime we start an [Express](http://expressjs.com) server and we include the routes for serving the health check and exposing the monitoring metrics. Apart from that we enable [CORS](https://developer.mozilla.org/en-US/docs/Web/HTTP/Access_control_CORS) requests and [Morgan](https://github.com/expressjs/morgan) for handling the logging in the server. Monitoring is supported if the function is synchronous or if it uses promises.

--- a/kubeless-non-rbac.jsonnet
+++ b/kubeless-non-rbac.jsonnet
@@ -106,13 +106,13 @@ local runtime_images ='[
       {
         "name": "node6",
         "version": "6",
-        "runtimeImage": "kubeless/nodejs@sha256:0a8a72af4cc3bfbfd4fe9bd309cbf486e7493d0dc32a691673b3f0d3fae07487",
+        "runtimeImage": "kubeless/nodejs@sha256:013facddb0f66c150844192584d823d7dfb2b5b8d79fd2ae98439c86685da657",
         "initImage": "node:6.10"
       },
       {
         "name": "node8",
         "version": "8",
-        "runtimeImage": "kubeless/nodejs@sha256:76ee28dc7e3613845fface2d1c56afc2e6e2c6d6392c724795a7ccc2f5e60582",
+        "runtimeImage": "kubeless/nodejs@sha256:b155d7e20e333044b60009c12a25a97c84eed610f2a3d9d314b47449dbdae0e5",
         "initImage": "node:8"
       }
     ],


### PR DESCRIPTION
**Issue Ref**: Fixes #818
 
**Description**: 

Make the maximum size for the payloads received with the env var `REQ_MB_LIMIT`.

cc/ @cscheiber

**TODOs**:
 - [X] Ready to review
 - [ ] Automated Tests
 - [X] Docs