### PR TITLE
Include information about nuget.config in .NET Core documentation

### DIFF
--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -438,14 +438,8 @@ kubeless function deploy fibonacci --from-file fibonacci.cs --handler module.han
 
 ##### `nuget.config`
 
-If you happen to be using custom nuget repositories through a `nuget.config` file, you'll need to include the file along with the code inside a `.zip` file with roughly this structure:
-```
-custom-deps.zip
-|\_ nuget.config
-\__ custom-deps.cs
-```
+If you happen to be using custom nuget repositories through a `nuget.config` file, you'll need to include the file along with the code inside a `.zip` file and then you can deploy the function with the `nuget.config` using the command:
 
-And then you can deploy it using the command:
 ```bash
 kubeless function deploy custom-deps --from-file custom-deps.zip --handler module.handler --dependencies custom-deps.csproj --runtime dotnetcore2.0
 ```

--- a/docs/runtimes.md
+++ b/docs/runtimes.md
@@ -436,6 +436,20 @@ You can deploy them using the command:
 kubeless function deploy fibonacci --from-file fibonacci.cs --handler module.handler --dependencies fibonacci.csproj --runtime dotnetcore2.0
 ```
 
+##### `nuget.config`
+
+If you happen to be using custom nuget repositories through a `nuget.config` file, you'll need to include the file along with the code inside a `.zip` file with roughly this structure:
+```
+custom-deps.zip
+|\_ nuget.config
+\__ custom-deps.cs
+```
+
+And then you can deploy it using the command:
+```bash
+kubeless function deploy custom-deps --from-file custom-deps.zip --handler module.handler --dependencies custom-deps.csproj --runtime dotnetcore2.0
+```
+
 ### Ballerina
 
 #### Example


### PR DESCRIPTION
**Issue Ref**: kubeless/runtimes#45
 
**Description**:
Information about usage of `nuget.config` is not readily available in the documentation and this PR aims to solve that issue.
Although this can be discovered through experimentation after finding out that using zip files is possible (which I discovered after seeing the REST API example in the functions repository), I believe it would be more beneficial to include it in the documentation.

**TODOs**:
 - [x] Ready to review
 - [x] ~Automated Tests~ (N/A)
 - [x] Docs