### PR TITLE
Fix formatting issue in use-existing-kafka.md

### DIFF
--- a/docs/use-existing-kafka.md
+++ b/docs/use-existing-kafka.md
@@ -132,6 +132,7 @@ hello world
 ```
 
 When using SASL you must add `KAFKA_ENABLE_SASL`, `KAFKA_USERNAME` and `KAFKA_PASSWORD` env var to set authentification (might use a secret).:
+
 ```yaml
 $ echo '
 ---


### PR DESCRIPTION
**Issue Ref**: 

None
 
**Description**: 

The final code block section in https://kubeless.io/docs/use-existing-kafka/ is missing a leading newline, which prevented the block being formatted as a code block. This PR adds that new line to fix the formatting issue on the page.

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 - [X] Docs
