### PR TITLE
differentiate service port and target port for container

### DIFF
--- a/cmd/kubeless/function/deploy.go
+++ b/cmd/kubeless/function/deploy.go
@@ -169,7 +169,7 @@ var deployCmd = &cobra.Command{
 		if err != nil {
 			logrus.Fatal(err)
 		}
-		if servicePort <= 0 || servicePort > 65535 {
+		if servicePort < 0 || servicePort > 65535 {
 			logrus.Fatalf("Invalid servicePort number %d specified", servicePort)
 		}
 

--- a/cmd/kubeless/function/deploy.go
+++ b/cmd/kubeless/function/deploy.go
@@ -285,5 +285,5 @@ func init() {
 	deployCmd.Flags().Bool("headless", false, "Deploy http-based function without a single service IP and load balancing support from Kubernetes. See: https://kubernetes.io/docs/concepts/services-networking/service/#headless-services")
 	deployCmd.Flags().Bool("dryrun", false, "Output JSON manifest of the function without creating it")
 	deployCmd.Flags().Int32("port", 8080, "Deploy http-based function with a custom port")
-	deployCmd.Flags().Int32("servicePort", 8080, "Deploy http-based function with a custom service port")
+	deployCmd.Flags().Int32("servicePort", 0, "Deploy http-based function with a custom service port")
 }

--- a/cmd/kubeless/function/deploy.go
+++ b/cmd/kubeless/function/deploy.go
@@ -164,6 +164,14 @@ var deployCmd = &cobra.Command{
 		if port <= 0 || port > 65535 {
 			logrus.Fatalf("Invalid port number %d specified", port)
 		}
+		
+		servicePort, err := cmd.Flags().GetInt32("servicePort")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		if servicePort <= 0 || servicePort > 65535 {
+			logrus.Fatalf("Invalid servicePort number %d specified", servicePort)
+		}
 
 		funcDeps := ""
 		if deps != "" {
@@ -191,7 +199,7 @@ var deployCmd = &cobra.Command{
 			"function":   funcName,
 		}
 
-		f, err := getFunctionDescription(funcName, ns, handler, file, funcDeps, runtime, runtimeImage, mem, cpu, timeout, imagePullPolicy, port, headless, envs, labels, secrets, defaultFunctionSpec)
+		f, err := getFunctionDescription(funcName, ns, handler, file, funcDeps, runtime, runtimeImage, mem, cpu, timeout, imagePullPolicy, port, servicePort, headless, envs, labels, secrets, defaultFunctionSpec)
 		if err != nil {
 			logrus.Fatal(err)
 		}
@@ -277,4 +285,5 @@ func init() {
 	deployCmd.Flags().Bool("headless", false, "Deploy http-based function without a single service IP and load balancing support from Kubernetes. See: https://kubernetes.io/docs/concepts/services-networking/service/#headless-services")
 	deployCmd.Flags().Bool("dryrun", false, "Output JSON manifest of the function without creating it")
 	deployCmd.Flags().Int32("port", 8080, "Deploy http-based function with a custom port")
+	deployCmd.Flags().Int32("servicePort", 8080, "Deploy http-based function with a custom service port")
 }

--- a/cmd/kubeless/function/deploy.go
+++ b/cmd/kubeless/function/deploy.go
@@ -164,7 +164,7 @@ var deployCmd = &cobra.Command{
 		if port <= 0 || port > 65535 {
 			logrus.Fatalf("Invalid port number %d specified", port)
 		}
-		
+
 		servicePort, err := cmd.Flags().GetInt32("servicePort")
 		if err != nil {
 			logrus.Fatal(err)

--- a/cmd/kubeless/function/function.go
+++ b/cmd/kubeless/function/function.go
@@ -205,7 +205,7 @@ func parseContent(file, contentType string) (string, string, error) {
 	return content, checksum, nil
 }
 
-func getFunctionDescription(funcName, ns, handler, file, deps, runtime, runtimeImage, mem, cpu, timeout string, imagePullPolicy string, port int32, headless bool, envs, labels []string, secrets []string, defaultFunction kubelessApi.Function) (*kubelessApi.Function, error) {
+func getFunctionDescription(funcName, ns, handler, file, deps, runtime, runtimeImage, mem, cpu, timeout string, imagePullPolicy string, port int32, servicePort int32, headless bool, envs, labels []string, secrets []string, defaultFunction kubelessApi.Function) (*kubelessApi.Function, error) {
 
 	function := defaultFunction
 	function.TypeMeta = metav1.TypeMeta{
@@ -328,7 +328,10 @@ func getFunctionDescription(funcName, ns, handler, file, deps, runtime, runtimeI
 	if port != 0 {
 		svcSpec.Ports[0].Port = port
 		svcSpec.Ports[0].TargetPort = intstr.FromInt(int(port))
-	}
+	} 
+	if servicePort != 0 {
+		svcSpec.Ports[0].Port = servicePort
+	} 
 	function.Spec.ServiceSpec = svcSpec
 
 	for _, secret := range secrets {

--- a/cmd/kubeless/function/function.go
+++ b/cmd/kubeless/function/function.go
@@ -33,7 +33,7 @@ import (
 	kubelessApi "github.com/kubeless/kubeless/pkg/apis/kubeless/v1beta1"
 	"github.com/kubeless/kubeless/pkg/client/clientset/versioned"
 	"github.com/spf13/cobra"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"

--- a/cmd/kubeless/function/function.go
+++ b/cmd/kubeless/function/function.go
@@ -33,7 +33,7 @@ import (
 	kubelessApi "github.com/kubeless/kubeless/pkg/apis/kubeless/v1beta1"
 	"github.com/kubeless/kubeless/pkg/client/clientset/versioned"
 	"github.com/spf13/cobra"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -328,10 +328,10 @@ func getFunctionDescription(funcName, ns, handler, file, deps, runtime, runtimeI
 	if port != 0 {
 		svcSpec.Ports[0].Port = port
 		svcSpec.Ports[0].TargetPort = intstr.FromInt(int(port))
-	} 
+	}
 	if servicePort != 0 {
 		svcSpec.Ports[0].Port = servicePort
-	} 
+	}
 	function.Spec.ServiceSpec = svcSpec
 
 	for _, secret := range secrets {

--- a/cmd/kubeless/function/function_test.go
+++ b/cmd/kubeless/function/function_test.go
@@ -102,7 +102,7 @@ func TestGetFunctionDescription(t *testing.T) {
 	file.Close()
 	defer os.Remove(file.Name()) // clean up
 
-	result, err := getFunctionDescription("test", "default", "file.handler", file.Name(), "dependencies", "runtime", "test-image", "128Mi", "", "10", "Always", 8080, false, []string{"TEST=1"}, []string{"test=1"}, []string{"secretName"}, kubelessApi.Function{})
+	result, err := getFunctionDescription("test", "default", "file.handler", file.Name(), "dependencies", "runtime", "test-image", "128Mi", "", "10", "Always", 8080, 0, false, []string{"TEST=1"}, []string{"test=1"}, []string{"secretName"}, kubelessApi.Function{})
 
 	if err != nil {
 		t.Error(err)
@@ -189,7 +189,7 @@ func TestGetFunctionDescription(t *testing.T) {
 	}
 
 	// It should take the default values
-	result2, err := getFunctionDescription("test", "default", "", "", "", "", "", "", "", "", "Always", 8080, false, []string{}, []string{}, []string{}, expectedFunction)
+	result2, err := getFunctionDescription("test", "default", "", "", "", "", "", "", "", "", "Always", 8080, 0, false, []string{}, []string{}, []string{}, expectedFunction)
 
 	if err != nil {
 		t.Error(err)
@@ -210,7 +210,7 @@ func TestGetFunctionDescription(t *testing.T) {
 	file.Close()
 	defer os.Remove(file.Name()) // clean up
 
-	result3, err := getFunctionDescription("test", "default", "file.handler2", file.Name(), "dependencies2", "runtime2", "test-image2", "256Mi", "100m", "20", "Always", 8080, false, []string{"TEST=2"}, []string{"test=2"}, []string{"secret2"}, expectedFunction)
+	result3, err := getFunctionDescription("test", "default", "file.handler2", file.Name(), "dependencies2", "runtime2", "test-image2", "256Mi", "100m", "20", "Always", 8080, 0, false, []string{"TEST=2"}, []string{"test=2"}, []string{"secret2"}, expectedFunction)
 
 	if err != nil {
 		t.Error(err)
@@ -336,7 +336,7 @@ func TestGetFunctionDescription(t *testing.T) {
 	file.Close()
 	zipW.Close()
 
-	result4, err := getFunctionDescription("test", "default", "file.handler", newfile.Name(), "dependencies", "runtime", "", "", "", "", "Always", 8080, false, []string{}, []string{}, []string{}, expectedFunction)
+	result4, err := getFunctionDescription("test", "default", "file.handler", newfile.Name(), "dependencies", "runtime", "", "", "", "", "Always", 8080, 0, false, []string{}, []string{}, []string{}, expectedFunction)
 	if err != nil {
 		t.Error(err)
 	}
@@ -345,7 +345,7 @@ func TestGetFunctionDescription(t *testing.T) {
 	}
 
 	// It should maintain previous HPA definition
-	result5, err := getFunctionDescription("test", "default", "file.handler", file.Name(), "dependencies", "runtime", "test-image", "128Mi", "", "10", "Always", 8080, false, []string{"TEST=1"}, []string{"test=1"}, []string{}, kubelessApi.Function{
+	result5, err := getFunctionDescription("test", "default", "file.handler", file.Name(), "dependencies", "runtime", "test-image", "128Mi", "", "10", "Always", 8080, 0, false, []string{"TEST=1"}, []string{"test=1"}, []string{}, kubelessApi.Function{
 
 		Spec: kubelessApi.FunctionSpec{
 			HorizontalPodAutoscaler: v2beta1.HorizontalPodAutoscaler{
@@ -359,12 +359,12 @@ func TestGetFunctionDescription(t *testing.T) {
 		t.Error("should maintain previous HPA definition")
 	}
 
-	// It should set the Port and headless service properly
-	result6, err := getFunctionDescription("test", "default", "file.handler", file.Name(), "dependencies", "runtime", "test-image", "128Mi", "", "", "Always", 9091, true, []string{}, []string{}, []string{}, kubelessApi.Function{})
+	// It should set the Port, ServicePort and headless service properly
+	result6, err := getFunctionDescription("test", "default", "file.handler", file.Name(), "dependencies", "runtime", "test-image", "128Mi", "", "", "Always", 9091, 9092, true, []string{}, []string{}, []string{}, kubelessApi.Function{})
 	expectedPort := v1.ServicePort{
 		Name:       "http-function-port",
 		Port:       9091,
-		TargetPort: intstr.FromInt(9091),
+		TargetPort: intstr.FromInt(9092),
 		NodePort:   0,
 		Protocol:   v1.ProtocolTCP,
 	}
@@ -457,7 +457,7 @@ func TestGetFunctionDescription(t *testing.T) {
 		},
 	}
 
-	result7, err := getFunctionDescription("test", "default", "file.handler", ts.URL, "dependencies", "runtime", "test-image", "128Mi", "", "10", "Always", 8080, false, []string{"TEST=1"}, []string{"test=1"}, []string{"secretName"}, kubelessApi.Function{})
+	result7, err := getFunctionDescription("test", "default", "file.handler", ts.URL, "dependencies", "runtime", "test-image", "128Mi", "", "10", "Always", 8080, 0, false, []string{"TEST=1"}, []string{"test=1"}, []string{"secretName"}, kubelessApi.Function{})
 
 	if err != nil {
 		t.Error(err)
@@ -481,7 +481,7 @@ func TestGetFunctionDescription(t *testing.T) {
 
 	expectedURLFunction.Spec.FunctionContentType = "url+zip"
 	expectedURLFunction.Spec.Function = ts2.URL + "/test.zip"
-	result8, err := getFunctionDescription("test", "default", "file.handler", ts2.URL+"/test.zip", "dependencies", "runtime", "test-image", "128Mi", "", "10", "Always", 8080, false, []string{"TEST=1"}, []string{"test=1"}, []string{"secretName"}, kubelessApi.Function{})
+	result8, err := getFunctionDescription("test", "default", "file.handler", ts2.URL+"/test.zip", "dependencies", "runtime", "test-image", "128Mi", "", "10", "Always", 8080, 0, false, []string{"TEST=1"}, []string{"test=1"}, []string{"secretName"}, kubelessApi.Function{})
 	if err != nil {
 		t.Error(err)
 	}

--- a/cmd/kubeless/function/function_test.go
+++ b/cmd/kubeless/function/function_test.go
@@ -363,8 +363,8 @@ func TestGetFunctionDescription(t *testing.T) {
 	result6, err := getFunctionDescription("test", "default", "file.handler", file.Name(), "dependencies", "runtime", "test-image", "128Mi", "", "", "Always", 9091, 9092, true, []string{}, []string{}, []string{}, kubelessApi.Function{})
 	expectedPort := v1.ServicePort{
 		Name:       "http-function-port",
-		Port:       9091,
-		TargetPort: intstr.FromInt(9092),
+		Port:       9092,
+		TargetPort: intstr.FromInt(9091),
 		NodePort:   0,
 		Protocol:   v1.ProtocolTCP,
 	}

--- a/cmd/kubeless/function/update.go
+++ b/cmd/kubeless/function/update.go
@@ -150,7 +150,7 @@ var updateCmd = &cobra.Command{
 		if err != nil {
 			logrus.Fatal(err)
 		}
-		if servicePort <= 0 || servicePort > 65535 {
+		if servicePort < 0 || servicePort > 65535 {
 			logrus.Fatalf("Invalid servicePort number %d specified", servicePort)
 		}
 

--- a/cmd/kubeless/function/update.go
+++ b/cmd/kubeless/function/update.go
@@ -225,7 +225,7 @@ func init() {
 	updateCmd.Flags().StringP("timeout", "", "180", "Maximum timeout (in seconds) for the function to complete its execution")
 	updateCmd.Flags().Bool("headless", false, "Deploy http-based function without a single service IP and load balancing support from Kubernetes. See: https://kubernetes.io/docs/concepts/services-networking/service/#headless-services")
 	updateCmd.Flags().Int32("port", 8080, "Deploy http-based function with a custom port")
-	updateCmd.Flags().Int32("servicePort", 8080, "Deploy http-based function with a custom service port")
+	updateCmd.Flags().Int32("servicePort", 0, "Deploy http-based function with a custom service port")
 	updateCmd.Flags().Bool("dryrun", false, "Output JSON manifest of the function without creating it")
 	updateCmd.Flags().StringP("output", "o", "yaml", "Output format")
 

--- a/cmd/kubeless/function/update.go
+++ b/cmd/kubeless/function/update.go
@@ -146,6 +146,13 @@ var updateCmd = &cobra.Command{
 		if port <= 0 || port > 65535 {
 			logrus.Fatalf("Invalid port number %d specified", port)
 		}
+		servicePort, err := cmd.Flags().GetInt32("servicePort")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		if servicePort <= 0 || servicePort > 65535 {
+			logrus.Fatalf("Invalid servicePort number %d specified", servicePort)
+		}
 
 		output, err := cmd.Flags().GetString("output")
 		if err != nil {
@@ -162,7 +169,7 @@ var updateCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 
-		f, err := getFunctionDescription(funcName, ns, handler, file, funcDeps, runtime, runtimeImage, mem, cpu, timeout, imagePullPolicy, port, headless, envs, labels, secrets, previousFunction)
+		f, err := getFunctionDescription(funcName, ns, handler, file, funcDeps, runtime, runtimeImage, mem, cpu, timeout, imagePullPolicy, port, servicePort, headless, envs, labels, secrets, previousFunction)
 		if err != nil {
 			logrus.Fatal(err)
 		}
@@ -218,6 +225,7 @@ func init() {
 	updateCmd.Flags().StringP("timeout", "", "180", "Maximum timeout (in seconds) for the function to complete its execution")
 	updateCmd.Flags().Bool("headless", false, "Deploy http-based function without a single service IP and load balancing support from Kubernetes. See: https://kubernetes.io/docs/concepts/services-networking/service/#headless-services")
 	updateCmd.Flags().Int32("port", 8080, "Deploy http-based function with a custom port")
+	updateCmd.Flags().Int32("servicePort", 8080, "Deploy http-based function with a custom service port")
 	updateCmd.Flags().Bool("dryrun", false, "Output JSON manifest of the function without creating it")
 	updateCmd.Flags().StringP("output", "o", "yaml", "Output format")
 

--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -539,7 +539,7 @@ func svcTargetPort(funcObj *kubelessApi.Function) int32 {
 	if len(funcObj.Spec.ServiceSpec.Ports) == 0 {
 		return int32(8080)
 	}
-	return funcObj.Spec.ServiceSpec.Ports[0].TargetPort.IntValue()
+	return int32(funcObj.Spec.ServiceSpec.Ports[0].TargetPort.IntValue())
 }
 
 func mergeMap(dst, src map[string]string) map[string]string {

--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -539,7 +539,7 @@ func svcTargetPort(funcObj *kubelessApi.Function) int32 {
 	if len(funcObj.Spec.ServiceSpec.Ports) == 0 {
 		return int32(8080)
 	}
-	return funcObj.Spec.ServiceSpec.Ports[0].TargetPort
+	return funcObj.Spec.ServiceSpec.Ports[0].TargetPort.IntValue()
 }
 
 func mergeMap(dst, src map[string]string) map[string]string {

--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -528,13 +528,6 @@ func EnsureFuncImage(client kubernetes.Interface, funcObj *kubelessApi.Function,
 	return err
 }
 
-func svcPort(funcObj *kubelessApi.Function) int32 {
-	if len(funcObj.Spec.ServiceSpec.Ports) == 0 {
-		return int32(8080)
-	}
-	return funcObj.Spec.ServiceSpec.Ports[0].Port
-}
-
 func svcTargetPort(funcObj *kubelessApi.Function) int32 {
 	if len(funcObj.Spec.ServiceSpec.Ports) == 0 {
 		return int32(8080)
@@ -655,7 +648,7 @@ func EnsureFuncDeployment(client kubernetes.Interface, funcObj *kubelessApi.Func
 	dpm.Spec.Template.Spec.Containers[0].Env = append(dpm.Spec.Template.Spec.Containers[0].Env,
 		v1.EnvVar{
 			Name:  "FUNC_PORT",
-			Value: strconv.Itoa(int(svcPort(funcObj))),
+			Value: strconv.Itoa(int(svcTargetPort(funcObj))),
 		},
 	)
 

--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -535,6 +535,13 @@ func svcPort(funcObj *kubelessApi.Function) int32 {
 	return funcObj.Spec.ServiceSpec.Ports[0].Port
 }
 
+func svcTargetPort(funcObj *kubelessApi.Function) int32 {
+	if len(funcObj.Spec.ServiceSpec.Ports) == 0 {
+		return int32(8080)
+	}
+	return funcObj.Spec.ServiceSpec.Ports[0].TargetPort
+}
+
 func mergeMap(dst, src map[string]string) map[string]string {
 	if len(dst) == 0 {
 		dst = make(map[string]string)
@@ -558,7 +565,7 @@ func EnsureFuncDeployment(client kubernetes.Interface, funcObj *kubelessApi.Func
 		// "targets")
 		"prometheus.io/scrape": "true",
 		"prometheus.io/path":   "/metrics",
-		"prometheus.io/port":   strconv.Itoa(int(svcPort(funcObj))),
+		"prometheus.io/port":   strconv.Itoa(int(svcTargetPort(funcObj))),
 	}
 	maxUnavailable := intstr.FromInt(0)
 
@@ -654,13 +661,13 @@ func EnsureFuncDeployment(client kubernetes.Interface, funcObj *kubelessApi.Func
 
 	dpm.Spec.Template.Spec.Containers[0].Name = funcObj.ObjectMeta.Name
 	dpm.Spec.Template.Spec.Containers[0].Ports = append(dpm.Spec.Template.Spec.Containers[0].Ports, v1.ContainerPort{
-		ContainerPort: svcPort(funcObj),
+		ContainerPort: svcTargetPort(funcObj),
 	})
 
 	// update deployment for loading dependencies
 	lr.UpdateDeployment(dpm, runtimeVolumeMount.MountPath, funcObj.Spec.Runtime)
 
-	livenessProbeInfo := lr.GetLivenessProbeInfo(funcObj.Spec.Runtime, int(svcPort(funcObj)))
+	livenessProbeInfo := lr.GetLivenessProbeInfo(funcObj.Spec.Runtime, int(svcTargetPort(funcObj)))
 
 	if dpm.Spec.Template.Spec.Containers[0].LivenessProbe == nil {
 		dpm.Spec.Template.Spec.Containers[0].LivenessProbe = livenessProbeInfo


### PR DESCRIPTION
**Issue Ref**: None
 
**Description**: After updating runtime images to use non-root user it is become impossible to run functions on port 80. To fix this `Service` can map port 80 to target port 8080. To support this this pull request was prepared. Also another one will come to `serverless-kubeless` plugin.

**TODOs**:
 - [x] Ready to review
 - [ ] Automated Tests
 - [ ] Docs
