### PR TITLE
Added CORS support for golang image for PR #934

### DIFF
--- a/docker/runtime/golang/kubeless.tpl.go
+++ b/docker/runtime/golang/kubeless.tpl.go
@@ -72,6 +72,16 @@ func handle(ctx context.Context, w http.ResponseWriter, r *http.Request) ([]byte
 }
 
 func handler(w http.ResponseWriter, r *http.Request) {
+
+	// add CORS support
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("Access-Control-Allow-Methods", "POST, GET, OPTIONS, PUT, DELETE")
+	w.Header().Set("Access-Control-Allow-Headers",
+	"Accept, Content-Type, Content-Length, Accept-Encoding, X-CSRF-Token, Authorization")
+	// Stop here if it's a Preflighted OPTIONS request
+	if r.Method == "OPTIONS" {
+		return
+	}
 	proxyUtils.Handler(w, r, handle)
 }
 


### PR DESCRIPTION
**Issue Ref**:  #934 
 
**Description**: 
Add CORS to golang runtime. 

[PR Description]
Added headers for CORS to the golang runtime. 

**TODOs**:
 - [ ] Ready to review
 - [ ] Automated Tests
 - [ ] Docs
