### PR TITLE
Docs: fix broken markdown links

### DIFF
--- a/docs/advanced-function-deployment.md
+++ b/docs/advanced-function-deployment.md
@@ -22,7 +22,7 @@ spec:
 
 The fields that a Function specification can contain are:
 
- - Runtime: Runtime ID and version that the function will use. It should match one of the availables in the [Kubeless configuration](/docs/function-controller-configuration).
+ - Runtime: Runtime ID and version that the function will use. It should match one of the availables in the [Kubeless configuration](/docs/function-controller-configuration.md).
  - Timeout: Maximum timeout for the given function. After that time, the function execution will be terminated.
  - Handler: Pair of `<file_name>.<function_name>`. When using `zip` in `function-content-type` the `<file_name>` will be used to find the file with the function to expose. In other case it will be used just as a final file name. `<function_name>` is used to select the function to run from the exported functions of `<file_name>`. This field is mandatory and should match with an exported function.
  - Deps: Dependencies of the function. The format of this field will depend on the runtime, e.g. a `package.json` for NodeJS functions or a `Gemfile` for Ruby.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -33,7 +33,7 @@ A _Trigger_ represents an event source the functions associated to it. When an e
 
 ### Runtime
 
-A _Runtime_ represents language and runtime specific environment in which function will be executed. Please see [runtimes](/docs/runtimes) for more details.
+A _Runtime_ represents language and runtime specific environment in which function will be executed. Please see [runtimes](/docs/runtimes.md) for more details.
 
 ## Design
 

--- a/docs/debug-functions.md
+++ b/docs/debug-functions.md
@@ -2,7 +2,7 @@
 
 In this document we will show how you can debug your function in order to spot possible errors. There could be several reasons that causes a wrong deployment. For learning how to successfully debug a function it is important to know what is the process of deploying a Kubeless function. In this guide we are going to assume that you are using the `kubeless` CLI tool to deploy your functions. If that is the case, this is the process to run a function:
 
- 1. The `kubeless` CLI read the parameters you give to it and produces a [Function](/docs/advanced-function-deployment) object that submits to the Kubernetes API server.
+ 1. The `kubeless` CLI read the parameters you give to it and produces a [Function](/docs/advanced-function-deployment.md) object that submits to the Kubernetes API server.
  2. The Kubeless Function Controller detects that a new `Function` has been created and reads its content. From the function content it generates: a `ConfigMap` with the function code and its dependencies, a `Service` to make the function reachable through HTTP and a `Deployment` with the base image and all the required steps to install and run your functions. It is important to know this order because if the controller fails to deploy the `ConfigMap` or the `Service` it will never create the `Deployment`. A failure in any step will abort the process.
  3. Once the `Deployment` has been created a `Pod` should be generated with your function. When a Pod starts it dinamically reads the content of your function (in case of interpreted languages).
 

--- a/docs/kubeless-functions.md
+++ b/docs/kubeless-functions.md
@@ -1,6 +1,6 @@
 # Kubeless Functions
 
-Functions are the main entity in Kubeless. It is possible to write Functions in different languages but all of them share common properties like the generic interface, the default timeout or the runtime UID. In this document we are going to explain some these common properties and different runtimes availables in Kubeless. You can find in depth details about the Function specification [here](/docs/advanced-function-deployment). 
+Functions are the main entity in Kubeless. It is possible to write Functions in different languages but all of them share common properties like the generic interface, the default timeout or the runtime UID. In this document we are going to explain some these common properties and different runtimes availables in Kubeless. You can find in depth details about the Function specification [here](/docs/advanced-function-deployment.md). 
 
 ## Functions Interface
 
@@ -54,4 +54,4 @@ Some Kubeless runtimes expose metrics at `/metrics` endpoint and these metrics w
 
 ## Runtime variants
 
-Check [this document](/docs/runtimes) to get more details about supported runtimes and languages.
+Check [this document](/docs/runtimes.md) to get more details about supported runtimes and languages.

--- a/docs/pubsub-functions.md
+++ b/docs/pubsub-functions.md
@@ -4,7 +4,7 @@ You can trigger any Kubeless function by a PubSub mechanism. The PubSub function
 
 ## Kafka
 
-In Kubeless [release page](https://github.com/kubeless/kubeless/releases), you can find the manifest to quickly deploy a collection of Kafka and Zookeeper statefulsets. If you have a Kafka cluster already running in the same Kubernetes environment, you can also deploy PubSub function with it. Check out [this tutorial](/docs/use-existing-kafka) for more details how to do that.
+In Kubeless [release page](https://github.com/kubeless/kubeless/releases), you can find the manifest to quickly deploy a collection of Kafka and Zookeeper statefulsets. If you have a Kafka cluster already running in the same Kubernetes environment, you can also deploy PubSub function with it. Check out [this tutorial](/docs/use-existing-kafka.md) for more details how to do that.
 
 If you want to deploy the manifest we provide to deploy Kafka and Zookeeper execute the following command:
 

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -407,7 +407,7 @@ Apart than changing the configuration, it is possible to use a custom runtime sp
  - It runs a web server listening in the port 8080
  - It exposes the endpoint `/healthz` to perform the container [liveness probe](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/)
 
-You can check the list of desired features that a runtime image should have [in this document](/docs/implementing-new-runtime).
+You can check the list of desired features that a runtime image should have [in this document](/docs/implementing-new-runtime.md).
 
 To deploy the container image you just need to specify it using the Kubeless CLI:
 

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -400,7 +400,7 @@ For the Ballerina runtime we start a [Ballerina HTTP server](../docker/runtime/b
 
 The Kubeless configuration defines a set of default container images per supported runtime variant.
 
-These default container images can be configured via Kubernetes environment variables on the Kubeless controller's deployment container. Or modifying the `kubeless-config` ConfigMap that is deployed along with the Kubeless controller. For more information about how to modify the Kubeless configuration check [this guide](/docs/function-controller-configuration).
+These default container images can be configured via Kubernetes environment variables on the Kubeless controller's deployment container. Or modifying the `kubeless-config` ConfigMap that is deployed along with the Kubeless controller. For more information about how to modify the Kubeless configuration check [this guide](/docs/function-controller-configuration.md).
 
 Apart than changing the configuration, it is possible to use a custom runtime specifying the image that the function will use. This way you are able to use any language or any binary with Kubeless as far as the image satisfies the following conditions:
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -38,4 +38,4 @@ zookeeper-zoo-0   Pending                                                     2m
 
 ```
 
-If you are running Kubernetes in GKE check the specific guide [here](/docs/GKE-deployment) to create the required disks and PVs. In other case, check the provider documentation of how to create these required volumes. Note that `kafka` and `zookeeper` are only needed when working with Kafka events, you can still use Kubeless to trigger functions using HTTP requests.
+If you are running Kubernetes in GKE check the specific guide [here](/docs/GKE-deployment.md) to create the required disks and PVs. In other case, check the provider documentation of how to create these required volumes. Note that `kafka` and `zookeeper` are only needed when working with Kafka events, you can still use Kubeless to trigger functions using HTTP requests.


### PR DESCRIPTION
**Issue Ref**: No existing issues found
 
**Description**: 
I noticed some relative links in the markdown docs were 404'ing. Just a couple quick fixes by appending `.md` to the link paths.
