### PR TITLE
Fix broken URL in kubeless function call

### DIFF
--- a/cmd/kubeless/function/call.go
+++ b/cmd/kubeless/function/call.go
@@ -78,7 +78,7 @@ var callCmd = &cobra.Command{
 		if get {
 			req = clientset.CoreV1().RESTClient().Get().Namespace(ns).Resource("services").SubResource("proxy").Name(funcName + ":" + port)
 		} else {
-			req = clientset.CoreV1().RESTClient().Post().Body(bytes.NewBuffer(str))
+			req = clientset.CoreV1().RESTClient().Post().Namespace(ns).Resource("services").SubResource("proxy").Name(funcName + ":" + port).Body(bytes.NewBuffer(str))
 			if utils.IsJSON(string(str)) {
 				req.SetHeader("Content-Type", "application/json")
 				req.SetHeader("event-type", "application/json")
@@ -89,7 +89,7 @@ var callCmd = &cobra.Command{
 			// REST package removes trailing slash when building URLs
 			// Causing POST requests to be redirected with an empty body
 			// So we need to manually build the URL
-			req = req.AbsPath(svc.ObjectMeta.SelfLink + ":" + port + "/proxy/")
+			req = req.AbsPath(req.URL().Path + "/")
 		}
 		timestamp := time.Now().UTC()
 		eventID, err := utils.GetRandString(11)


### PR DESCRIPTION
**Issue Ref**: https://github.com/kubeless/kubeless/issues/1226
 
**Description**: 

First of all, thank you for the exciting project.

My kubeless is running on Kubernetes 1.21.
As a result of creating a function according to Quick Start (https://kubeless.io/docs/quick-start/), I confirmed that the function cannot be called with `kubeless function call` like https://github.com/kubeless/kubeless/issues/1226.
However, when I checked the function using `kubectl proxy` and` curl`, it was working properly.
So I guessed that there was a problem with the assembled URL in the command.

When I checked the assembled URL, it was as follows.

```
https://kubernetes/:http-function-port/proxy/
```

I fixed `svc.ObjectMeta.SelfLink` and` svc.SelfLink` to not be used because they were empty.
Then, I have confirmed that it works.

Thank you. 






**TODOs**:
 - [x] Ready to review
 - [x] Automated Tests
 - [x] Docs
