### PR TITLE
Add CORS support

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,8 +84,6 @@ jobs:
       # go build creates files under /usr/local/go where the running user doesn't have permissions to write
       - run: sudo chown -R circleci:circleci /usr/local/go/
       - run: go get -u golang.org/x/lint/golint
-      # go build creates files under /usr/local/go where the running user doesn't have permissions to write
-      - run: sudo chown -R circleci:circleci /usr/local/go/
       - run: make bootstrap
       - run: make VERSION=${CONTROLLER_TAG} binary
       - run: make test

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,6 +84,8 @@ jobs:
       # go build creates files under /usr/local/go where the running user doesn't have permissions to write
       - run: sudo chown -R circleci:circleci /usr/local/go/
       - run: go get -u golang.org/x/lint/golint
+      # go build creates files under /usr/local/go where the running user doesn't have permissions to write
+      - run: sudo chown -R circleci:circleci /usr/local/go/
       - run: make bootstrap
       - run: make VERSION=${CONTROLLER_TAG} binary
       - run: make test

--- a/cmd/kubeless/trigger/http/create.go
+++ b/cmd/kubeless/trigger/http/create.go
@@ -105,12 +105,6 @@ var createCmd = &cobra.Command{
 		}
 		httpTrigger.Spec.CorsEnable = corsEnabled
 
