### PR TITLE
kubeless function describe panic

### DIFF
--- a/cmd/kubeless/function/describe.go
+++ b/cmd/kubeless/function/describe.go
@@ -79,18 +79,24 @@ func print(f kubelessApi.Function, name, output string) error {
 		if err != nil {
 			return err
 		}
-		env, err := json.Marshal(f.Spec.Deployment.Spec.Template.Spec.Containers[0].Env)
-		if err != nil {
-			return err
+		var env, memory string
+		if len(f.Spec.Deployment.Spec.Template.Spec.Containers) != 0 {
+			b, err := json.Marshal(f.Spec.Deployment.Spec.Template.Spec.Containers[0].Env)
+			if err != nil {
+				return err
+			}
+			env = string(b)
+			memory = f.Spec.Deployment.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()
 		}
+
 		table.AddRow("Name:", name)
-		table.AddRow("Namespace:", fmt.Sprintf(f.ObjectMeta.Namespace))
-		table.AddRow("Handler:", fmt.Sprintf(f.Spec.Handler))
-		table.AddRow("Runtime:", fmt.Sprintf(f.Spec.Runtime))
-		table.AddRow("Label:", fmt.Sprintf(string(label)))
-		table.AddRow("Envvar:", fmt.Sprintf(string(env)))
-		table.AddRow("Memory:", fmt.Sprintf(f.Spec.Deployment.Spec.Template.Spec.Containers[0].Resources.Requests.Memory().String()))
-		table.AddRow("Dependencies:", fmt.Sprintf(f.Spec.Deps))
+		table.AddRow("Namespace:", f.ObjectMeta.Namespace)
+		table.AddRow("Handler:", f.Spec.Handler)
+		table.AddRow("Runtime:", f.Spec.Runtime)
+		table.AddRow("Label:", string(label))
+		table.AddRow("Envvar:", env)
+		table.AddRow("Memory:", memory)
+		table.AddRow("Dependencies:", f.Spec.Deps)
 		fmt.Println(table)
 	case "json":
 		b, err := json.MarshalIndent(f, "", "  ")


### PR DESCRIPTION

**Issue Ref**: [Issue number related to this PR or None]

None 

**Description**: 

bug fix : kubeless function describe will panic when Containers are empty.
This happened when function is created by kubeless-ui.

```go
func print(f kubelessApi.Function, name, output string) error {
...
    env, err := json.Marshal(f.Spec.Deployment.Spec.Template.Spec.Containers[0].Env)
```

The function is 

```yaml
$ kubectl get function xxx -o yaml
apiVersion: kubeless.io/v1beta1
kind: Function
metadata:
  clusterName: ""
  creationTimestamp: 2018-06-29T06:59:34Z
  finalizers:
  - kubeless.io/function
  generation: 1
  name: xxx
  namespace: default
  resourceVersion: "872425"
  selfLink: /apis/kubeless.io/v1beta1/namespaces/default/functions/xxx
  uid: fabbed3a-7b69-11e8-8251-6c0b84ace257
spec:
  checksum: sha256:f727da8be400e7412981aa011900905151c59c59e6ce959f3cec0f5c2bc00b8f
  deployment:
    metadata:
      creationTimestamp: null
    spec:
      strategy: {}
      template:
        metadata:
          creationTimestamp: null
        spec:
          containers: null
    status: {}
  deps: ""
```

And I think there is no need to use `fmt.Sprintf` for a string var.

**TODOs**:
 - [x] Ready to review
 - [ ] Automated Tests
 - [ ] Docs
