### PR TITLE
BUGFIX: Extending PYTHONPATH to fix local imports

### DIFF
--- a/docker/runtime/python/Dockerfile.3.6
+++ b/docker/runtime/python/Dockerfile.3.6
@@ -9,7 +9,8 @@ RUN wget -nc -P /tmp/bitnami/pkg/cache/ https://downloads.bitnami.com/files/stac
 
 ENV BITNAMI_APP_NAME="python" \
     BITNAMI_IMAGE_VERSION="3.6.3-r0" \
-    PATH="/opt/bitnami/python/bin:$PATH"
+    PATH="/opt/bitnami/python/bin:$PATH" \
+    PYTHONPATH="/kubeless/:$PYTHONPATH"
 
 RUN curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py
 RUN python ./get-pip.py

--- a/docker/runtime/python/Dockerfile.3.6
+++ b/docker/runtime/python/Dockerfile.3.6
@@ -9,8 +9,7 @@ RUN wget -nc -P /tmp/bitnami/pkg/cache/ https://downloads.bitnami.com/files/stac
 
 ENV BITNAMI_APP_NAME="python" \
     BITNAMI_IMAGE_VERSION="3.6.3-r0" \
-    PATH="/opt/bitnami/python/bin:$PATH" \
-    PYTHONPATH="/kubeless/:$PYTHONPATH"
+    PATH="/opt/bitnami/python/bin:$PATH"
 
 RUN curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py
 RUN python ./get-pip.py

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -15,7 +15,7 @@ get-python-update-verify:
 	kubeless function call get-python |egrep hello.world.updated
 
 get-python-deps:
-	zip hellowithdeps.zip hellowithdeps.py  hellowithdepshelper.py
+	zip hellowithdeps.zip python/hellowithdeps.py  python/hellowithdepshelper.py
 	kubeless function deploy get-python-deps --runtime python2.7 --handler helloget.foo --from-file python/hellowithdeps.zip --dependencies python/requirements.txt
 
 get-python-deps-verify:

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -15,7 +15,8 @@ get-python-update-verify:
 	kubeless function call get-python |egrep hello.world.updated
 
 get-python-deps:
-	kubeless function deploy get-python-deps --runtime python2.7 --handler helloget.foo --from-file python/hellowithdeps.py --dependencies python/requirements.txt
+	zip hellowithdeps.zip hellowithdeps.py  hellowithdepshelper.py
+	kubeless function deploy get-python-deps --runtime python2.7 --handler helloget.foo --from-file python/hellowithdeps.zip --dependencies python/requirements.txt
 
 get-python-deps-verify:
 	kubeless function call get-python-deps |egrep Google

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -15,7 +15,7 @@ get-python-update-verify:
 	kubeless function call get-python |egrep hello.world.updated
 
 get-python-deps:
-	zip python/hellowithdeps.zip python/hellowithdeps.py  python/hellowithdepshelper.py
+	cd python && zip hellowithdeps.zip hellowithdeps.py  hellowithdepshelper.py && cd ..
 	kubeless function deploy get-python-deps --runtime python2.7 --handler hellowithdeps.foo --from-file python/hellowithdeps.zip --dependencies python/requirements.txt
 
 get-python-deps-verify:

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -15,7 +15,7 @@ get-python-update-verify:
 	kubeless function call get-python |egrep hello.world.updated
 
 get-python-deps:
-	zip hellowithdeps.zip python/hellowithdeps.py  python/hellowithdepshelper.py
+	zip python/hellowithdeps.zip python/hellowithdeps.py  python/hellowithdepshelper.py
 	kubeless function deploy get-python-deps --runtime python2.7 --handler helloget.foo --from-file python/hellowithdeps.zip --dependencies python/requirements.txt
 
 get-python-deps-verify:

--- a/examples/Makefile
+++ b/examples/Makefile
@@ -16,7 +16,7 @@ get-python-update-verify:
 
 get-python-deps:
 	zip python/hellowithdeps.zip python/hellowithdeps.py  python/hellowithdepshelper.py
-	kubeless function deploy get-python-deps --runtime python2.7 --handler helloget.foo --from-file python/hellowithdeps.zip --dependencies python/requirements.txt
+	kubeless function deploy get-python-deps --runtime python2.7 --handler hellowithdeps.foo --from-file python/hellowithdeps.zip --dependencies python/requirements.txt
 
 get-python-deps-verify:
 	kubeless function call get-python-deps |egrep Google

