### PR TITLE
use `--no-cache-dir` flag to `pip` in dockerfiles to save space

### DIFF
--- a/docker/event-sources/kubernetes/Dockerfile
+++ b/docker/event-sources/kubernetes/Dockerfile
@@ -3,8 +3,8 @@ FROM bitnami/minideb:jessie
 RUN install_packages python3 curl ca-certificates git
 RUN curl https://bootstrap.pypa.io/get-pip.py --output get-pip.py
 RUN python3 ./get-pip.py
-RUN pip3 install --upgrade kubernetes
-RUN pip3 install --upgrade requests
+RUN pip3 install  --no-cache-dir --upgrade kubernetes
+RUN pip3 install  --no-cache-dir --upgrade requests
 
 RUN git clone https://github.com/dpkp/kafka-python
 WORKDIR kafka-python


### PR DESCRIPTION
**Issue Ref**: [None]

 
**Description**: 

using "--no-cache-dir" flag in pip install ,make sure downloaded packages
by pip don't cached on system . This is a best practice which make sure
to fetch from repo instead of using local cached one . Further , in case
of Docker Containers , by restricting caching , we can reduce image size.
In term of stats , it depends upon the number of python packages
multiplied by their respective size . e.g for heavy packages with a lot
of dependencies it reduce a lot by don't caching pip packages.

Further , more detail information can be found at

https://medium.com/sciforce/strategies-of-docker-images-optimization-2ca9cc5719b6

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>