### PR TITLE
Remove description for CRDs

### DIFF
--- a/docs/function-controller-configuration.md
+++ b/docs/function-controller-configuration.md
@@ -96,7 +96,6 @@ or the following information can be added to `functions.kubeless.io` `CustomReso
 
 ```yaml
 apiVersion: apiextensions.k8s.io/v1beta1
-description: Kubernetes Native Serverless Framework
 kind: CustomResourceDefinition
 metadata:
   name: functions.kubeless.io

--- a/docs/implementing-new-trigger.md
+++ b/docs/implementing-new-trigger.md
@@ -17,7 +17,6 @@ First step is to create a new CRD for the event source. CRD for the new triggers
 
 ```yaml
 apiVersion: apiextensions.k8s.io/v1beta1
-description: CRD object for Kafka trigger type
 kind: CustomResourceDefinition
 metadata:
   name: kafkatriggers.kubeless.io

--- a/docs/use-existing-kafka.md
+++ b/docs/use-existing-kafka.md
@@ -57,7 +57,6 @@ spec:
       serviceAccountName: controller-acct
 ---
 apiVersion: apiextensions.k8s.io/v1beta1
-description: CRD object for Kafka trigger type
 kind: CustomResourceDefinition
 metadata:
   name: kafkatriggers.kubeless.io

--- a/kafka-zookeeper.jsonnet
+++ b/kafka-zookeeper.jsonnet
@@ -16,7 +16,6 @@ local crd = [
     kind: "CustomResourceDefinition",
     metadata: objectMeta.name("kafkatriggers.kubeless.io"),
     spec: {group: "kubeless.io", version: "v1beta1", scope: "Namespaced", names: {plural: "kafkatriggers", singular: "kafkatrigger", kind: "KafkaTrigger"}},
-    description: "CRD object for Kafka trigger type",
   },
 ];
 

--- a/kubeless-non-rbac.jsonnet
+++ b/kubeless-non-rbac.jsonnet
@@ -62,21 +62,18 @@ local crd = [
     kind: "CustomResourceDefinition",
     metadata: objectMeta.name("functions.kubeless.io"),
     spec: {group: "kubeless.io", version: "v1beta1", scope: "Namespaced", names: {plural: "functions", singular: "function", kind: "Function"}},
-    description: "Kubernetes Native Serverless Framework",
   },
   {
     apiVersion: "apiextensions.k8s.io/v1beta1",
     kind: "CustomResourceDefinition",
     metadata: objectMeta.name("httptriggers.kubeless.io"),
     spec: {group: "kubeless.io", version: "v1beta1", scope: "Namespaced", names: {plural: "httptriggers", singular: "httptrigger", kind: "HTTPTrigger"}},
-    description: "CRD object for HTTP trigger type",
   },
   {
     apiVersion: "apiextensions.k8s.io/v1beta1",
     kind: "CustomResourceDefinition",
     metadata: objectMeta.name("cronjobtriggers.kubeless.io"),
     spec: {group: "kubeless.io", version: "v1beta1", scope: "Namespaced", names: {plural: "cronjobtriggers", singular: "cronjobtrigger", kind: "CronJobTrigger"}},
-    description: "CRD object for HTTP trigger type",
   }
 ];
 


### PR DESCRIPTION
**Issue Ref**: Fixes  #881
 
**Description**: 

In K8s 1.11 the `Description` field is not available.

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 - [X] Docs