### PR TITLE
Ruby example is wrong or outdated

### DIFF
--- a/examples/ruby/function.yaml
+++ b/examples/ruby/function.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: k8s.io/v1
+apiVersion: kubeless.io/v1beta1
 kind: Function
 metadata:
   name: function
@@ -7,8 +7,8 @@ spec:
   handler: test.run
   runtime: ruby2.4
   function: |
-    # Obtains the latest Kubeless release published 
-    def run(request)
+    # Obtains the latest Kubeless release published
+    def run(event, context)
       require "net/https"
       require "uri"
       require "json"
@@ -23,9 +23,11 @@ spec:
       # Parse response
       output = JSON.parse(response.body)
 
-      # Create a Hash for output 
+      # Create a Hash for output
       output_hash = { version: output.first['name'] }
 
       # Print the stuff (JSON)
       puts JSON.pretty_generate(output_hash)
+
+      return output_hash[:version]
     end


### PR DESCRIPTION
Is a need for volunteers on this project?  I think it's something I would use, maybe someone can throw out some ideas for what else is needed in terms of updating docs or other things that a new contributor could helpfully tackle.

Was the API `apiVersion: k8s.io/v1` intentional?  I don't know if kubeless is intended to be upstreamed into k8s.io but function does not seem to be in my `k8s.io/v1` as of the latest minikube.

(Also, thanks for the mostly working example!)

**Issue Ref**: None
 
**Description**: 

I had to make a couple of changes to this example to get it to work, but this version worked.

Submitted for your consideration

**TODOs**:
 - [ ] Ready to review
 - [ ] Automated Tests
 - [ ] Docs
