### PR TITLE
Add secrets to runtime configuration

### DIFF
--- a/docs/function-controller-configuration.md
+++ b/docs/function-controller-configuration.md
@@ -236,7 +236,7 @@ It is possible to configure the different images that Kubeless uses to deploy an
   - Init Image: Image used for installing the function and/or dependencies.
   - (Optional) Image Pull Secrets: Secret required to pull the image in case the repository is private.
   - (Optional) Environment variables.
-  - (Optional) Secrets: Shared with the container as mounted volumes.
+  - (Optional) Secrets: Shared with the container as volumes mounted at `/var/run/secrets/kubeless.io/`.
  - The image used to populate the base image with the function. This is called `provision-image`. This image should have at least `unzip`, `GNU tar`, `gzip`, `bzip2`, `xz` and `curl`. It is also possible to specify `provision-image-secret` to specify a secret to pull that image from a private registry.
  - The image used to build function images. This is called `builder-image`. This image is optional since its usage can be disabled with the property `enable-build-step`. A Dockerfile to build this image can be found [here](https://github.com/kubeless/kubeless/tree/master/docker/function-image-builder). It is also possible to specify `builder-image-secret` to specify a secret to pull that image from a private registry.
  

--- a/docs/function-controller-configuration.md
+++ b/docs/function-controller-configuration.md
@@ -227,14 +227,16 @@ The same process should be followed for any trigger controller installed (Kafka,
 
 ## Using custom images
 
-It is possible to configure the different images that Kubeless uses for deploy and execute functions. In this ConfigMap you can configure:
+It is possible to configure the different images that Kubeless uses to deploy and execute functions. In this ConfigMap you can configure:
 
- - Different or additional runtimes. For doing so it is possible to modify/add a runtime in the field `runtimeImages`. Runtimes are categorized by major version. See the guide for [implementing a new runtime](/docs/implementing-new-runtime) for more information. Each major version has:
+ - Different or additional runtimes. For doing so it is possible to modify/add a runtime in the field `runtime-images`. Runtimes are categorized by major version. See the guide for [implementing a new runtime](/docs/implementing-new-runtime) for more information. Each major version has:
   - Name: Unique ID of the runtime. It should contain the runtime name and version.
   - Version: Major and minor version of the runtime.
   - Runtime Image: Image used to execute the function.
   - Init Image: Image used for installing the function and/or dependencies.
   - (Optional) Image Pull Secrets: Secret required to pull the image in case the repository is private.
+  - (Optional) Environment variables.
+  - (Optional) Secrets: Shared with the container as mounted volumes.
  - The image used to populate the base image with the function. This is called `provision-image`. This image should have at least `unzip`, `GNU tar`, `gzip`, `bzip2`, `xz` and `curl`. It is also possible to specify `provision-image-secret` to specify a secret to pull that image from a private registry.
  - The image used to build function images. This is called `builder-image`. This image is optional since its usage can be disabled with the property `enable-build-step`. A Dockerfile to build this image can be found [here](https://github.com/kubeless/kubeless/tree/master/docker/function-image-builder). It is also possible to specify `builder-image-secret` to specify a secret to pull that image from a private registry.
  

--- a/pkg/controller/function_controller.go
+++ b/pkg/controller/function_controller.go
@@ -116,6 +116,7 @@ func NewFunctionController(cfg Config, smclient *monitoringv1alpha1.MonitoringV1
 	if config.Data["enable-build-step"] == "true" {
 		imagePullSecrets = append(imagePullSecrets, utils.GetSecretsAsLocalObjectReference("kubeless-registry-credentials")...)
 	}
+
 	return &FunctionController{
 		logger:           logrus.WithField("pkg", "function-controller"),
 		clientset:        cfg.KubeCli,
@@ -277,19 +278,31 @@ func (c *FunctionController) startImageBuildJob(funcObj *kubelessApi.Function, o
 		return "", false, fmt.Errorf("Unable to parse registry URL: %v", err)
 	}
 	image := fmt.Sprintf("%s/%s:%s", regURL.Host, imageName, tag)
-	if !exists {
-		tlsVerify := true
-		if c.config.Data["function-registry-tls-verify"] == "false" {
-			tlsVerify = false
-		}
-		err = utils.EnsureFuncImage(c.clientset, funcObj, c.langRuntime, or, imageName, tag, c.config.Data["builder-image"], regURL.Host, imagePullSecret.Name, c.config.Data["provision-image"], tlsVerify, c.imagePullSecrets)
-		if err != nil {
-			return "", false, fmt.Errorf("Unable to create image build job: %v", err)
-		}
-	} else {
-		// Image already exists
+	if exists {
 		return image, false, nil
 	}
+
+	tlsVerify := true
+	if c.config.Data["function-registry-tls-verify"] == "false" {
+		tlsVerify = false
+	}
+	if err = utils.EnsureFuncImage(
+		c.clientset,
+		funcObj,
+		c.langRuntime,
+		or,
+		imageName,
+		tag,
+		c.config.Data["builder-image"],
+		regURL.Host,
+		imagePullSecret.Name,
+		c.config.Data["provision-image"],
+		tlsVerify,
+		c.imagePullSecrets,
+	); err != nil {
+		return "", false, fmt.Errorf("Unable to create image build job: %v", err)
+	}
+
 	return image, true, nil
 }
 
@@ -352,8 +365,15 @@ func (c *FunctionController) ensureK8sResources(funcObj *kubelessApi.Function) e
 		logrus.Infof("Skipping image-build step for %s", funcObj.ObjectMeta.Name)
 	}
 
-	err = utils.EnsureFuncDeployment(c.clientset, funcObj, or, c.langRuntime, prebuiltImage, c.config.Data["provision-image"], c.imagePullSecrets)
-	if err != nil {
+	if err = utils.EnsureFuncDeployment(
+		c.clientset,
+		funcObj,
+		or,
+		c.langRuntime,
+		prebuiltImage,
+		c.config.Data["provision-image"],
+		c.imagePullSecrets,
+	); err != nil {
 		return err
 	}
 

--- a/pkg/langruntime/langruntime.go
+++ b/pkg/langruntime/langruntime.go
@@ -7,10 +7,10 @@ import (
 	"regexp"
 	"strings"
 
-	yaml "github.com/ghodss/yaml"
+	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
 	appsv1 "k8s.io/api/apps/v1"
-	v1 "k8s.io/api/core/v1"
+	"k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 )
 
@@ -35,6 +35,12 @@ type Image struct {
 	Image   string            `yaml:"image"`
 	Command string            `yaml:"command,omitempty"`
 	Env     map[string]string `yaml:"env,omitempty"`
+	Secrets []Secret          `yaml:"secrets,omitempty"`
+}
+
+// Secret is a reference to a secret.
+type Secret struct {
+	Name string `yaml:"name,omitempty"`
 }
 
 // RuntimeVersion is a struct with all the info about the images and secrets
@@ -210,11 +216,11 @@ func (l *Langruntimes) GetImageSecrets(runtime string) ([]v1.LocalObjectReferenc
 
 	runtimeInf, err := l.findRuntimeVersion(runtime)
 	if err != nil {
-		return []v1.LocalObjectReference{}, err
+		return nil, err
 	}
 
 	if len(runtimeInf.ImagePullSecrets) == 0 {
-		return []v1.LocalObjectReference{}, nil
+		return nil, nil
 	}
 
 	for _, s := range runtimeInf.ImagePullSecrets {
@@ -229,6 +235,33 @@ func (l *Langruntimes) GetImageSecrets(runtime string) ([]v1.LocalObjectReferenc
 	}
 
 	return lors, nil
+}
+
+// GetInitContainersSecrets gets the secrets of the init container with name
+func (l *Langruntimes) GetInitContainerSecrets(runtime, name string) ([]v1.LocalObjectReference, error) {
+	runtimeInf, err := l.findRuntimeVersion(runtime)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(runtimeInf.Images) == 0 {
+		return nil, nil
+	}
+
+	var secrets []Secret
+	phase := name2phase(name)
+	for _, i := range runtimeInf.Images {
+		if i.Phase == phase {
+			secrets = append(secrets, i.Secrets...)
+			break
+		}
+	}
+	var refs []v1.LocalObjectReference
+	for _, s := range secrets {
+		refs = append(refs, v1.LocalObjectReference{Name: s.Name})
+	}
+
+	return refs, nil
 }
 
 func appendToCommand(orig string, command ...string) string {
@@ -346,4 +379,15 @@ func (l *Langruntimes) GetCompilationContainer(runtime, funcName string, env []v
 		WorkingDir:      installVolume.MountPath,
 		Resources:       resources,
 	}, nil
+}
+
+// name2phase returns the phase of an init container
+func name2phase(name string) string {
+	switch name {
+	case "compile":
+		return PhaseCompilation
+	case "install":
+		return PhaseInstallation
+	}
+	return name
 }

--- a/pkg/langruntime/langruntime.go
+++ b/pkg/langruntime/langruntime.go
@@ -216,11 +216,11 @@ func (l *Langruntimes) GetImageSecrets(runtime string) ([]v1.LocalObjectReferenc
 
 	runtimeInf, err := l.findRuntimeVersion(runtime)
 	if err != nil {
-		return nil, err
+		return []v1.LocalObjectReference{}, err
 	}
 
 	if len(runtimeInf.ImagePullSecrets) == 0 {
-		return nil, nil
+		return []v1.LocalObjectReference{}, nil
 	}
 
 	for _, s := range runtimeInf.ImagePullSecrets {

--- a/pkg/langruntime/langruntime.go
+++ b/pkg/langruntime/langruntime.go
@@ -237,7 +237,7 @@ func (l *Langruntimes) GetImageSecrets(runtime string) ([]v1.LocalObjectReferenc
 	return lors, nil
 }
 
-// GetInitContainersSecrets gets the secrets of the init container with name
+// GetInitContainerSecrets gets the secrets of the init container with name
 func (l *Langruntimes) GetInitContainerSecrets(runtime, name string) ([]v1.LocalObjectReference, error) {
 	runtimeInf, err := l.findRuntimeVersion(runtime)
 	if err != nil {

--- a/pkg/langruntime/langruntimetestutils.go
+++ b/pkg/langruntime/langruntimetestutils.go
@@ -12,45 +12,40 @@ import (
 func AddFakeConfig(clientset *fake.Clientset) {
 
 	runtimeImages := `[
-		{
-      "ID": "python",
-      "compiled": false,
-      "depName": "requirements.txt",
-			"fileNameSuffix": ".py",
-      "livenessProbeInfo": {
-        "exec": {
-          "command": [
-            "curl",
-            "-f",
-            "http://localhost:8080/healthz"
-          ]
-        },
-        "initialDelaySeconds": 5,
-        "periodseconds": 10
+  {
+    "ID": "python",
+    "compiled": false,
+    "depName": "requirements.txt",
+    "fileNameSuffix": ".py",
+    "livenessProbeInfo": {
+      "exec": {
+        "command": ["curl", "-f", "http://localhost:8080/healthz"]
       },
-      "versions": [
-         {
-            "images": [
-               {
-                  "command": "foo",
-                  "image": "python:2.7",
-                  "phase": "installation"
-               },
-               {
-                  "image": "bar",
-									"phase": "runtime",
-									"env": {
-										"PYTHONPATH": "/kubeless/lib/python2.7/site-packages:/kubeless"
-									}
-               }
-            ],
-            "name": "python27",
-						"version": "2.7",
-						"imagePullSecrets": [{"ImageSecret": "p1"}, {"ImageSecret": "p2"}]
-        },
-	  	]
-		}
-	]`
+      "initialDelaySeconds": 5,
+      "periodseconds": 10
+    },
+    "versions": [
+      {
+        "images": [
+          {
+            "command": "foo",
+            "image": "python:2.7",
+            "phase": "installation",
+            "secrets": [{"name": "my-secret"}]            
+          },
+          {
+            "image": "bar",
+            "phase": "runtime",
+            "env": {"PYTHONPATH": "/kubeless/lib/python2.7/site-packages:/kubeless"}
+          }
+        ],
+        "name": "python27",
+        "version": "2.7",
+        "imagePullSecrets": [{"ImageSecret": "p1"}, {"ImageSecret": "p2"}]
+      }
+    ]
+  }
+]`
 	cm := v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "kubeless-config",

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -163,7 +163,7 @@ func GetKubelessClientOutCluster() (versioned.Interface, error) {
 	return kubelessClient, nil
 }
 
-//GetDefaultNamespace returns the namespace set in current cluster context
+// GetDefaultNamespace returns the namespace set in current cluster context
 func GetDefaultNamespace() string {
 	rules := clientcmd.NewDefaultClientConfigLoadingRules()
 	rules.DefaultClientConfig = &clientcmd.DefaultClientConfig
@@ -448,7 +448,7 @@ func GetAnnotationsFromCRD(clientset clientsetAPIExtensions.Interface, name stri
 	return crd.GetAnnotations(), nil
 }
 
-// GetRandString returns a random string of lenght N
+// GetRandString returns a random string of length N
 func GetRandString(n int) (string, error) {
 	b := make([]byte, n)
 	if _, err := rand.Read(b); err != nil {
@@ -459,7 +459,7 @@ func GetRandString(n int) (string, error) {
 
 // GetSecretsAsLocalObjectReference returns a list of LocalObjectReference based on secret names
 func GetSecretsAsLocalObjectReference(secrets ...string) []v1.LocalObjectReference {
-	res := []v1.LocalObjectReference{}
+	var res []v1.LocalObjectReference
 	for _, secret := range secrets {
 		if secret != "" {
 			res = append(res, v1.LocalObjectReference{Name: secret})

--- a/pkg/utils/k8sutil.go
+++ b/pkg/utils/k8sutil.go
@@ -448,7 +448,7 @@ func GetAnnotationsFromCRD(clientset clientsetAPIExtensions.Interface, name stri
 	return crd.GetAnnotations(), nil
 }
 
-// GetRandString returns a random string of length N
+// GetRandString returns a random string of lenght N
 func GetRandString(n int) (string, error) {
 	b := make([]byte, n)
 	if _, err := rand.Read(b); err != nil {
@@ -459,7 +459,7 @@ func GetRandString(n int) (string, error) {
 
 // GetSecretsAsLocalObjectReference returns a list of LocalObjectReference based on secret names
 func GetSecretsAsLocalObjectReference(secrets ...string) []v1.LocalObjectReference {
-	var res []v1.LocalObjectReference
+	res := []v1.LocalObjectReference{}
 	for _, secret := range secrets {
 		if secret != "" {
 			res = append(res, v1.LocalObjectReference{Name: secret})

--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -29,6 +29,7 @@ import (
 	"net/url"
 	"os"
 	"path"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"unicode/utf8"
@@ -49,6 +50,9 @@ import (
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 )
+
+// secretsMountPath is the files system path where volumes populated with secrets are mounted.
+const secretsMountPath = "/var/run/secrets/kubeless.io"
 
 // GetFunctionPort returns the port for a function service
 func GetFunctionPort(clientset kubernetes.Interface, namespace, functionName string) (string, error) {
@@ -464,7 +468,7 @@ func populatePodSpec(funcObj *kubelessApi.Function, lr *langruntime.Langruntimes
 			result.InitContainers[i].VolumeMounts = append(result.InitContainers[i].VolumeMounts, v1.VolumeMount{
 				Name:      secret.Name,
 				ReadOnly:  true,
-				MountPath: "/" + secret.Name,
+				MountPath: filepath.Join(secretsMountPath, secret.Name),
 			})
 		}
 	}

--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -21,6 +21,7 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -325,7 +326,14 @@ func getChecksum(content string) (string, error) {
 // The caller should define the runtime container(s).
 // It accepts a prepopulated podSpec with default information and volume that the
 // runtime container should mount
-func populatePodSpec(funcObj *kubelessApi.Function, lr *langruntime.Langruntimes, podSpec *v1.PodSpec, runtimeVolumeMount v1.VolumeMount, provisionImage string, imagePullSecrets []v1.LocalObjectReference) error {
+func populatePodSpec(
+	funcObj *kubelessApi.Function,
+	lr *langruntime.Langruntimes,
+	podSpec *v1.PodSpec,
+	runtimeVolumeMount v1.VolumeMount,
+	provisionImage string,
+	imagePullSecrets []v1.LocalObjectReference,
+) error {
 	depsVolumeName := funcObj.ObjectMeta.Name + "-deps"
 	result := podSpec
 	if len(imagePullSecrets) > 0 {
@@ -384,7 +392,7 @@ func populatePodSpec(funcObj *kubelessApi.Function, lr *langruntime.Langruntimes
 		result.InitContainers = []v1.Container{provisionContainer}
 	}
 
-	// Add the imagesecrets if present to pull images from private docker registry
+	// add the image secrets if present to pull images from private docker registry
 	if funcObj.Spec.Runtime != "" {
 		imageSecrets, err := lr.GetImageSecrets(funcObj.Spec.Runtime)
 		if err != nil {
@@ -430,13 +438,64 @@ func populatePodSpec(funcObj *kubelessApi.Function, lr *langruntime.Langruntimes
 			*compContainer,
 		)
 	}
+
+	// mount volumes with init container secrets specified in runtime configuration
+	lr.ReadConfigMap()
+	for i := 0; i < len(result.InitContainers); i++ {
+		secrets, err := lr.GetInitContainerSecrets(funcObj.Spec.Runtime, result.InitContainers[i].Name)
+		if err != nil {
+			return fmt.Errorf("Unable to fetch init container secrets for runtime %s at phase %s: %v", funcObj.Spec.Runtime, result.InitContainers[i].Name, err)
+		}
+		for _, secret := range secrets {
+			// add volume if not available in the pod spec already
+			var found bool
+			for _, vol := range result.Volumes {
+				if vol.Name == secret.Name && (vol.Secret == nil || vol.Secret.SecretName != secret.Name) {
+					return fmt.Errorf("Unable to add volume for secret %s, volume already defined %#v", secret.Name, vol)
+				}
+				if vol.Name == secret.Name && vol.Secret != nil && vol.Secret.SecretName == secret.Name {
+					found = true
+					break
+				}
+			}
+			if !found {
+				result.Volumes = append(result.Volumes, v1.Volume{
+					Name: secret.Name,
+					VolumeSource: v1.VolumeSource{
+						Secret: &v1.SecretVolumeSource{SecretName: secret.Name},
+					},
+				})
+			}
+
+			// add volume mount to the init container
+			result.InitContainers[i].VolumeMounts = append(result.InitContainers[i].VolumeMounts, v1.VolumeMount{
+				Name:      secret.Name,
+				ReadOnly:  true,
+				MountPath: "/" + secret.Name,
+			})
+		}
+	}
+
 	return nil
 }
 
 // EnsureFuncImage creates a Job to build a function image
-func EnsureFuncImage(client kubernetes.Interface, funcObj *kubelessApi.Function, lr *langruntime.Langruntimes, or []metav1.OwnerReference, imageName, tag, builderImage, registryHost, dockerSecretName, provisionImage string, registryTLSEnabled bool, imagePullSecrets []v1.LocalObjectReference) error {
+func EnsureFuncImage(
+	client kubernetes.Interface,
+	funcObj *kubelessApi.Function,
+	lr *langruntime.Langruntimes,
+	or []metav1.OwnerReference,
+	imageName string,
+	tag string,
+	builderImage string,
+	registryHost string,
+	dockerSecretName string,
+	provisionImage string,
+	registryTLSEnabled bool,
+	imagePullSecrets []v1.LocalObjectReference,
+) error {
 	if len(tag) < 64 {
-		return fmt.Errorf("Expecting sha256 as image tag")
+		return errors.New("Expecting sha256 as image tag")
 	}
 	jobName := fmt.Sprintf("build-%s-%s", funcObj.ObjectMeta.Name, tag[0:10])
 	_, err := client.BatchV1().Jobs(funcObj.ObjectMeta.Namespace).Get(jobName, metav1.GetOptions{})
@@ -449,8 +508,15 @@ func EnsureFuncImage(client kubernetes.Interface, funcObj *kubelessApi.Function,
 		RestartPolicy: v1.RestartPolicyOnFailure,
 	}
 	runtimeVolumeMount := getRuntimeVolumeMount(funcObj.ObjectMeta.Name)
-	err = populatePodSpec(funcObj, lr, &podSpec, runtimeVolumeMount, provisionImage, imagePullSecrets)
-	if err != nil {
+
+	if err = populatePodSpec(
+		funcObj,
+		lr,
+		&podSpec,
+		runtimeVolumeMount,
+		provisionImage,
+		imagePullSecrets,
+	); err != nil {
 		return err
 	}
 
@@ -562,7 +628,15 @@ func mergeMap(dst, src map[string]string) map[string]string {
 }
 
 // EnsureFuncDeployment creates/updates a function deployment
-func EnsureFuncDeployment(client kubernetes.Interface, funcObj *kubelessApi.Function, or []metav1.OwnerReference, lr *langruntime.Langruntimes, prebuiltRuntimeImage, provisionImage string, imagePullSecrets []v1.LocalObjectReference) error {
+func EnsureFuncDeployment(
+	client kubernetes.Interface,
+	funcObj *kubelessApi.Function,
+	or []metav1.OwnerReference,
+	lr *langruntime.Langruntimes,
+	prebuiltRuntimeImage string,
+	provisionImage string,
+	imagePullSecrets []v1.LocalObjectReference,
+) error {
 
 	var err error
 
@@ -578,7 +652,7 @@ func EnsureFuncDeployment(client kubernetes.Interface, funcObj *kubelessApi.Func
 	}
 	maxUnavailable := intstr.FromInt(0)
 
-	//add deployment and copy all func's Spec.Deployment to the deployment
+	// add deployment and copy all func's Spec.Deployment to the deployment
 	dpm := funcObj.Spec.Deployment.DeepCopy()
 	dpm.OwnerReferences = or
 	dpm.ObjectMeta.Name = funcObj.ObjectMeta.Name
@@ -592,7 +666,7 @@ func EnsureFuncDeployment(client kubernetes.Interface, funcObj *kubelessApi.Func
 		},
 	}
 
-	//append data to dpm deployment
+	// append data to dpm deployment
 	dpm.Labels = addDefaultLabel(mergeMap(dpm.Labels, funcObj.Labels))
 	dpm.Spec.Template.Labels = mergeMap(dpm.Spec.Template.Labels, funcObj.Labels)
 	dpm.Annotations = mergeMap(dpm.Annotations, funcObj.Annotations)
@@ -609,10 +683,17 @@ func EnsureFuncDeployment(client kubernetes.Interface, funcObj *kubelessApi.Func
 		if err != nil {
 			return err
 		}
-		//only resolve the image name and build the function if it has not been built already
+		// only resolve the image name and build the function if it has not been built already
 		if dpm.Spec.Template.Spec.Containers[0].Image == "" && prebuiltRuntimeImage == "" {
-			err := populatePodSpec(funcObj, lr, &dpm.Spec.Template.Spec, runtimeVolumeMount, provisionImage, imagePullSecrets)
-			if err != nil {
+
+			if err := populatePodSpec(
+				funcObj,
+				lr,
+				&dpm.Spec.Template.Spec,
+				runtimeVolumeMount,
+				provisionImage,
+				imagePullSecrets,
+			); err != nil {
 				return err
 			}
 

--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -51,7 +51,7 @@ import (
 	"k8s.io/client-go/rest"
 )
 
-// secretsMountPath is the files system path where volumes populated with secrets are mounted.
+// secretsMountPath is the file system path where volumes populated with secrets are mounted.
 const secretsMountPath = "/var/run/secrets/kubeless.io"
 
 // GetFunctionPort returns the port for a function service

--- a/pkg/utils/kubelessutil_test.go
+++ b/pkg/utils/kubelessutil_test.go
@@ -449,7 +449,7 @@ func TestEnsureImage(t *testing.T) {
 		t.Error("Missing ImagePullSecrets")
 	}
 
-	// ensure my-secret is mounted as /my-secret to install container
+	// ensure my-secret is mounted as /var/run/secrets/kubeless.io/my-secret to install container
 	var container v1.Container
 	for _, c := range jobs.Items[0].Spec.Template.Spec.InitContainers {
 		if c.Name == "install" {
@@ -461,12 +461,12 @@ func TestEnsureImage(t *testing.T) {
 	}
 	var found bool
 	for _, v := range container.VolumeMounts {
-		if v.MountPath == "/my-secret" {
+		if v.MountPath == "/var/run/secrets/kubeless.io/my-secret" {
 			found = true
 		}
 	}
 	if !found {
-		t.Fatalf("Cannot find volume mount /my-secret")
+		t.Fatalf("Cannot find volume mount /var/run/secrets/kubeless.io/my-secret")
 	}
 }
 
@@ -703,7 +703,7 @@ func TestEnsureDeployment(t *testing.T) {
 		t.Errorf("Resources must be set for init container")
 	}
 
-	// ensure my-secret is mounted as /my-secret to install container
+	// ensure my-secret is mounted as /var/run/secrets/kubeless.io/my-secret to install container
 	var container v1.Container
 	for _, c := range dpm.Spec.Template.Spec.InitContainers {
 		if c.Name == "install" {
@@ -715,12 +715,12 @@ func TestEnsureDeployment(t *testing.T) {
 	}
 	var found bool
 	for _, v := range container.VolumeMounts {
-		if v.MountPath == "/my-secret" {
+		if v.MountPath == "/var/run/secrets/kubeless.io/my-secret" {
 			found = true
 		}
 	}
 	if !found {
-		t.Fatalf("Cannot find volume mount /my-secret")
+		t.Fatalf("Cannot find volume mount /var/run/secrets/kubeless.io/my-secret")
 	}
 }
 

--- a/pkg/utils/kubelessutil_test.go
+++ b/pkg/utils/kubelessutil_test.go
@@ -417,20 +417,8 @@ func TestEnsureImage(t *testing.T) {
 	pullSecrets := []v1.LocalObjectReference{
 		{Name: "creds"},
 	}
-	if err := EnsureFuncImage(
-		clientset,
-		f1,
-		lr,
-		or,
-		"user/image",
-		"4840d87600137157493ba43a24f0b4bb6cf524ebbf095ce96c79f85bf5a3ff5a",
-		"kubeless/builder",
-		"registry.docker.io",
-		"registry-creds",
-		"unzip",
-		true,
-		pullSecrets,
-	); err != nil {
+	err := EnsureFuncImage(clientset, f1, lr, or, "user/image", "4840d87600137157493ba43a24f0b4bb6cf524ebbf095ce96c79f85bf5a3ff5a", "kubeless/builder", "registry.docker.io", "registry-creds", "unzip", true, pullSecrets)
+	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
 	jobs, err := clientset.BatchV1().Jobs(ns).List(metav1.ListOptions{})
@@ -743,7 +731,7 @@ func TestEnsureDeploymentWithoutFuncNorHandler(t *testing.T) {
 	f2 := getDefaultFunc(funcName, ns)
 	f2.Spec.Function = ""
 	f2.Spec.Handler = ""
-	err := EnsureFuncDeployment(clientset, f2, or, lr, "", "unzip", nil)
+	err := EnsureFuncDeployment(clientset, f2, or, lr, "", "unzip", []v1.LocalObjectReference{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -759,7 +747,7 @@ func TestEnsureDeploymentWithImage(t *testing.T) {
 	// If the Image has been already provided it should not resolve it
 	f3 := getDefaultFunc(funcName, ns)
 	f3.Spec.Deployment.Spec.Template.Spec.Containers[0].Image = "test-image"
-	err := EnsureFuncDeployment(clientset, f3, or, lr, "", "unzip", nil)
+	err := EnsureFuncDeployment(clientset, f3, or, lr, "", "unzip", []v1.LocalObjectReference{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -779,7 +767,7 @@ func TestEnsureDeploymentWithoutFunc(t *testing.T) {
 	f4 := getDefaultFunc(funcName, ns)
 	f4.Spec.Function = ""
 	f4.Spec.Deps = ""
-	err := EnsureFuncDeployment(clientset, f4, or, lr, "", "unzip", nil)
+	err := EnsureFuncDeployment(clientset, f4, or, lr, "", "unzip", []v1.LocalObjectReference{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -806,7 +794,7 @@ func TestEnsureUpdateDeployment(t *testing.T) {
 	f1.Spec.Deployment.Spec.Template.ObjectMeta = metav1.ObjectMeta{
 		Annotations: funcAnno,
 	}
-	err := EnsureFuncDeployment(clientset, f1, or, lr, "", "unzip", nil)
+	err := EnsureFuncDeployment(clientset, f1, or, lr, "", "unzip", []v1.LocalObjectReference{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -814,7 +802,7 @@ func TestEnsureUpdateDeployment(t *testing.T) {
 	f6 = *f1
 	f6.Spec.Handler = "foo.bar2"
 	f6.Spec.Deployment.ObjectMeta.Annotations["new-key"] = "value"
-	err = EnsureFuncDeployment(clientset, &f6, or, lr, "", "unzip", nil)
+	err = EnsureFuncDeployment(clientset, &f6, or, lr, "", "unzip", []v1.LocalObjectReference{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -832,7 +820,7 @@ func TestAvoidDeploymentOverwrite(t *testing.T) {
 		},
 	})
 	f1 := getDefaultFunc(f1Name, ns)
-	err := EnsureFuncDeployment(clientset, f1, or, lr, "", "unzip", nil)
+	err := EnsureFuncDeployment(clientset, f1, or, lr, "", "unzip", []v1.LocalObjectReference{})
 	if err == nil && strings.Contains(err.Error(), "conflicting object") {
 		t.Errorf("It should fail because a conflict")
 	}
@@ -845,7 +833,7 @@ func TestDeploymentWithUnsupportedRuntime(t *testing.T) {
 	f7 := getDefaultFunc("func7", ns)
 	f7.Spec.Deps = "deps"
 	f7.Spec.Runtime = "cobol"
-	err := EnsureFuncDeployment(clientset, f7, or, lr, "", "unzip", nil)
+	err := EnsureFuncDeployment(clientset, f7, or, lr, "", "unzip", []v1.LocalObjectReference{})
 
 	if err == nil {
 		t.Fatal("An error should be thrown")
@@ -858,7 +846,7 @@ func TestDeploymentWithTimeout(t *testing.T) {
 	// If a timeout is specified it should set an environment variable FUNC_TIMEOUT
 	f8 := getDefaultFunc(funcName, ns)
 	f8.Spec.Timeout = "10"
-	err := EnsureFuncDeployment(clientset, f8, or, lr, "", "unzip", nil)
+	err := EnsureFuncDeployment(clientset, f8, or, lr, "", "unzip", []v1.LocalObjectReference{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -876,7 +864,7 @@ func TestDeploymentWithPrebuiltImage(t *testing.T) {
 	clientset, or, ns, lr := prepareDeploymentTest(funcName)
 	// If a prebuilt image is specified it should not build the function using init containers
 	f9 := getDefaultFunc(funcName, ns)
-	err := EnsureFuncDeployment(clientset, f9, or, lr, "user/image:test", "unzip", nil)
+	err := EnsureFuncDeployment(clientset, f9, or, lr, "user/image:test", "unzip", []v1.LocalObjectReference{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -909,7 +897,7 @@ func TestDeploymentWithVolumes(t *testing.T) {
 			MountPath: "/tmp/test",
 		},
 	}
-	err := EnsureFuncDeployment(clientset, f10, or, lr, "", "unzip", nil)
+	err := EnsureFuncDeployment(clientset, f10, or, lr, "", "unzip", []v1.LocalObjectReference{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}
@@ -931,7 +919,7 @@ func TestEnsureDeploymentWithAffinityOverridden(t *testing.T) {
 	// If the Image has been already provided it should not resolve it
 	f3 := getDefaultFunc(funcName, ns)
 	f3.Spec.Deployment.Spec.Template.Spec.Affinity = &v1.Affinity{}
-	err := EnsureFuncDeployment(clientset, f3, or, lr, "", "unzip", nil)
+	err := EnsureFuncDeployment(clientset, f3, or, lr, "", "unzip", []v1.LocalObjectReference{})
 	if err != nil {
 		t.Errorf("Unexpected error: %s", err)
 	}


### PR DESCRIPTION
**Issue Ref**: None
 
**Description**: 

Adds support for using secrets via mounted volumes.

Extends the `runtime-images` structure in `kubeless-config` configmap to allow using secrets in the init containers of function deployments, in a similar way as providing environment variables.

**Usage:**

Manifest for `github-token` secret.
```yaml
apiVersion: v1
kind: Secret
metadata:
  name: github-token
type: Opaque
stringData:
  token: foobar

```

Manifest for `kubeless-config` configmap
```yaml
...
data:
  runtime-images: |
    [
        {
            "ID": "go",
            "depName": "go.mod",
            "fileNameSuffix": ".go",
            "versions": [
                {
                    "imagePullSecrets": [{"ImageSecret": "docker-registry"}],
                    "images": [
                        {
                            "command": "docker-entrypoint",
                            "env": {
                                "GITHUB_TOKEN_SECRET_FILE": "/var/run/secrets/kubeless.io/github-token/token",
                                "GOCACHE": "$(KUBELESS_INSTALL_VOLUME)/.cache",
                                "GOPRIVATE": "github.com/acme/*"
                            },
                            "image": "quay.io/acme/kubeless-runtime:go-1.14",
                            "phase": "compilation",
                            "secrets": [{"name": "github-token"}]
                        },
                        {
                            "image": "kubeless/go@sha256:55759228714d7080b3dd858e56530d4e1f539d071906e88d88b454ee3b3c9b16",
                            "phase": "runtime"
                        }
                    ],
                    "name": "go1.14",
                    "version": "1.14"
                }
            ]
        }
    ]
...
```

The above runtime configuration specified custom image for Go 1.14 runtime with a secret `github-token` shared with the container as a volume mounted at `/var/run/secrets/kubeless.io/{{secret.name}}` (`/var/run/secrets/kubeless.io/github-token` in this example). Now the container can read the GitHub token secret from the filesystem and use it to download private Go packages.

**TODOs**:
 - [x] Ready to review
 - [x] Automated Tests
 - [x] Docs
