### PR TITLE
Support several instances of Kubeless per cluster

### DIFF
--- a/kafka-zookeeper.jsonnet
+++ b/kafka-zookeeper.jsonnet
@@ -21,7 +21,7 @@ local crd = [
 ];
 
 local controllerContainer =
-  container.default("kafka-trigger-controller", "bitnami/kafka-trigger-controller:v1.0.0-alpha.8") +
+  container.default("kafka-trigger-controller", "bitnami/kafka-trigger-controller:v1.0.0-alpha.9") +
   container.imagePullPolicy("IfNotPresent");
 
 local kubelessLabel = {kubeless: "kafka-trigger-controller"};

--- a/kubeless-non-rbac.jsonnet
+++ b/kubeless-non-rbac.jsonnet
@@ -35,12 +35,12 @@ local functionControllerContainer =
   container.env(controllerEnv);
 
 local httpTriggerControllerContainer =
-  container.default("http-trigger-controller", "bitnami/http-trigger-controller:v1.0.0-alpha.8") +
+  container.default("http-trigger-controller", "bitnami/http-trigger-controller:v1.0.0-alpha.9") +
   container.imagePullPolicy("IfNotPresent") +
   container.env(controllerEnv);
 
 local cronjobTriggerContainer =
-  container.default("cronjob-trigger-controller", "bitnami/cronjob-trigger-controller:v1.0.0-alpha.8") +
+  container.default("cronjob-trigger-controller", "bitnami/cronjob-trigger-controller:v1.0.0-alpha.9") +
   container.imagePullPolicy("IfNotPresent") +
   container.env(controllerEnv);
 


### PR DESCRIPTION
**Issue Ref**: Fixes #829 #867
 
**Description**: 

Allow administrators to set the config property "functions-namespace" for the controller to listen in a specific namespace. This PR also include docs to explain how to install different instances of Kubeless in the same cluster.

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 - [X] Docs