### PR TITLE
Use new apps/v1 endpoint

### DIFF
--- a/cmd/kubeless/function/function.go
+++ b/cmd/kubeless/function/function.go
@@ -33,7 +33,7 @@ import (
 	kubelessApi "github.com/kubeless/kubeless/pkg/apis/kubeless/v1beta1"
 	"github.com/kubeless/kubeless/pkg/client/clientset/versioned"
 	"github.com/spf13/cobra"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -359,7 +359,7 @@ func getFunctionDescription(funcName, ns, handler, file, deps, runtime, runtimeI
 }
 
 func getDeploymentStatus(cli kubernetes.Interface, funcName, ns string) (string, error) {
-	dpm, err := cli.ExtensionsV1beta1().Deployments(ns).Get(funcName, metav1.GetOptions{})
+	dpm, err := cli.AppsV1().Deployments(ns).Get(funcName, metav1.GetOptions{})
 	if err != nil {
 		return "", err
 	}

--- a/cmd/kubeless/function/function_test.go
+++ b/cmd/kubeless/function/function_test.go
@@ -28,9 +28,9 @@ import (
 	"testing"
 
 	kubelessApi "github.com/kubeless/kubeless/pkg/apis/kubeless/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/autoscaling/v2beta1"
-	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
@@ -129,8 +129,8 @@ func TestGetFunctionDescription(t *testing.T) {
 			FunctionContentType: "text",
 			Deps:                "dependencies",
 			Timeout:             "10",
-			Deployment: v1beta1.Deployment{
-				Spec: v1beta1.DeploymentSpec{
+			Deployment: appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
 					Template: v1.PodTemplateSpec{
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{
@@ -237,8 +237,8 @@ func TestGetFunctionDescription(t *testing.T) {
 			Checksum:            "sha256:1958eb96d7d3cadedd0f327f09322eb7db296afb282ed91aa66cb4ab0dcc3c9f",
 			Deps:                "dependencies2",
 			Timeout:             "20",
-			Deployment: v1beta1.Deployment{
-				Spec: v1beta1.DeploymentSpec{
+			Deployment: appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
 					Template: v1.PodTemplateSpec{
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{
@@ -401,8 +401,8 @@ func TestGetFunctionDescription(t *testing.T) {
 			FunctionContentType: "url",
 			Deps:                "dependencies",
 			Timeout:             "10",
-			Deployment: v1beta1.Deployment{
-				Spec: v1beta1.DeploymentSpec{
+			Deployment: appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
 					Template: v1.PodTemplateSpec{
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{

--- a/cmd/kubeless/function/list_test.go
+++ b/cmd/kubeless/function/list_test.go
@@ -22,8 +22,8 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/kubernetes"
@@ -58,8 +58,8 @@ func TestList(t *testing.T) {
 					Function: "ffunction",
 					Runtime:  "fruntime",
 					Deps:     "fdeps",
-					Deployment: v1beta1.Deployment{
-						Spec: v1beta1.DeploymentSpec{
+					Deployment: appsv1.Deployment{
+						Spec: appsv1.DeploymentSpec{
 							Template: v1.PodTemplateSpec{
 								Spec: v1.PodSpec{
 									Containers: []v1.Container{{}},
@@ -82,8 +82,8 @@ func TestList(t *testing.T) {
 					Function: "bfunction",
 					Runtime:  "nodejs6",
 					Deps:     "{\"dependencies\": {\"test\": \"^1.0.0\"}}",
-					Deployment: v1beta1.Deployment{
-						Spec: v1beta1.DeploymentSpec{
+					Deployment: appsv1.Deployment{
+						Spec: appsv1.DeploymentSpec{
 							Template: v1.PodTemplateSpec{
 								Spec: v1.PodSpec{
 									Containers: []v1.Container{
@@ -124,8 +124,8 @@ func TestList(t *testing.T) {
 					Function: "ffunction",
 					Runtime:  "fruntime",
 					Deps:     "fdeps",
-					Deployment: v1beta1.Deployment{
-						Spec: v1beta1.DeploymentSpec{
+					Deployment: appsv1.Deployment{
+						Spec: appsv1.DeploymentSpec{
 							Template: v1.PodTemplateSpec{
 								Spec: v1.PodSpec{
 									Containers: []v1.Container{{}},
@@ -140,22 +140,22 @@ func TestList(t *testing.T) {
 
 	client := fFake.NewSimpleClientset(listObj.Items[0], listObj.Items[1], listObj.Items[2])
 
-	deploymentFoo := v1beta1.Deployment{
+	deploymentFoo := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "foo",
 			Namespace: "myns",
 		},
-		Status: v1beta1.DeploymentStatus{
+		Status: appsv1.DeploymentStatus{
 			Replicas:      int32(1),
 			ReadyReplicas: int32(1),
 		},
 	}
-	deploymentBar := v1beta1.Deployment{
+	deploymentBar := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "bar",
 			Namespace: "myns",
 		},
-		Status: v1beta1.DeploymentStatus{
+		Status: appsv1.DeploymentStatus{
 			Replicas:      int32(2),
 			ReadyReplicas: int32(0),
 		},

--- a/cmd/kubeless/function/top_test.go
+++ b/cmd/kubeless/function/top_test.go
@@ -25,8 +25,8 @@ import (
 	"strings"
 	"testing"
 
-	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes"
@@ -280,8 +280,8 @@ func TestTop(t *testing.T) {
 					Function: function1Name,
 					Runtime:  "pyruntime",
 					Deps:     "pydeps",
-					Deployment: v1beta1.Deployment{
-						Spec: v1beta1.DeploymentSpec{
+					Deployment: appsv1.Deployment{
+						Spec: appsv1.DeploymentSpec{
 							Template: v1.PodTemplateSpec{
 								Spec: v1.PodSpec{
 									Containers: []v1.Container{{}},
@@ -301,8 +301,8 @@ func TestTop(t *testing.T) {
 					Function: function2Name,
 					Runtime:  "goruntime",
 					Deps:     "godeps",
-					Deployment: v1beta1.Deployment{
-						Spec: v1beta1.DeploymentSpec{
+					Deployment: appsv1.Deployment{
+						Spec: appsv1.DeploymentSpec{
 							Template: v1.PodTemplateSpec{
 								Spec: v1.PodSpec{
 									Containers: []v1.Container{{}},
@@ -317,22 +317,22 @@ func TestTop(t *testing.T) {
 
 	client := fFake.NewSimpleClientset(listObj.Items[0], listObj.Items[1])
 
-	deploymentPy := v1beta1.Deployment{
+	deploymentPy := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      function1Name,
 			Namespace: namespace,
 		},
-		Status: v1beta1.DeploymentStatus{
+		Status: appsv1.DeploymentStatus{
 			Replicas:      int32(1),
 			ReadyReplicas: int32(1),
 		},
 	}
-	deploymentGo := v1beta1.Deployment{
+	deploymentGo := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      function2Name,
 			Namespace: namespace,
 		},
-		Status: v1beta1.DeploymentStatus{
+		Status: appsv1.DeploymentStatus{
 			Replicas:      int32(1),
 			ReadyReplicas: int32(1),
 		},

--- a/pkg/apis/kubeless/v1beta1/function.go
+++ b/pkg/apis/kubeless/v1beta1/function.go
@@ -17,9 +17,9 @@ limitations under the License.
 package v1beta1
 
 import (
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/autoscaling/v2beta1"
-	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -42,7 +42,7 @@ type FunctionSpec struct {
 	Runtime                 string                          `json:"runtime"`               // Function runtime to use
 	Timeout                 string                          `json:"timeout"`               // Maximum timeout for the function to complete its execution
 	Deps                    string                          `json:"deps"`                  // Function dependencies
-	Deployment              v1beta1.Deployment              `json:"deployment" protobuf:"bytes,3,opt,name=template"`
+	Deployment              appsv1.Deployment               `json:"deployment" protobuf:"bytes,3,opt,name=template"`
 	ServiceSpec             v1.ServiceSpec                  `json:"service"`
 	HorizontalPodAutoscaler v2beta1.HorizontalPodAutoscaler `json:"horizontalPodAutoscaler" protobuf:"bytes,3,opt,name=horizontalPodAutoscaler"`
 }

--- a/pkg/controller/function_controller.go
+++ b/pkg/controller/function_controller.go
@@ -24,9 +24,9 @@ import (
 
 	monitoringv1alpha1 "github.com/coreos/prometheus-operator/pkg/client/monitoring/v1alpha1"
 	"github.com/sirupsen/logrus"
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/autoscaling/v2beta1"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
 	apiequality "k8s.io/apimachinery/pkg/api/equality"
 	k8sErrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -300,7 +300,7 @@ func (c *FunctionController) ensureK8sResources(funcObj *kubelessApi.Function) e
 	}
 	funcObj.ObjectMeta.Labels["function"] = funcObj.ObjectMeta.Name
 
-	deployment := v1beta1.Deployment{}
+	deployment := appsv1.Deployment{}
 	if deploymentConfigData, ok := c.config.Data["deployment"]; ok {
 		err := yaml.Unmarshal([]byte(deploymentConfigData), &deployment)
 		if err != nil {

--- a/pkg/langruntime/langruntime.go
+++ b/pkg/langruntime/langruntime.go
@@ -9,8 +9,8 @@ import (
 
 	yaml "github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
-	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -293,7 +293,7 @@ func (l *Langruntimes) GetBuildContainer(runtime, depsChecksum string, env []v1.
 }
 
 // UpdateDeployment object in case of custom runtime
-func (l *Langruntimes) UpdateDeployment(dpm *v1beta1.Deployment, volPath, runtime string) {
+func (l *Langruntimes) UpdateDeployment(dpm *appsv1.Deployment, volPath, runtime string) {
 	versionInf, err := l.findRuntimeVersion(runtime)
 	if err != nil {
 		// Not found an image for the given runtime

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -28,9 +28,9 @@ import (
 	kubelessApi "github.com/kubeless/kubeless/pkg/apis/kubeless/v1beta1"
 	"github.com/sirupsen/logrus"
 
+	appsv1 "k8s.io/api/apps/v1"
 	"k8s.io/api/autoscaling/v2beta1"
-	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	v1 "k8s.io/api/core/v1"
 	clientsetAPIExtensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
@@ -347,7 +347,7 @@ func DeleteServiceMonitor(smclient monitoringv1alpha1.MonitoringV1alpha1Client, 
 
 // InitializeEmptyMapsInDeployment initializes all nil maps in a Deployment object
 // This is done to counteract with side-effects of github.com/imdario/mergo which panics when provided with a nil map in a struct
-func initializeEmptyMapsInDeployment(deployment *v1beta1.Deployment) {
+func initializeEmptyMapsInDeployment(deployment *appsv1.Deployment) {
 	if deployment.ObjectMeta.Annotations == nil {
 		deployment.Annotations = make(map[string]string)
 	}
@@ -369,7 +369,7 @@ func initializeEmptyMapsInDeployment(deployment *v1beta1.Deployment) {
 }
 
 // MergeDeployments merges two deployment objects
-func MergeDeployments(destinationDeployment *v1beta1.Deployment, sourceDeployment *v1beta1.Deployment) error {
+func MergeDeployments(destinationDeployment *appsv1.Deployment, sourceDeployment *appsv1.Deployment) error {
 	// Initializing nil maps in deployment objects else github.com/imdario/mergo panics
 	initializeEmptyMapsInDeployment(destinationDeployment)
 	initializeEmptyMapsInDeployment(sourceDeployment)

--- a/pkg/utils/k8sutil_test.go
+++ b/pkg/utils/k8sutil_test.go
@@ -7,8 +7,8 @@ import (
 	"io/ioutil"
 	"testing"
 
+	appsv1 "k8s.io/api/apps/v1"
 	v2beta1 "k8s.io/api/autoscaling/v2beta1"
-	"k8s.io/api/extensions/v1beta1"
 	extensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	fakeextensionsapi "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -100,7 +100,7 @@ func TestDeleteAutoscaleResource(t *testing.T) {
 }
 
 func TestInitializeEmptyMapsInDeployment(t *testing.T) {
-	deployment := v1beta1.Deployment{}
+	deployment := appsv1.Deployment{}
 	deployment.Spec.Selector = &metav1.LabelSelector{}
 	initializeEmptyMapsInDeployment(&deployment)
 	if deployment.ObjectMeta.Annotations == nil {
@@ -126,7 +126,7 @@ func TestInitializeEmptyMapsInDeployment(t *testing.T) {
 func TestMergeDeployments(t *testing.T) {
 	var replicas int32
 	replicas = 10
-	destinationDeployment := v1beta1.Deployment{
+	destinationDeployment := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				"foo1-deploy": "bar",
@@ -134,13 +134,13 @@ func TestMergeDeployments(t *testing.T) {
 		},
 	}
 
-	sourceDeployment := v1beta1.Deployment{
+	sourceDeployment := appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Annotations: map[string]string{
 				"foo2-deploy": "bar",
 			},
 		},
-		Spec: v1beta1.DeploymentSpec{
+		Spec: appsv1.DeploymentSpec{
 			Replicas: &replicas,
 		},
 	}

--- a/pkg/utils/kubelessutil_test.go
+++ b/pkg/utils/kubelessutil_test.go
@@ -9,8 +9,8 @@ import (
 	kubelessApi "github.com/kubeless/kubeless/pkg/apis/kubeless/v1beta1"
 	"github.com/kubeless/kubeless/pkg/langruntime"
 
-	"k8s.io/api/core/v1"
-	"k8s.io/api/extensions/v1beta1"
+	appsv1 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/client-go/kubernetes/fake"
@@ -470,8 +470,8 @@ func getDefaultFunc(name, ns string) *kubelessApi.Function {
 				},
 				Type: v1.ServiceTypeClusterIP,
 			},
-			Deployment: v1beta1.Deployment{
-				Spec: v1beta1.DeploymentSpec{
+			Deployment: appsv1.Deployment{
+				Spec: appsv1.DeploymentSpec{
 					Template: v1.PodTemplateSpec{
 						Spec: v1.PodSpec{
 							Containers: []v1.Container{
@@ -534,7 +534,7 @@ func TestEnsureDeployment(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
-	dpm, err := clientset.ExtensionsV1beta1().Deployments(ns).Get(f1Name, metav1.GetOptions{})
+	dpm, err := clientset.AppsV1().Deployments(ns).Get(f1Name, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -653,7 +653,7 @@ func TestEnsureDeploymentWithoutFuncNorHandler(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
-	_, err = clientset.ExtensionsV1beta1().Deployments(ns).Get(funcName, metav1.GetOptions{})
+	_, err = clientset.AppsV1().Deployments(ns).Get(funcName, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -669,7 +669,7 @@ func TestEnsureDeploymentWithImage(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
-	dpm, err := clientset.ExtensionsV1beta1().Deployments(ns).Get(funcName, metav1.GetOptions{})
+	dpm, err := clientset.AppsV1().Deployments(ns).Get(funcName, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -689,7 +689,7 @@ func TestEnsureDeploymentWithoutFunc(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
-	dpm, err := clientset.ExtensionsV1beta1().Deployments(ns).Get(funcName, metav1.GetOptions{})
+	dpm, err := clientset.AppsV1().Deployments(ns).Get(funcName, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -731,7 +731,7 @@ func TestEnsureUpdateDeployment(t *testing.T) {
 func TestAvoidDeploymentOverwrite(t *testing.T) {
 	f1Name := "f1"
 	clientset, or, ns, lr := prepareDeploymentTest(f1Name)
-	clientset.ExtensionsV1beta1().Deployments(ns).Create(&v1beta1.Deployment{
+	clientset.AppsV1().Deployments(ns).Create(&appsv1.Deployment{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      f1Name,
 			Namespace: ns,
@@ -768,7 +768,7 @@ func TestDeploymentWithTimeout(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
-	dpm, err := clientset.ExtensionsV1beta1().Deployments(ns).Get(funcName, metav1.GetOptions{})
+	dpm, err := clientset.AppsV1().Deployments(ns).Get(funcName, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -786,7 +786,7 @@ func TestDeploymentWithPrebuiltImage(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
-	dpm, err := clientset.ExtensionsV1beta1().Deployments(ns).Get(funcName, metav1.GetOptions{})
+	dpm, err := clientset.AppsV1().Deployments(ns).Get(funcName, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -819,7 +819,7 @@ func TestDeploymentWithVolumes(t *testing.T) {
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
-	dpm, err := clientset.ExtensionsV1beta1().Deployments(ns).Get(funcName, metav1.GetOptions{})
+	dpm, err := clientset.AppsV1().Deployments(ns).Get(funcName, metav1.GetOptions{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}


### PR DESCRIPTION
**Issue Ref**: #1086 
 
**Description**: 

Use apps/v1 endpoint instead of the deprecated extensions/v1beta1.

**TODOs**:
 - [X] Ready to review
 - [X] Automated Tests
 ~~- [ ] Docs~~
