### PR TITLE
Use only 'function' and 'created-by' labels as deployment matchLabels

### DIFF
--- a/pkg/utils/kubelessutil.go
+++ b/pkg/utils/kubelessutil.go
@@ -626,7 +626,7 @@ func EnsureFuncDeployment(client kubernetes.Interface, funcObj *kubelessApi.Func
 	dpm.OwnerReferences = or
 	dpm.ObjectMeta.Name = funcObj.ObjectMeta.Name
 	dpm.Spec.Selector = &metav1.LabelSelector{
-		MatchLabels: funcObj.ObjectMeta.Labels,
+		MatchLabels: map[string]string{"created-by": funcObj.ObjectMeta.Labels["created-by"], "function": funcObj.ObjectMeta.Labels["function"]},
 	}
 
 	dpm.Spec.Strategy = appsv1.DeploymentStrategy{


### PR DESCRIPTION
**Issue Ref**: 
[1211](https://github.com/kubeless/kubeless/issues/1211)
 
**Description**: 

With this PR the function deployment uses only 'function' and 'created-by' labels as matchLabels instead of all the function labels.

This PR is really simple but i couldn't test if it works correctly.

Thank you for your great work!
Lorenzo

**TODOs**:
 - [ ] Ready to review
 - [ ] Automated Tests
 - [ ] Docs
