### PR TITLE
fixes bug so that configmap volumemounts are merged in deployment

### DIFF
--- a/pkg/utils/k8sutil_test.go
+++ b/pkg/utils/k8sutil_test.go
@@ -8,8 +8,8 @@ import (
 	"testing"
 
 	appsv1 "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 	v2beta1 "k8s.io/api/autoscaling/v2beta1"
+	corev1 "k8s.io/api/core/v1"
 	extensionsv1beta1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
 	fakeextensionsapi "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset/fake"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"


### PR DESCRIPTION
**Issue Ref**: [#1035]
 
**Description**: 

Manually merge VolumeMounts in runtime container if defined in configmap.
[Mergo](https://github.com/imdario/mergo) doesn't add the VolumeMounts https://github.com/kubeless/kubeless/blob/master/pkg/utils/k8sutil.go#L376
possibly due to this error
```
cannot use deployment.Spec.Template.Spec.Containers[0].VolumeMounts (type []"k8s.io/api/core/v1".VolumeMount) as type "k8s.io/api/core/v1".VolumeMount in append
```

**TODOs**:
 - [x] Ready to review
 - [x] Automated Tests
 - [ ] Docs
