### PR TITLE
Cmdtop2

### DIFF
--- a/cmd/kubeless/function/top.go
+++ b/cmd/kubeless/function/top.go
@@ -112,7 +112,7 @@ func printTop(w io.Writer, metrics []*utils.Metric, cli kubernetes.Interface, ou
 		table := uitable.New()
 		table.MaxColWidth = 50
 		table.Wrap = true
-		table.AddRow("NAME", "NAMESPACE", "METHOD", "TOTAL_CALLS", "TOTAL_FAILURES", "TOTAL_DURATION_SECONDS", "AVG_DURATION_SECONDS", "ERROR")
+		table.AddRow("NAME", "NAMESPACE", "METHOD", "TOTAL_CALLS", "TOTAL_FAILURES", "TOTAL_DURATION_SECONDS", "AVG_DURATION_SECONDS", "MESSAGE")
 		for _, f := range metrics {
 			if f.Message != "" {
 				table.AddRow(f.FunctionName, f.Namespace, "", "", "", "", "", f.Message)

--- a/cmd/kubeless/function/top.go
+++ b/cmd/kubeless/function/top.go
@@ -112,9 +112,13 @@ func printTop(w io.Writer, metrics []*utils.Metric, cli kubernetes.Interface, ou
 		table := uitable.New()
 		table.MaxColWidth = 50
 		table.Wrap = true
-		table.AddRow("NAME", "NAMESPACE", "METHOD", "TOTAL_CALLS", "TOTAL_FAILURES", "TOTAL_DURATION_SECONDS", "AVG_DURATION_SECONDS")
+		table.AddRow("NAME", "NAMESPACE", "METHOD", "TOTAL_CALLS", "TOTAL_FAILURES", "TOTAL_DURATION_SECONDS", "AVG_DURATION_SECONDS", "ERROR")
 		for _, f := range metrics {
-			table.AddRow(f.FunctionName, f.Namespace, f.Method, f.TotalCalls, f.TotalFailures, f.TotalDurationSeconds, f.AvgDurationSeconds)
+			if f.Message != "" {
+				table.AddRow(f.FunctionName, f.Namespace, "", "", "", "", "", f.Message)
+			} else {
+				table.AddRow(f.FunctionName, f.Namespace, f.Method, f.TotalCalls, f.TotalFailures, f.TotalDurationSeconds, f.AvgDurationSeconds, "")
+			}
 		}
 		fmt.Fprintln(w, table)
 	} else {

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -272,6 +272,7 @@ get-dotnetcore:
 
 get-dotnetcore-verify:
 	kubeless function call get-dotnetcore |egrep hello.world
+	kubeless function top --function get-dotnetcore --out yaml |egrep "Function does not expose metrics" 
 
 get-dotnetcore-dependency:
 	kubeless function deploy get-dotnetcore-dependency --runtime dotnetcore2.0 --handler module.handler --from-file dotnetcore/dependency-yaml.cs --dependencies dotnetcore/dependency-yaml.csproj

--- a/pkg/utils/metrics.go
+++ b/pkg/utils/metrics.go
@@ -29,7 +29,7 @@ type Metric struct {
 	FunctionName         string  `json:"function,omitempty"`
 	Namespace            string  `json:"namespace,omitempty"`
 	Method               string  `json:"method,omitempty"`
-	Message              string  `json:"error,omitempty"`
+	Message              string  `json:"message,omitempty"`
 	TotalCalls           float64 `json:"total_calls,omitempty"`
 	TotalFailures        float64 `json:"total_failures,omitempty"`
 	TotalDurationSeconds float64 `json:"total_duration_seconds,omitempty"`
@@ -118,7 +118,7 @@ func GetFunctionMetrics(apiV1Client kubernetes.Interface, h MetricsRetriever, na
 	res, err := h.GetRawMetrics(apiV1Client, namespace, functionName)
 	if err != nil {
 		return []*Metric{
-			&Metric{
+			{
 				FunctionName: functionName,
 				Namespace:    namespace,
 				Message:      "Function does not expose metrics",
@@ -129,7 +129,7 @@ func GetFunctionMetrics(apiV1Client kubernetes.Interface, h MetricsRetriever, na
 	metrics, err := parseMetrics(namespace, functionName, res)
 	if err != nil {
 		return []*Metric{
-			&Metric{
+			{
 				FunctionName: functionName,
 				Namespace:    namespace,
 				Message:      "Unable to get function metrics",

--- a/pkg/utils/metrics.go
+++ b/pkg/utils/metrics.go
@@ -29,6 +29,7 @@ type Metric struct {
 	FunctionName         string  `json:"function,omitempty"`
 	Namespace            string  `json:"namespace,omitempty"`
 	Method               string  `json:"method,omitempty"`
+	Message              string  `json:"error,omitempty"`
 	TotalCalls           float64 `json:"total_calls,omitempty"`
 	TotalFailures        float64 `json:"total_failures,omitempty"`
 	TotalDurationSeconds float64 `json:"total_duration_seconds,omitempty"`
@@ -116,12 +117,24 @@ func GetFunctionMetrics(apiV1Client kubernetes.Interface, h MetricsRetriever, na
 
 	res, err := h.GetRawMetrics(apiV1Client, namespace, functionName)
 	if err != nil {
-		return []*Metric{}
+		return []*Metric{
+			&Metric{
+				FunctionName: functionName,
+				Namespace:    namespace,
+				Message:      "Function does not expose metrics",
+			},
+		}
 	}
 
 	metrics, err := parseMetrics(namespace, functionName, res)
 	if err != nil {
-		return []*Metric{}
+		return []*Metric{
+			&Metric{
+				FunctionName: functionName,
+				Namespace:    namespace,
+				Message:      "Unable to get function metrics",
+			},
+		}
 	}
 	return metrics
 }


### PR DESCRIPTION
**Issue Ref**: Fixed minor issue noted in [PR 823](https://github.com/kubeless/kubeless/pull/823)
 
**Description**: Added a status field to the `kubeless function top` command output that displays a `Function does not expose metrics` message when functions do not expose metrics. Added a message field to the JSON and YAML formatted results.

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 - [ ] Docs