--- a/examples/python/hellowithdeps.py
+++ b/examples/python/hellowithdeps.py
@@ -1,7 +1,1 @@
-from bs4 import BeautifulSoup
-import urllib2
-
-def foo(event, context):
-    page = urllib2.urlopen("https://www.google.com/").read()
-    soup = BeautifulSoup(page, 'html.parser')
-    return soup.title.string
+from hellowithdepshelper import foo

--- a/examples/python/hellowithdepshelper.py
+++ b/examples/python/hellowithdepshelper.py
@@ -1,0 +1,1 @@
+from hellowithdeps import foo

--- a/examples/python/hellowithdepshelper.py
+++ b/examples/python/hellowithdepshelper.py
@@ -1,1 +1,7 @@
-from hellowithdeps import foo
+from bs4 import BeautifulSoup
+import urllib2
+
+def foo(event, context):
+    page = urllib2.urlopen("https://www.google.com/").read()
+    soup = BeautifulSoup(page, 'html.parser')
+    return soup.title.string

--- a/pkg/langruntime/langruntime.go
+++ b/pkg/langruntime/langruntime.go
@@ -291,9 +291,10 @@ func (l *Langruntimes) GetBuildContainer(runtime, depsChecksum string, env []v1.
 func (l *Langruntimes) UpdateDeployment(dpm *v1beta1.Deployment, depsPath, runtime string) {
 	switch {
 	case strings.Contains(runtime, "python"):
+		pythonPaths := []string{path.Join(depsPath, "lib/python"+l.getVersionFromRuntime(runtime)+"/site-packages"), depsPath}
 		dpm.Spec.Template.Spec.Containers[0].Env = append(dpm.Spec.Template.Spec.Containers[0].Env, v1.EnvVar{
 			Name:  "PYTHONPATH",
-			Value: strings.Join(path.Join(depsPath, "lib/python"+l.getVersionFromRuntime(runtime)+"/site-packages"), depsPath),
+			Value: strings.Join(pythonPaths, ":"),
 		})
 	case strings.Contains(runtime, "nodejs"):
 		dpm.Spec.Template.Spec.Containers[0].Env = append(dpm.Spec.Template.Spec.Containers[0].Env, v1.EnvVar{

--- a/pkg/langruntime/langruntime.go
+++ b/pkg/langruntime/langruntime.go
@@ -293,7 +293,7 @@ func (l *Langruntimes) UpdateDeployment(dpm *v1beta1.Deployment, depsPath, runti
 	case strings.Contains(runtime, "python"):
 		dpm.Spec.Template.Spec.Containers[0].Env = append(dpm.Spec.Template.Spec.Containers[0].Env, v1.EnvVar{
 			Name:  "PYTHONPATH",
-			Value: path.Join(depsPath, "lib/python"+l.getVersionFromRuntime(runtime)+"/site-packages"),
+			Value: strings.Join(path.Join(depsPath, "lib/python"+l.getVersionFromRuntime(runtime)+"/site-packages"), depsPath),
 		})
 	case strings.Contains(runtime, "nodejs"):
 		dpm.Spec.Template.Spec.Containers[0].Env = append(dpm.Spec.Template.Spec.Containers[0].Env, v1.EnvVar{

--- a/pkg/utils/kubelessutil_test.go
+++ b/pkg/utils/kubelessutil_test.go
@@ -538,7 +538,7 @@ func TestEnsureDeployment(t *testing.T) {
 			},
 			{
 				Name:  "PYTHONPATH",
-				Value: "/kubeless/lib/python2.7/site-packages",
+				Value: "/kubeless/lib/python2.7/site-packages:/kubeless",
 			},
 		},
 		VolumeMounts: []v1.VolumeMount{


### PR DESCRIPTION
**Issue Ref**: Fixes https://github.com/kubeless/kubeless/issues/860 and #590

**Description**: 
~Adding `PYTHONPATH` environment variable so python files can import other python files.~ The current setup is broken because the python program is not run from the directory of the project files. Adding the mount directory to the python path should alleviate this problem

EDIT: Extending the `PYTHONPATH` variable to also include the mount point for the assets

As a failing test case, I made `examples/python/hellowithdeps.py` pull it's implementation of foo from a local file, as such I needed to make the deploy function send up a zip with both files instead of just the single python file. Before, this would fail with `hellowithdepshelper not found`, the modified test demonstrates it passing.

**TODOs**:
~Necessary for 2.7? How do we test that this is ok with respect to the mount point (`/kubeless`)?~
 - [x] Ready to review
 - [x] Automated Tests
 - [x] Docs
    not necessary, should be transparent to the users
