### PR TITLE
Passing Container env variables to Compile container

### DIFF
--- a/pkg/langruntime/langruntime.go
+++ b/pkg/langruntime/langruntime.go
@@ -316,7 +316,7 @@ func (l *Langruntimes) UpdateDeployment(dpm *v1beta1.Deployment, volPath, runtim
 }
 
 // GetCompilationContainer returns a Container definition based on a runtime
-func (l *Langruntimes) GetCompilationContainer(runtime, funcName string, installVolume v1.VolumeMount) (*v1.Container, error) {
+func (l *Langruntimes) GetCompilationContainer(runtime, funcName string, env []v1.EnvVar, installVolume v1.VolumeMount) (*v1.Container, error) {
 	versionInf, err := l.findRuntimeVersion(runtime)
 	if err != nil {
 		return nil, err
@@ -328,11 +328,12 @@ func (l *Langruntimes) GetCompilationContainer(runtime, funcName string, install
 		return nil, nil
 	}
 
-	env := append(
-		parseEnv(imageInf.Env),
+	env = append(
+		env,
 		v1.EnvVar{Name: "KUBELESS_INSTALL_VOLUME", Value: installVolume.MountPath},
 		v1.EnvVar{Name: "KUBELESS_FUNC_NAME", Value: funcName},
 	)
+	env = append(env, parseEnv(imageInf.Env)...)
 	return &v1.Container{
 		Name:            "compile",
 		Image:           imageInf.Image,

--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -379,13 +379,13 @@ func populatePodSpec(funcObj *kubelessApi.Function, lr *langruntime.Langruntimes
 
 	// ensure that the runtime is supported for installing dependencies
 	_, err := lr.GetRuntimeInfo(funcObj.Spec.Runtime)
+	envVars := []v1.EnvVar{}
+	if len(result.Containers) > 0 {
+		envVars = result.Containers[0].Env
+	}
 	if funcObj.Spec.Deps != "" && err != nil {
 		return fmt.Errorf("Unable to install dependencies for the runtime %s", funcObj.Spec.Runtime)
 	} else if funcObj.Spec.Deps != "" {
-		envVars := []v1.EnvVar{}
-		if len(result.Containers) > 0 {
-			envVars = result.Containers[0].Env
-		}
 		depsChecksum, err := getChecksum(funcObj.Spec.Deps)
 		if err != nil {
 			return fmt.Errorf("Unable to obtain dependencies checksum: %v", err)
@@ -404,7 +404,7 @@ func populatePodSpec(funcObj *kubelessApi.Function, lr *langruntime.Langruntimes
 
 	// add compilation init container if needed
 	_, funcName, _ := splitHandler(funcObj.Spec.Handler)
-	compContainer, err := lr.GetCompilationContainer(funcObj.Spec.Runtime, funcName, runtimeVolumeMount)
+	compContainer, err := lr.GetCompilationContainer(funcObj.Spec.Runtime, funcName, envVars, runtimeVolumeMount)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Container env variable array was not passed to Compile Container method. This made all those environment variable missing in Compile container phase
This is for issue 972

**Issue Ref**: 972
 
**Description**: Container env variable array was not passed to Compile Container method. This made all those environment variable missing in Compile container phase

[PR Description]:Pass environment variables to compile phase of a Java function container
