### PR TITLE
Display function list command with namespace argument after deploy/update

### DIFF
--- a/cmd/kubeless/function/deploy.go
+++ b/cmd/kubeless/function/deploy.go
@@ -100,8 +100,11 @@ var deployCmd = &cobra.Command{
 		if err != nil {
 			logrus.Fatal(err)
 		}
+		var nsArg string
 		if ns == "" {
 			ns = kubelessutil.GetDefaultNamespace()
+		} else {
+			nsArg = fmt.Sprintf(" -n %s", ns)
 		}
 
 		deps, err := cmd.Flags().GetString("dependencies")
@@ -243,7 +246,7 @@ var deployCmd = &cobra.Command{
 			logrus.Fatalf("Failed to deploy %s. Received:\n%s", funcName, err)
 		}
 		logrus.Infof("Function %s submitted for deployment", funcName)
-		logrus.Infof("Check the deployment status executing 'kubeless function ls %s'", funcName)
+		logrus.Infof("Check the deployment status executing 'kubeless function ls %s%s'", funcName, nsArg)
 
 		if schedule != "" {
 			cronJobTrigger := cronjobApi.CronJobTrigger{}

--- a/cmd/kubeless/function/update.go
+++ b/cmd/kubeless/function/update.go
@@ -52,8 +52,11 @@ var updateCmd = &cobra.Command{
 		if err != nil {
 			logrus.Fatal(err)
 		}
+		var nsArg string
 		if ns == "" {
 			ns = utils.GetDefaultNamespace()
+		} else {
+			nsArg = fmt.Sprintf(" -n %s", ns)
 		}
 
 		handler, err := cmd.Flags().GetString("handler")
@@ -210,7 +213,7 @@ var updateCmd = &cobra.Command{
 			logrus.Fatal(err)
 		}
 		logrus.Infof("Function %s submitted for deployment", funcName)
-		logrus.Infof("Check the deployment status executing 'kubeless function ls %s'", funcName)
+		logrus.Infof("Check the deployment status executing 'kubeless function ls %s%s'", funcName, nsArg)
 	},
 }
 


### PR DESCRIPTION
**Issue Ref**: #1160 
 
**Description**: 

The `kubeless function ls` command which is displayed at the end of function deploy/update should include the namespace argument (if any) without which the command does not display any functions.

**TODOs**:
 - [x] Ready to review
 - [ ] Automated Tests
 - [ ] Docs
