### PR TITLE
Fix GKE build for CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ defaults: &defaults
     KINESIS_CONTROLLER_IMAGE_NAME: bitnami/kinesis-trigger-controller
     CGO_ENABLED: "0"
     TEST_DEBUG: "1"
-    GKE_VERSION: 1.8.8-gke.0
+    GKE_VERSION: 1.8.10-gke.0
     MINIKUBE_VERSION: v0.25.2
     MANIFESTS: kubeless kubeless-non-rbac kubeless-openshift kafka-zookeeper kafka-zookeeper-openshift nats kinesis
 exports: &exports

--- a/docs/GKE-deployment.md
+++ b/docs/GKE-deployment.md
@@ -22,7 +22,7 @@ Once you are logged in, you can create the cluster:
 
 ```console
 gcloud container clusters create \
-  --cluster-version=1.8.8-gke.0 \
+  --cluster-version=1.8.10-gke.0 \
   my-cluster \
   --num-nodes 5
 ```


### PR DESCRIPTION
This is the oldest version supported on GKE now, I think

(1.8.10-gke.0)

**TODOs**:
 - [X] Ready to review
 - [x] Automated Tests
 - [X] Docs