-		corsDomain, err := cmd.Flags().GetString("cors-domain")
-		if err != nil {
-			logrus.Fatal(err)
-		}
-		httpTrigger.Spec.CorsDomain = corsDomain
-
 		tlsSecret, err := cmd.Flags().GetString("tls-secret")
 		if err != nil {
 			logrus.Fatal(err)

--- a/cmd/kubeless/trigger/http/create.go
+++ b/cmd/kubeless/trigger/http/create.go
@@ -18,13 +18,12 @@ package http
 
 import (
 	"fmt"
-
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
-
 	httpApi "github.com/kubeless/http-trigger/pkg/apis/kubeless/v1beta1"
 	httpUtils "github.com/kubeless/http-trigger/pkg/utils"
 	kubelessUtils "github.com/kubeless/kubeless/pkg/utils"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -38,7 +37,6 @@ var createCmd = &cobra.Command{
 			logrus.Fatal("Need exactly one argument - http trigger name")
 		}
 		triggerName := args[0]
-
 		ns, err := cmd.Flags().GetString("namespace")
 		if err != nil {
 			logrus.Fatal(err)
@@ -100,6 +98,18 @@ var createCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 		httpTrigger.Spec.TLSAcme = enableTLSAcme
+
+		corsEnabled, err := cmd.Flags().GetBool("cors-enable")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		httpTrigger.Spec.CorsEnable = corsEnabled
+
+		corsDomain, err := cmd.Flags().GetString("cors-domain")
+		if err != nil {
+			logrus.Fatal(err)
+		}
+		httpTrigger.Spec.CorsDomain = corsDomain
 
 		tlsSecret, err := cmd.Flags().GetString("tls-secret")
 		if err != nil {
@@ -179,5 +189,7 @@ func init() {
 	createCmd.Flags().StringP("tls-secret", "", "", "Specify an existing secret that contains a TLS private key and certificate to secure ingress")
 	createCmd.Flags().Bool("dryrun", false, "Output JSON manifest of the function without creating it")
 	createCmd.Flags().StringP("output", "o", "yaml", "Output format")
+	createCmd.Flags().BoolP("cors-enable","",false,"If true then cors will be enabled on Http Trigger")
+	createCmd.Flags().StringP("cors-domain","","*","Specify CORS origin domain, by default its value is * if cors is enabled")
 	createCmd.MarkFlagRequired("function-name")
 }

--- a/cmd/kubeless/trigger/http/create.go
+++ b/cmd/kubeless/trigger/http/create.go
@@ -18,11 +18,11 @@ package http
 
 import (
 	"fmt"
-	"github.com/sirupsen/logrus"
-	"github.com/spf13/cobra"
 	httpApi "github.com/kubeless/http-trigger/pkg/apis/kubeless/v1beta1"
 	httpUtils "github.com/kubeless/http-trigger/pkg/utils"
 	kubelessUtils "github.com/kubeless/kubeless/pkg/utils"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -183,6 +183,6 @@ func init() {
 	createCmd.Flags().StringP("tls-secret", "", "", "Specify an existing secret that contains a TLS private key and certificate to secure ingress")
 	createCmd.Flags().Bool("dryrun", false, "Output JSON manifest of the function without creating it")
 	createCmd.Flags().StringP("output", "o", "yaml", "Output format")
-	createCmd.Flags().BoolP("cors-enable","",false,"If true then cors will be enabled on Http Trigger")
+	createCmd.Flags().BoolP("cors-enable", "", false, "If true then cors will be enabled on Http Trigger")
 	createCmd.MarkFlagRequired("function-name")
 }

--- a/cmd/kubeless/trigger/http/create.go
+++ b/cmd/kubeless/trigger/http/create.go
@@ -184,6 +184,5 @@ func init() {
 	createCmd.Flags().Bool("dryrun", false, "Output JSON manifest of the function without creating it")
 	createCmd.Flags().StringP("output", "o", "yaml", "Output format")
 	createCmd.Flags().BoolP("cors-enable","",false,"If true then cors will be enabled on Http Trigger")
-	createCmd.Flags().StringP("cors-domain","","*","Specify CORS origin domain, by default its value is * if cors is enabled")
 	createCmd.MarkFlagRequired("function-name")
 }

--- a/docs/http-triggers.md
+++ b/docs/http-triggers.md
@@ -83,6 +83,7 @@ Usage:
 
 Flags:
       --basic-auth-secret string   Specify an existing secret name for basic authentication
+      --cors-enable                If true then cors will be enabled on Http Trigger
       --enableTLSAcme              If true, routing rule will be configured for use with kube-lego
       --function-name string       Name of the function to be associated with trigger
       --gateway string             Specify a valid gateway for the Ingress. Supported: nginx, traefik, kong (default "nginx")
@@ -128,6 +129,37 @@ $ curl --data '{"Another": "Echo"}' \
 {"Another": "Echo"}
 ```
 
+To enable CORS on a HTTPTrigger there are following ways.
+
+- Use cors-enable flag in "kubeless trigger http create"
+- Specify cors-enable in HTTPTrigger yaml file as below. i.e.
+```
+apiVersion: kubeless.io/v1beta1
+kind: HTTPTrigger
+metadata:
+ name: cors-trigger
+spec:
+ function-name: get-python
+ host-name: example.com
+ path: echo
+ gateway: nginx
+ cors-enable: true
+```
+- Specify annotations in HTTPTrigger yaml file, which will get copied to annotations
+of ingress resource. Using this you can be more granular in specifying CORS settings.
+```
+apiVersion: kubeless.io/v1beta1
+kind: HTTPTrigger
+metadata:
+ name: cors-trigger
+ annotations:
+  nginx.ingress.kubernetes.io/enable-cors: "true"
+  nginx.ingress.kubernetes.io/cors-allow-methods: "GET"
+spec:
+ function-name: get-python
+ host-name: example.com
+ path: echo
+``` 
 ## Enable TLS
 
 Once you have one of the supported Ingress Controller it is possible to enable TLS using a certificate:

--- a/docs/http-triggers.md
+++ b/docs/http-triggers.md
@@ -129,38 +129,6 @@ $ curl --data '{"Another": "Echo"}' \
 {"Another": "Echo"}
 ```
 
-To enable CORS on a HTTPTrigger there are following ways.
-
-- Use cors-enable flag in "kubeless trigger http create"
-- Specify cors-enable in HTTPTrigger yaml file as below. i.e.
-```
-apiVersion: kubeless.io/v1beta1
-kind: HTTPTrigger
-metadata:
- name: cors-trigger
-spec:
- function-name: get-python
- host-name: example.com
- path: echo
- gateway: nginx
- cors-enable: true
-```
-- Specify annotations in HTTPTrigger yaml file, which will get copied to annotations
-of ingress resource. Using this you can be more granular in specifying CORS settings.
-```
-apiVersion: kubeless.io/v1beta1
-kind: HTTPTrigger
-metadata:
- name: cors-trigger
- annotations:
-  nginx.ingress.kubernetes.io/enable-cors: "true"
-  nginx.ingress.kubernetes.io/cors-allow-methods: "GET"
-spec:
- function-name: get-python
- host-name: example.com
- path: echo
-``` 
-
 ## Enable TLS
 
 Once you have one of the supported Ingress Controller it is possible to enable TLS using a certificate:
@@ -260,6 +228,32 @@ hello world
 ### Enable Basic Authentication with Kong
 
 It is not yet supported to create an HTTP trigger with basic authentication using Kong as backend but the steps to do it manually are pretty simple. It is possible to do so using Kong plugins. In the [next section](#enable-kong-security-plugins) we explain how to enable any of the available Kong plugins and in particular we explain how to enable the basic-auth plugin.
+
+## Enable CORS
+
+It's possible to enable CORS requests at the HTTPTrigger level. To do so use the --cors-enable flag when deploying
+the HTTPTrigger or add the field cors-enable: true to the YAML manifest.
+
+## Add arbitrary annotations
+
+It is also possible to add any annotation to the resulting Ingress object if you add those to the HTTPTrigger. For example:
+
+```
+apiVersion: kubeless.io/v1beta1
+kind: HTTPTrigger
+metadata:
+ name: cors-trigger
+ annotations:
+  nginx.ingress.kubernetes.io/enable-cors: "true"
+  nginx.ingress.kubernetes.io/cors-allow-methods: "GET"
+spec:
+ function-name: get-python
+ host-name: example.com
+ path: echo
+```
+
+The above will create an Ingress object with the annotations nginx.ingress.kubernetes.io/enable-cors: "true"
+and nginx.ingress.kubernetes.io/cors-allow-methods: "GET".
 
 ## Enable Kong Security plugins
 

--- a/docs/http-triggers.md
+++ b/docs/http-triggers.md
@@ -160,6 +160,7 @@ spec:
  host-name: example.com
  path: echo
 ``` 
+
 ## Enable TLS
 
 Once you have one of the supported Ingress Controller it is possible to enable TLS using a certificate:

--- a/script/start-test-environment.sh
+++ b/script/start-test-environment.sh
@@ -15,7 +15,7 @@ if ! minikube status | grep -q "minikube: $"; then
   exit 1
 fi
 
-minikube start --extra-config=apiserver.Authorization.Mode=RBAC --insecure-registry 0.0.0.0/0
+minikube start --extra-config=apiserver.authorization-mode=RBAC --insecure-registry 0.0.0.0/0
 eval $(minikube docker-env)
 
 CONTEXT=$(kubectl config current-context)

--- a/vendor/github.com/kubeless/http-trigger/pkg/apis/kubeless/v1beta1/http_trigger.go
+++ b/vendor/github.com/kubeless/http-trigger/pkg/apis/kubeless/v1beta1/http_trigger.go
@@ -39,6 +39,7 @@ type HTTPTriggerSpec struct {
 	Path            string `json:"path"`
 	BasicAuthSecret string `json:"basic-auth-secret"`
 	Gateway         string `json:"gateway"`
+	CorsEnable		bool `json:"cors-enable"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/vendor/github.com/kubeless/http-trigger/pkg/utils/k8sutil.go
+++ b/vendor/github.com/kubeless/http-trigger/pkg/utils/k8sutil.go
@@ -25,16 +25,14 @@ import (
 
 	httptriggerapi "github.com/kubeless/http-trigger/pkg/apis/kubeless/v1beta1"
 	kubelessApi "github.com/kubeless/http-trigger/pkg/apis/kubeless/v1beta1"
+
 	"k8s.io/api/extensions/v1beta1"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
-
-	"github.com/sirupsen/logrus"
-
 	"k8s.io/client-go/rest"
-
+	"k8s.io/client-go/tools/clientcmd"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/types"
 
 	// Auth plugins
@@ -266,6 +264,20 @@ func CreateIngress(client kubernetes.Interface, httpTriggerObj *kubelessApi.HTTP
 	// Without a rewrite any request will return 404. Set the annotation ingress.kubernetes.io/rewrite-target
 	// to the path expected by the service
 	ingressAnnotations["nginx.ingress.kubernetes.io/rewrite-target"] = "/"
+	if len(httpTriggerObj.ObjectMeta.Annotations) > 0 {
+		for k,v := range httpTriggerObj.ObjectMeta.Annotations {
+			ingressAnnotations[k] = v
+		}
+	}
+
+	if httpTriggerObj.Spec.CorsEnable == true {
+		switch gateway := httpTriggerObj.Spec.Gateway; gateway {
+		case "nginx":
+			ingressAnnotations["nginx.ingress.kubernetes.io/enable-cors"] = "true"
+		default:
+			ingressAnnotations["ingress.kubernetes.io/enable-cors"] = "true"
+		}
+	}
 
 	if len(httpTriggerObj.Spec.BasicAuthSecret) > 0 {
 		switch gateway := httpTriggerObj.Spec.Gateway; gateway {


### PR DESCRIPTION
**Issue Ref**: [Issue number related to this PR or None]
 934
**Description**: 
Support for CORS for HTTP endpoints is expected here. This pull request provides cors flag while creating HTTP trigger.

[PR Description]
cors flag has been added to below command
kubeless trigger http create
cors-enable flag is a boolean flag, by default it is false to be backward compatible.
if cors-enable flag is true, then one can specify cors-domain  which will set that only for this cors-domain, cors will be enabled.
Tests have been added to http-trigger repo.
**TODOs**:
 - [x] Ready to review
 - [x] Automated Tests
 - [ ] Docs