### PR TITLE
Use camelCase for functionContentType

### DIFF
--- a/docs/advanced-function-deployment.md
+++ b/docs/advanced-function-deployment.md
@@ -17,7 +17,7 @@ spec:
   handler: helloget.foo
   deps: ""
   checksum: sha256:d251999dcbfdeccec385606fd0aec385b214cfc74ede8b6c9e47af71728f6e9a
-  function-content-type: text
+  functionContentType: text
   function: |
     def foo(event, context):
         return "hello world"
@@ -27,7 +27,7 @@ The fields that a Function specification can contain are:
 
  - Runtime: Runtime ID and version that the function will use. It should match one of the availables in the [Kubeless configuration](/docs/function-controller-configuration).
  - Timeout: Maximum timeout for the given function. After that time, the function execution will be terminated.
- - Handler: Pair of `<file_name>.<function_name>`. When using `zip` in `function-content-type` the `<file_name>` will be used to find the file with the function to expose. In other case it will be used just as a final file name. `<function_name>` is used to select the function to run from the exported functions of `<file_name>`. This field is mandatory and should match with an exported function.
+ - Handler: Pair of `<file_name>.<function_name>`. When using `zip` in `functionContentType` the `<file_name>` will be used to find the file with the function to expose. In other case it will be used just as a final file name. `<function_name>` is used to select the function to run from the exported functions of `<file_name>`. This field is mandatory and should match with an exported function.
  - Deps: Dependencies of the function. The format of this field will depend on the runtime, e.g. a `package.json` for NodeJS functions or a `Gemfile` for Ruby.
  - Checksum: SHA256 of the function content.
  - Function content type: Content type of the function. Current supported values are `base64`, `url` or `text`. If the content is zipped the suffix `+zip` should be added.
@@ -42,7 +42,7 @@ As any Kubernetes object, function objects have a maximum size of 1.5MiB (due to
 ```yaml
   checksum: sha256:d1f84e9f0a8ce27e7d9ce6f457126a8f92e957e5109312e7996373f658015547
   function: https://github.com/kubeless/kubeless/blob/master/examples/nodejs/helloFunctions.zip?raw=true
-  function-content-type: url+zip
+  functionContentType: url+zip
 ```
 
 ## Custom Deployment

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -115,7 +115,7 @@ spec:
   function: |
     def foo(event, context):
         return "hello world"
-  function-content-type: text
+  functionContentType: text
   handler: helloget.foo
   horizontalPodAutoscaler:
     metadata:

--- a/docs/function-controller-configuration.md
+++ b/docs/function-controller-configuration.md
@@ -71,7 +71,7 @@ spec:
             res.end('hello world updated!!!')
       }
     }
-  function-content-type: text
+  functionContentType: text
   handler: hello.foo
   runtime: nodejs8
   service:

--- a/pkg/apis/kubeless/v1beta1/function.go
+++ b/pkg/apis/kubeless/v1beta1/function.go
@@ -37,7 +37,7 @@ type Function struct {
 type FunctionSpec struct {
 	Handler                 string                          `json:"handler"`               // Function handler: "file.function"
 	Function                string                          `json:"function"`              // Function file content or URL of the function
-	FunctionContentType     string                          `json:"function-content-type"` // Function file content type (plain text, base64 or zip)
+	FunctionContentType     string                          `json:"functionContentType"` // Function file content type (plain text, base64 or zip)
 	Checksum                string                          `json:"checksum"`              // Checksum of the file
 	Runtime                 string                          `json:"runtime"`               // Function runtime to use
 	Timeout                 string                          `json:"timeout"`               // Maximum timeout for the function to complete its execution

--- a/pkg/apis/kubeless/v1beta1/function.go
+++ b/pkg/apis/kubeless/v1beta1/function.go
@@ -35,13 +35,13 @@ type Function struct {
 
 // FunctionSpec contains func specification
 type FunctionSpec struct {
-	Handler                 string                          `json:"handler"`               // Function handler: "file.function"
-	Function                string                          `json:"function"`              // Function file content or URL of the function
+	Handler                 string                          `json:"handler"`             // Function handler: "file.function"
+	Function                string                          `json:"function"`            // Function file content or URL of the function
 	FunctionContentType     string                          `json:"functionContentType"` // Function file content type (plain text, base64 or zip)
-	Checksum                string                          `json:"checksum"`              // Checksum of the file
-	Runtime                 string                          `json:"runtime"`               // Function runtime to use
-	Timeout                 string                          `json:"timeout"`               // Maximum timeout for the function to complete its execution
-	Deps                    string                          `json:"deps"`                  // Function dependencies
+	Checksum                string                          `json:"checksum"`            // Checksum of the file
+	Runtime                 string                          `json:"runtime"`             // Function runtime to use
+	Timeout                 string                          `json:"timeout"`             // Maximum timeout for the function to complete its execution
+	Deps                    string                          `json:"deps"`                // Function dependencies
 	Deployment              v1beta1.Deployment              `json:"deployment" protobuf:"bytes,3,opt,name=template"`
 	ServiceSpec             v1.ServiceSpec                  `json:"service"`
 	HorizontalPodAutoscaler v2beta1.HorizontalPodAutoscaler `json:"horizontalPodAutoscaler" protobuf:"bytes,3,opt,name=horizontalPodAutoscaler"`


### PR DESCRIPTION
Use camelCase for function-content-type to make it more consistent with kubernetes naming.

**Issue Ref**: #954 
 
**Description**: 

Refactor `function-content-type` to `functionContentType`.

**TODOs**:
 - [x] Ready to review
 - [x] Automated Tests
 - [x] Docs
