### PR TITLE
remove 386 from the build

### DIFF
--- a/script/binary-cli
+++ b/script/binary-cli
@@ -17,7 +17,7 @@
 set -e
 
 OS_PLATFORM_ARG=(-os="darwin linux windows")
-OS_ARCH_ARG=(-arch="386 amd64")
+OS_ARCH_ARG=(-arch="amd64")
 
 GIT_COMMIT=$(git describe --tags --dirty)
 BUILD_DATE=$(date)


### PR DESCRIPTION
I don't think we need 386 client build anymore


