### PR TITLE
Use `--depth` flag to `git clone` in Dockerfiles, to save space

### DIFF
--- a/docker/dev-environment/Dockerfile
+++ b/docker/dev-environment/Dockerfile
@@ -25,7 +25,7 @@ RUN set -eux; \
     # Install gox and golint
     go get github.com/mitchellh/gox github.com/golang/lint/golint && \
     # Install bats
-    git clone https://github.com/sstephenson/bats /usr/local/bats && \
+    git clone --depth 1 https://github.com/sstephenson/bats /usr/local/bats && \
     # Install kubecfg
     wget "https://github.com/ksonnet/kubecfg/releases/download/v0.5.0/kubecfg-linux-amd64" -O "/usr/local/bin/kubecfg" && chmod +x "/usr/local/bin/kubecfg"
 

--- a/docker/event-sources/kubernetes/Dockerfile
+++ b/docker/event-sources/kubernetes/Dockerfile
@@ -6,7 +6,7 @@ RUN python3 ./get-pip.py
 RUN pip3 install --upgrade kubernetes
 RUN pip3 install --upgrade requests
 
-RUN git clone https://github.com/dpkp/kafka-python
+RUN git clone --depth 1 https://github.com/dpkp/kafka-python
 WORKDIR kafka-python
 RUN python3 ./setup.py install
 


### PR DESCRIPTION
**Issue Ref**: [None]

**Description**: 

optimize the git clone using --depth flag in term of size of clone
and also in term's of time taken to fetch the files and commit history
of whole repository .

More detail can be found at blog
https://www.atlassian.com/git/tutorials/big-repositories

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>