### PR TITLE
Wrong namespace in curl example

### DIFF
--- a/docs/quick-start.md
+++ b/docs/quick-start.md
@@ -121,7 +121,7 @@ $ kubectl proxy -p 8080 &
 
 $ curl -L --data '{"Another": "Echo"}' \
   --header "Content-Type:application/json" \
-  localhost:8080/api/v1/namespaces/default/services/hello:http-function-port/proxy/
+  localhost:8080/api/v1/namespaces/kubeless/services/hello:http-function-port/proxy/
 {"Another": "Echo"}
 ```
 


### PR DESCRIPTION
The curl example in the quick start uses the "default" namespace, while the installation only refers to the kubeless namespace. Even if the test hello function is then showed being in the default namespace, no active switchover to that namespace was done. So the kubeless function deploy hello command will result in having the function being deployed to the kubeless namespace.
