### PR TITLE
Update K8s GKE version

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ defaults: &defaults
     KINESIS_CONTROLLER_IMAGE_NAME: bitnami/kinesis-trigger-controller
     CGO_ENABLED: "0"
     TEST_DEBUG: "1"
-    GKE_VERSION: 1.8.10-gke.0
+    GKE_VERSION: 1.9.7-gke.3
     MINIKUBE_VERSION: v0.25.2
     MANIFESTS: kubeless kubeless-non-rbac kubeless-openshift kafka-zookeeper kafka-zookeeper-openshift nats kinesis
 exports: &exports

--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ Kubeless fully supports two major versions of Kubernetes (1.8 and 1.9) at the mo
 | Platform | Kubernetes Version | HTTP functions | Scheduled functions | PubSub (Kafka) functions | PubSub (NATS) functions | Autoscaling (CPU) |
 | ------------- | ----- | - | - | - | - | - |
 | GKE           | 1.7.X | ✓ | X | ✓ | ✓ | X |
-| GKE (CI)      | 1.8.X | ✓ | ✓ | ✓ | ✓ | ✓ |
-| GKE           | 1.9.X | ✓ | ✓ | ✓ | ✓ | ✓ |
+| GKE           | 1.8.X | ✓ | ✓ | ✓ | ✓ | ✓ |
+| GKE (CI)      | 1.9.X | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Minikube      | 1.7.X | ✓ | X | ✓ | ✓ | ✓ |
 | Minikube      | 1.8.X | ✓ | ✓ | ✓ | ✓ | ✓ |
 | Minikube (CI) | 1.9.X | ✓ | ✓ | ✓ | ✓ | ✓ |


### PR DESCRIPTION
**Issue Ref**: None
 
**Description**: 

Using Kubernetes 1.8 now in GKE throws a warning. They have moved the default version to 1.9 so we can stop using 1.8 in our CI for GKE. Next step would be to start testing in 1.10.

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 - [X] Docs