### PR TITLE
Disable runtime check if has no permissions to do so

### DIFF
--- a/cmd/kubeless/function/deploy.go
+++ b/cmd/kubeless/function/deploy.go
@@ -40,21 +40,30 @@ var deployCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		cli := kubelessUtils.GetClientOutOfCluster()
 		apiExtensionsClientset := kubelessUtils.GetAPIExtensionsClientOutOfCluster()
-		config, err := kubelessUtils.GetKubelessConfig(cli, apiExtensionsClientset)
-		checkRuntime := true
-		var lr *langruntime.Langruntimes
-		if err != nil {
-			logrus.Warnf("%v. Runtime check is disabled.", err)
-			checkRuntime = false
-		} else {
-			lr = langruntime.New(config)
-			lr.ReadConfigMap()
-		}
 
 		if len(args) != 1 {
 			logrus.Fatal("Need exactly one argument - function name")
 		}
 		funcName := args[0]
+
+		runtime, err := cmd.Flags().GetString("runtime")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+
+		// Checking runtime parameter if allowed by RBAC, otherwide skip the check
+		config, err := kubelessUtils.GetKubelessConfig(cli, apiExtensionsClientset)
+		if config == nil || err != nil {
+			logrus.Warnf("%v. Runtime check is disabled.", err)
+		} else {
+			lr := langruntime.New(config)
+			lr.ReadConfigMap()
+
+			if runtime != "" && !lr.IsValidRuntime(runtime) {
+				logrus.Fatalf("Invalid runtime: %s. Supported runtimes are: %s",
+					runtime, strings.Join(lr.GetRuntimes(), ", "))
+			}
+		}
 
 		schedule, err := cmd.Flags().GetString("schedule")
 		if err != nil {
@@ -75,18 +84,6 @@ var deployCmd = &cobra.Command{
 		envs, err := cmd.Flags().GetStringSlice("env")
 		if err != nil {
 			logrus.Fatal(err)
-		}
-
-		runtime, err := cmd.Flags().GetString("runtime")
-		if err != nil {
-			logrus.Fatal(err)
-		}
-
-		if checkRuntime {
-			if runtime != "" && !lr.IsValidRuntime(runtime) {
-				logrus.Fatalf("Invalid runtime: %s. Supported runtimes are: %s",
-					runtime, strings.Join(lr.GetRuntimes(), ", "))
-			}
 		}
 
 		handler, err := cmd.Flags().GetString("handler")

--- a/cmd/kubeless/function/deploy.go
+++ b/cmd/kubeless/function/deploy.go
@@ -47,7 +47,7 @@ var deployCmd = &cobra.Command{
 			logrus.Warnf("%v. Runtime check is disabled.", err)
 			checkRuntime = false
 		} else {
-			lr := langruntime.New(config)
+			lr = langruntime.New(config)
 			lr.ReadConfigMap()
 		}
 


### PR DESCRIPTION
**Issue Ref**: [Issue number related to this PR or None]
https://github.com/kubeless/kubeless/issues/989

**Description**: 
In RBAC-restricted cluster user might have no permissions to see cluster-scoped things

[PR Description]
I was not sure whether you still want to leave the warning and do that check.

**TODOs**:
 - [x] Ready to review
 - [x] Automated Tests
 - [ ] Docs
